### PR TITLE
Notes not rendering correctly

### DIFF
--- a/source/css/common.css.scss
+++ b/source/css/common.css.scss
@@ -676,7 +676,7 @@ div[role="main"] {
   .info, .note {
     @extend .serif-italic;
     @include allCorners();
-    background  : url('/images/layout/info-bg.jpg') left top repeat transparent;
+    background  : inline-image('layout/info-bg.jpg') left top repeat transparent;
     margin      : 2em 0;
     border      : 1px solid #9ec6df;
     padding     : 15px 15px 15px 40px;
@@ -695,8 +695,8 @@ div[role="main"] {
     
     .info-icon {
       @include size(24px, 24px);
+      @include layout-sprite(info);
       display     : block;
-      background  : url('/images/layout/info.png') left top no-repeat transparent;
       position    : absolute;
       top         : 15px;
       left        : 9px;


### PR DESCRIPTION
It appears the blue background in our notes isn't appearing online (it does when I build the docs localy).  We just get the blue outline of the note.  E.g., the first note on the install from source page,
http://docs.basho.com/riak/1.2.1/tutorials/installation/Installing-Riak-from-Source/
