### PR TITLE
Fix formatting of link specification parts on Link Walking page.

### DIFF
--- a/source/riak/tutorials/fast-track/Links-and-Link-Walking.md
+++ b/source/riak/tutorials/fast-track/Links-and-Link-Walking.md
@@ -75,9 +75,9 @@ $ curl -v http://127.0.0.1:8091/riak/people/timoreilly/people,friend,1
 
 You'll notice that at the end of that request we've tacked on "/people,friend,1" That is the link specification. It's composed of three parts:
 
-# Bucket - a bucket name to limit the links to (in the above request it's 'people')
-# Tag - the "riaktag" to limit the links ('friend' is the tag in the above request)
-# Keep - 0 or 1, whether to return results from this step or phase
+* Bucket - a bucket name to limit the links to (in the above request it's 'people')
+* Tag - the "riaktag" to limit the links ('friend' is the tag in the above request)
+* Keep - 0 or 1, whether to return results from this step or phase
 
 If all went well, the response body from the above request should include the record for the "dhh" object.
 


### PR DESCRIPTION
Change the formatting of the link specification parts list to be a list instead of a heading.
