### PR TITLE
Usability fix for HTML anchors

### DIFF
--- a/source/js/docs/toc-generator.coffee
+++ b/source/js/docs/toc-generator.coffee
@@ -11,7 +11,7 @@ $ ->
       h2s.each ->
         return if $(this).hasClass('title')
         content = $(this).html()
-        name = content.replace(' ', '_', 'g')
+        name = content.replace(' ', '-', 'g')
         # name = content.replace(' ', '+')
         # name = encodeURI(content)
         anchor = "<a href=\"##{name}\">#{content}</a>";


### PR DESCRIPTION
add underscores to anchors (instead of spaces) so that they're easier to
copy and paste places. otherwise madness will ensue
