### PR TITLE
erlang api links broken

### DIFF
--- a/lib/sitemap_render_override.rb
+++ b/lib/sitemap_render_override.rb
@@ -156,6 +156,12 @@ module SitemapRenderOverride
         end
       end
 
+      # if this is data, make absolute, not relative
+      if href =~ /^\/data\/(.+)$/
+        url = "/shared/#{version_str}/data/#{$1}"
+        next "<a #{anchor.gsub(href, url)}>"
+      end
+
       # force the root page to point to the latest projcets
       if $production && project == :root && href =~ /^\/(riak[^\/]*?)\/[\d\.]+\/$/
         "<a href=\"/#{$1}/latest/\">"

--- a/source/riak/references/appendices/MapReduce-Implementation.md
+++ b/source/riak/references/appendices/MapReduce-Implementation.md
@@ -12,11 +12,11 @@ This page details how Riak implements MapReduce, the programming paradigm popula
 
 <div class="info">
 <div class="title">Hands On Resources</div>
-If you're new to MapReduce in Riak, check out the
+If you're new to MapReduce in Riak, check out these resources.
 
-* [[Main MapReduce page|MapReduce]]
+* [[Starting With MapReduce|MapReduce]]
 * [[Loading Data and Running MapReduce Queries]] on [[The Riak Fast Track]]
-* [[Riak Function Contrib|http://contrib.basho.com]]
+* [[Riak Contributed Functions|http://contrib.basho.com]]
 </div>
 
 ## How Riak Spreads Processing


### PR DESCRIPTION
On the page:

http://docs.basho.com/riak/latest/references/appendices/MapReduce-Implementation/#MapReduce-via%20the%20Erlang%20API

The following links are broken:

For examples, see:

MapReduce [localstream.erl](http://docs.basho.com/riak/latest/data/MapReduce-localstream.erl)
MapReduce [pbstream.erl](http://docs.basho.com/riak/latest/data/MapReduce-pbstream.erl)
