### PR TITLE
Fix: Syntax error in Erlang load_data

### DIFF
--- a/source/riak/tutorials/fast-track/Loading-Data-and-Running-MapReduce-Queries.md
+++ b/source/riak/tutorials/fast-track/Loading-Data-and-Running-MapReduce-Queries.md
@@ -27,7 +27,7 @@ main([Filename]) ->
     lists:foreach(fun(L) -> LS = re:split(L, ","), format_and_insert(LS) end, Lines).
 
 format_and_insert(Line) ->
-    JSON = io_lib:format("{\\"Date\\":\\"~s\\",\\"Open\\":~s,\\"High\\":~s,\\"Low\\":~s,\\"Close\\":~s,\\"Volume\\":~s,\\"Adj. Close\\":~s}", Line),
+    JSON = io_lib:format("{\"Date\":\"~s\",\"Open\":~s,\"High\":~s,\"Low\":~s,\"Close\":~s,\"Volume\":~s,\"Adj. Close\":~s}", Line),
     Command = io_lib:format("curl -XPUT http://127.0.0.1:8091/riak/goog/~s -d '~s' -H 'content-type: application/json'", [hd(Line),JSON]),
     io:format("Inserting: ~s~n", [hd(Line)]),
     os:cmd(Command).


### PR DESCRIPTION
Attempting to run load_data would cause the following errors:
./load_data:9: syntax error before: Date
./load_data:9: syntax error before: Close

This is fixed by removing the duplicated backslashes in the snippet.
