### PR TITLE
Change 'RB15B01 or later' to 'RB1501'. Warn about error using RB15B02

### DIFF
--- a/source/riak/tutorials/fast-track/Building-a-Development-Environment.md
+++ b/source/riak/tutorials/fast-track/Building-a-Development-Environment.md
@@ -14,7 +14,7 @@ In this section, we’ll install Riak and build a four node cluster running on y
 
 ## Dependencies
 
-Building Riak from source requires Erlang R15B01. (Note: don't use Erlang version R15B02, for the moment, as it causes an [error with riak-admin status](https://github.com/basho/riak/issues/227) commands).
+Building Riak from source requires Erlang R15B01. *Note: don't use Erlang version R15B02, for the moment, as it causes an [error with riak-admin status](https://github.com/basho/riak/issues/227) commands*.
 
 Basho's pre-packaged Riak binaries, the latest versions of which can be found in our [Downloads Directory](http://basho.com/resources/downloads/), embed the Erlang runtime. However, this tutorial is based on a source build, so if you do not have Erlang already installed, see [[Installing Erlang]] for instructions on how to do this.
 

--- a/source/riak/tutorials/installation/Installing-Erlang.md
+++ b/source/riak/tutorials/installation/Installing-Erlang.md
@@ -10,7 +10,7 @@ up:   ["Installing and Upgrading", "index.html"]
 next: ["Installing on Debian and Ubuntu", "Installing-on-Debian-and-Ubuntu.html"]
 ---
 
-Riak 1.2 and 1.2.1 requires [[Erlang|http://erlang.org/]] R15B01. (Note: don't use Erlang version R15B02, for the moment, as it causes an [error with riak-admin status](https://github.com/basho/riak/issues/227) commands).
+Riak 1.2 and 1.2.1 requires [[Erlang|http://erlang.org/]] R15B01. *Note: don't use Erlang version R15B02, for the moment, as it causes an [error with riak-admin status](https://github.com/basho/riak/issues/227) commands*.
 
 Riak 1.0 requires [[Erlang|http://erlang.org]] R14B03 or later. Riak versions prior to 1.0 will not function on the R14B02 or later. 
 

--- a/source/riak/tutorials/installation/Installing-Riak-from-Source.md
+++ b/source/riak/tutorials/installation/Installing-Riak-from-Source.md
@@ -13,7 +13,7 @@ next: ["Rolling Upgrades", "Rolling-Upgrades.html"]
 Riak should be installed from source if you are building on a platform for which a package does not exist or you are interested in contributing to Riak.
 
 ## Dependencies
-Riak requires [[Erlang|http://www.erlang.org/]] R15B01. (Note: don't use Erlang version R15B02, for the moment, as it causes an [error with riak-admin status](https://github.com/basho/riak/issues/227) commands).
+Riak requires [[Erlang|http://www.erlang.org/]] R15B01. *Note: don't use Erlang version R15B02, for the moment, as it causes an [error with riak-admin status](https://github.com/basho/riak/issues/227) commands*.
 
 If you do not have Erlang already installed, see [[Installing Erlang]]. Don't worry, it's easy!
 

--- a/source/riak/tutorials/installation/Installing-on-Debian-and-Ubuntu.md
+++ b/source/riak/tutorials/installation/Installing-on-Debian-and-Ubuntu.md
@@ -79,7 +79,7 @@ First, install Riak dependencies using apt:
     $ sudo apt-get install build-essential libc6-dev-i386 git
 ```
 
-Riak requires [Erlang](http://www.erlang.org/) R15B01. (Note: don't use Erlang version R15B02, for the moment, as it causes an [error with riak-admin status](https://github.com/basho/riak/issues/227) commands). 
+Riak requires [Erlang](http://www.erlang.org/) R15B01. *Note: don't use Erlang version R15B02, for the moment, as it causes an [error with riak-admin status](https://github.com/basho/riak/issues/227) commands*. 
 If Erlang is not already installed, install it before continuing (see:
 [[Installing Erlang]] for more information).
 

--- a/source/riak/tutorials/installation/Installing-on-Mac-OS-X.md
+++ b/source/riak/tutorials/installation/Installing-on-Mac-OS-X.md
@@ -55,7 +55,7 @@ You must have XCode tools installed from the CD that came with your Mac or from 
 
 <div class="note">Riak will not compile with Clang. Please make sure your default C/C++ compiler is GCC.</div>
 
-Riak requires [[Erlang|http://www.erlang.org/]] R15B01. (Note: don't use Erlang version R15B02, for the moment, as it causes an [error with riak-admin status](https://github.com/basho/riak/issues/227) commands). 
+Riak requires [[Erlang|http://www.erlang.org/]] R15B01. *Note: don't use Erlang version R15B02, for the moment, as it causes an [error with riak-admin status](https://github.com/basho/riak/issues/227) commands*. 
 
 If you do not have Erlang already installed, see [[Installing Erlang]]. Don't worry, it's easy!
 

--- a/source/riak/tutorials/installation/Installing-on-RHEL-and-CentOS.md
+++ b/source/riak/tutorials/installation/Installing-on-RHEL-and-CentOS.md
@@ -34,7 +34,7 @@ sudo rpm -Uvh riak-1.2.0-1.el6.x86_64.rpm
 ```
 
 ## Installing From Source
-Riak requires [[Erlang|http://www.erlang.org/]] R15B01. (Note: don't use Erlang version R15B02, for the moment, as it causes an [error with riak-admin status](https://github.com/basho/riak/issues/227) commands).
+Riak requires [[Erlang|http://www.erlang.org/]] R15B01. *Note: don't use Erlang version R15B02, for the moment, as it causes an [error with riak-admin status](https://github.com/basho/riak/issues/227) commands*.
 
 If you do not have Erlang already installed, see our guide to [[Installing Erlang]]. Don’t worry, it’s easy!
 


### PR DESCRIPTION
Change build from source instructions from "RB15B01 or later" to "RB15B01" and add warning against using RB15B02, with link to bug 02 currently causes.
