### PR TITLE
updating links to 'riak wiki'

### DIFF
--- a/data/global_nav.yml
+++ b/data/global_nav.yml
@@ -15,6 +15,7 @@ riak:
       - title: "MapReduce"
         sub:
           - "[[Overview|MapReduce]]"
+          - "[[Implementing|MapReduce Implementation]]"
           - "[[Key Filters]]"
       - title: "Search"
         sub:
@@ -139,7 +140,6 @@ riak:
       - "[[APIs]]"
       - "[[Client Libraries]]"
       - "[[Community Developed Libraries and Projects]]"
-      - "[[MapReduce Implementation]]"
       - "[[Backend API]]"
       - "[[Java Client Benchmark]]"
       - "[[Client Implementation Guide]]"

--- a/source/riak/cookbooks/Benchmarking.md
+++ b/source/riak/cookbooks/Benchmarking.md
@@ -29,7 +29,7 @@ Documentation
 <div class="info">
 <div class="title">Note on Documentation</div>
 
-This wiki topic replaces the documentation that was in the basho_bench
+This topic replaces the documentation that was in the basho_bench
 repository under `docs/Documentation.org` prior to February 2011.
 </div>
 

--- a/source/riak/cookbooks/Statistics-and-Monitoring.md
+++ b/source/riak/cookbooks/Statistics-and-Monitoring.md
@@ -64,7 +64,7 @@ The following are solutions which customers and community members have reported 
 Riaknostic integrates into the `riak-admin` command via a `diag` subcommand, and is a great first step in the process of diagnosing and troubleshooting issues on Riak nodes.
 
 #### Riak Control
-[Riak Control](http://wiki.basho.com/Riak-Control.html) is Basho's REST-driven user-interface for managing Riak clusters. It is designed to give you quick insight into the health of your cluster and allow for easy management of nodes.
+[[Riak Control]] is Basho's REST-driven user-interface for managing Riak clusters. It is designed to give you quick insight into the health of your cluster and allow for easy management of nodes.
 
 While Riak Control does not currently offer specific monitoring and statistics aggregation or analysis functionality, it does offer features which provide immediate insight into overall cluster health, node status, and handoff operations.
 
@@ -111,13 +111,13 @@ Splunk can be used to aggregate all Riak cluster node operational log files, inc
 ## Summary
 Riak exposes numerous forms of vital statistic information which can be aggregated, monitored, analyzed, graphed, and reported on in a variety of ways using numerous open source and commercial solutions.
 
-If you use a solution not listed here with Riak and would like to include it (or would otherwise like to update the information on this page), feel free to fork the wiki, add it in the appropriate section, and send a pull request to the [Riak wiki project](https://github.com/basho/basho_docs).
+If you use a solution not listed here with Riak and would like to include it (or would otherwise like to update the information on this page), feel free to fork the docs, add it in the appropriate section, and send a pull request to the [Riak Docs project](https://github.com/basho/basho_docs).
 
 ## References
 
-* [Inspecting a Node](http://wiki.basho.com/Inspecting-a-Node.html)
+* [[Inspecting a Node]]
 * [Riaknostic](http://riaknostic.basho.com)
-* [Riak Control](http://wiki.basho.com/Riak-Control.html)
+* [[Riak Control]]
 * [collectd](http://collectd.org)
 * [Ganglia](http://ganglia.info)
 * [Nagio](http://www.nagios.org)
@@ -129,4 +129,4 @@ If you use a solution not listed here with Riak and would like to include it (or
 * [Folsom Backed Stats Riak 1.2](http://basho.com/blog/technical/2012/07/02/folsom-backed-stats-riak-1-2/)
 * [Circonus](http://circonus.com)
 * [Splunk](http://www.splunk.com)
-* [Riak Wiki Github](https://github.com/basho/basho_docs)
+* [Riak Docs Github](https://github.com/basho/basho_docs)

--- a/source/riak/cookbooks/faqs/community-faq.html.fml
+++ b/source/riak/cookbooks/faqs/community-faq.html.fml
@@ -38,7 +38,7 @@ A:
 
 Q: Who will be considered for being a docs committer?
 A:
-  * Those who come forward and ask for privileges. To do this, simply send an email to _+wiki@basho.com+_ and tell us why you want to edit the docs and where precisely you can shine as a Community Editor.
+  * Those who come forward and ask for privileges. To do this, simply send an email to _+docs@basho.com+_ and tell us why you want to edit the docs and where precisely you can shine as a Community Editor.
   * Community Members who are nominated by a member of the Riak Development or Support teams
 
 Q: How will individuals be evaluated?
@@ -48,4 +48,4 @@ A:
   
   In both cases, members of the Basho Development and Support teams will hold a vote, via email, to approve the nominee.   Upon acceptance, the nominee will be notified via email.
   
-  [[See a list of current Community Wiki Committers|Contributors]]
+  [[See a list of current Community Docs Committers|Contributors]]

--- a/source/riak/cookbooks/faqs/developing-faq.html.fml
+++ b/source/riak/cookbooks/faqs/developing-faq.html.fml
@@ -278,7 +278,7 @@ A:
 Q: Is there a way to enforce a schema on data in a given bucket?
   Suppose I'd like to set up a bucket from which to store data adhering to a particular schema. Is there any way to set this up with riak? This way, when an attempt to store on a particular bucket, it will check with this schema first before storing it. Otherwise, it will produce an error.
 A:
-  Riak does not implement any form of schema validation. A pre-commit hook can be used in this scenario but would have to be written by your development team. You can read more about pre-commit hooks on the wiki. The wiki provides two pre-commit hook examples; one in Erlang that restricts objects that are too large and one in Javascript that restricts non-JSON content.
+  Riak does not implement any form of schema validation. A pre-commit hook can be used in this scenario but would have to be written by your development team. You can read more about pre-commit hooks on the docs. The docs provides two pre-commit hook examples; one in Erlang that restricts objects that are too large and one in Javascript that restricts non-JSON content.
 
 
 Q: How does the Erlang Riak Client manage node failures?

--- a/source/riak/cookbooks/faqs/operations-faq.html.fml
+++ b/source/riak/cookbooks/faqs/operations-faq.html.fml
@@ -154,7 +154,7 @@ A:
   1. **File system cache**. An active Riak node will have most of its free RAM consumed by the file system cache, which on Linux can be found as the "Cached" line in '/proc/meminfo' or the "cached" column when running the 'free -m' command. A healthy size for this metric is 20-30% of available RAM.
   2. **Virtual memory size of the Riak process**.  Also known as VSZ, when this metric approaches the amount of available RAM, the Riak node may be unable to allocate more memory (depending on whether you have swap enabled).  You can read this metric on Linux from the output of 'ps aux', and is measured in KB.
   
-  Adding those to your monitoring system will improve your ability to detect when nodes should be added to the cluster or the RAM upgraded. For more information about planning the size of your cluster, read the wiki pages on the subject.
+  Adding those to your monitoring system will improve your ability to detect when nodes should be added to the cluster or the RAM upgraded. For more information about planning the size of your cluster, read the docs on the subject.
 
 
 Q: What is the recommended procedure to add multiple new nodes?

--- a/source/riak/references/Command-Line-Tools---riak-admin.md
+++ b/source/riak/references/Command-Line-Tools---riak-admin.md
@@ -244,10 +244,10 @@ riak-admin transfer-limit <node> <limit>
 
 <div class="note">
 <div class="title">Deprecation Notice</title></div>
-As of Riak version 1.2, the <tt>riak-admin force-remove</tt> command has been deprecated in favor of the new <a href="#cluster"><code>riak-admin cluster force-remove</code></a> command. The command can still be used by providing a <code>-f</code> option, however.
+As of Riak version 1.2, the <tt>riak-admin force-remove</tt> command has been deprecated in favor of the new [[riak-admin cluster force-remove|Command-Line Tools - riak-admin#cluster-force-remove]] command. The command can still be used by providing a <code>-f</code> option, however.
 </div>
 
-Immediately removes a node from the cluster without ensuring handoff of its replicas. This is a dangerous command, and is designed to only be used in cases were the normal, safe leave behavior cannot be used -- e.g. when the node you are removing had a major hardware failure and is unrecoverable. Using this command will result in a loss of all replicas living on the removed node which will then need to be recovered through other means such as [[read repair|Replication#Read-Repair]]. It's recommended that you use the [[riak-admin leave|http://wiki.basho.com/Command-Line-Tools---riak-admin.html#leave]] command whenever possible.
+Immediately removes a node from the cluster without ensuring handoff of its replicas. This is a dangerous command, and is designed to only be used in cases were the normal, safe leave behavior cannot be used -- e.g. when the node you are removing had a major hardware failure and is unrecoverable. Using this command will result in a loss of all replicas living on the removed node which will then need to be recovered through other means such as [[read repair|Replication#Read-Repair]]. It's recommended that you use the [[riak-admin leave|Command-Line Tools - riak-admin#leave]] command whenever possible.
 
 ```bash
 riak-admin force-remove -f <node>

--- a/source/riak/references/Community-Developed-Libraries-and-Projects.md
+++ b/source/riak/references/Community-Developed-Libraries-and-Projects.md
@@ -9,7 +9,7 @@ audience: intermediate
 keywords: [client, drivers]
 ---
 
-The Riak Community is developing at a break-neck pace, and the number of community-contributed libraries and drivers is growing right along side it. Here is a list of projects that may suit your programming needs or curiosities. If you know of something that needs to be added or are developing something that you wish to see added to this list, please fork the [Riak Wiki repo on GitHub](https://github.com/basho/basho_docs) and send us a pull request.
+The Riak Community is developing at a break-neck pace, and the number of community-contributed libraries and drivers is growing right along side it. Here is a list of projects that may suit your programming needs or curiosities. If you know of something that needs to be added or are developing something that you wish to see added to this list, please fork the [Riak Docs repo on GitHub](https://github.com/basho/basho_docs) and send us a pull request.
 
 <div class="info">
 All of these projects and libraries are at various stages of completeness and may not suit your application's needs based on their level of maturity and activity.

--- a/source/riak/references/appendices/Sample-Data.md
+++ b/source/riak/references/appendices/Sample-Data.md
@@ -12,7 +12,7 @@ When learning how to use a database, reading tutorials and blogs and watching vi
 
 This page is intended to be a repository of sample data for that exact purpose. We will be expanding it as often as possible with different types of data that are suitable for different types of application testing.
 
-And, if you have sample data that you can spare or pointers to some data of which you are particularly fond, shoot an email to _wiki@basho.com_ and we'll add it to the page and expand the list.
+And, if you have sample data that you can spare or pointers to some data of which you are particularly fond, shoot an email to _docs@basho.com_ and we'll add it to the page and expand the list.
 
 ### Google Historical Stock Data
 

--- a/source/riak/references/appendices/community/Contributors.md
+++ b/source/riak/references/appendices/community/Contributors.md
@@ -9,7 +9,7 @@ keywords: [community]
 
 There are many ways to contribute to Riak and the community that backs it. The two primary avenues for contribution are code and documentation.
 
-This page is a listing of people who have contributed or are currently contributing to our code base and our wiki. We just wanted to say "Thanks!"
+This page is a listing of people who have contributed or are currently contributing to our code base and our docs. We just wanted to say "Thanks!"
 
 For more information on how to contribute, look through the [[Riak Community FAQs]].
 
@@ -17,9 +17,9 @@ For more information on how to contribute, look through the [[Riak Community FAQ
 
 Please see the [[THANKS file in the Riak repo on GitHub|https://github.com/basho/riak/blob/master/THANKS]] for a mostly-complete list of people who have contributed code to some part of Riak. (If your name should be on there but it's not, please submit a pull request of email *mark@basho.com*.)
 
-### Community Wiki Committers
+### Community Docs Committers
 
-Community Wiki Committers are non-Basho hackers who have commits access to the [[Riak Wiki Repo on GitHub|https://github.com/basho/basho_docs]].
+Community Docs Committers are non-Basho hackers who have commits access to the [[Riak Docs Repo on GitHub|https://github.com/basho/basho_docs]].
 
 * [[Scott Gonyea|http://twitter.com/acts_as]]
 * [[Mårten Gustafson|http://twitter.com/martengustafson]]

--- a/source/riak/references/appendices/community/Developing-with-Riak.md
+++ b/source/riak/references/appendices/community/Developing-with-Riak.md
@@ -10,7 +10,7 @@ keywords: [community, resources]
 
 This page is a collection of videos, slides, papers, and other media discussing developing with Riak (general guidelines, using client libraries, etc.).
 
-_If you have a video to add, please fork the [Riak Wiki Repo on GitHub](https://github.com/basho/basho_docs) and do so._
+_If you have a video to add, please fork the [Riak Docs Repo on GitHub](https://github.com/basho/basho_docs) and do so._
 
 ## Videos
 
@@ -47,7 +47,7 @@ _If you have a video to add, please fork the [Riak Wiki Repo on GitHub](https://
 
 This is a sample of the slide decks used in presentations given by Riak Core Developers and Developer Advocates, and members of the Riak Community at conferences, meetups, and various other events worldwide.
 
-_If you have a Slide Deck to add, please fork the [Riak Wiki Repo on GitHub](https://github.com/basho/basho_docs) and do so._
+_If you have a Slide Deck to add, please fork the [Riak Docs Repo on GitHub](https://github.com/basho/basho_docs) and do so._
 
 * [[riak-js: Javascript Turtles All the Way Down|http://www.slideshare.net/seancribbs/riakjs-javascript-turtles-all-the-way-down]] - riak-js is an awesome client driver for the Riak distributed datastore.
 * [[Building Distributed Systems With Riak and Riak Core|http://www.slideshare.net/argv0/riak-coredevnation]] - My talk from DevNationSF 2010 

--- a/source/riak/references/appendices/community/Production-Deployment.md
+++ b/source/riak/references/appendices/community/Production-Deployment.md
@@ -88,7 +88,7 @@ Oct. 11, 2011 Kresten Krab Thorup discusses a MySQL project that was moved to Ri
 
 ## Slide Decks
 
-This is a sample of the slide decks used in presentations given by Riak Core Developers and Developer Advocates, and members of the Riak Community at conferences, meetups, and various other events worldwide. *(If you have a Slide Deck to add, please fork the [Riak Wiki Repo on GitHub](https://github.com/basho/basho_docs) and do so.)*
+This is a sample of the slide decks used in presentations given by Riak Core Developers and Developer Advocates, and members of the Riak Community at conferences, meetups, and various other events worldwide. *(If you have a Slide Deck to add, please fork the [Riak Docs Repo on GitHub](https://github.com/basho/basho_docs) and do so.)*
 
 * [[Riak at Posterous|http://www.slideshare.net/capotej/riak-at-posterous]] - Posterous recently deployed Riak to serve as their content cache. In this talk, Julio Capote will cover why the engineering team chose Riak for the use case. He'll also share some details on the old post cache and its problems, what solutions they evaluated, and how they settled on Riak.
 * [[Scaling with Riak at Showyou|http://www.slideshare.net/jmuellerleile/scaling-with-riak-at-showyou]] - A presentation on how Showyou uses the Riak datastore at Showyou.com, as well as work we've been doing on a custom Riak backend for search and analytics.

--- a/source/riak/references/appendices/comparisons/Riak-Compared-to-CouchDB.md
+++ b/source/riak/references/appendices/comparisons/Riak-Compared-to-CouchDB.md
@@ -8,7 +8,7 @@ index: true
 keywords: [comparisons, couchdb]
 ---
 
-This is intended to be a brief, objective and technical comparison of Riak and CouchDB.  The CouchDB version described is 1.2.x. The Riak version described is Riak 1.1.x. If you feel this comparison is unfaithful at all for whatever reason, please [fix it](https://github.com/basho/riak_wiki/issues/new) or send an email to **docs@basho.com**.
+This is intended to be a brief, objective and technical comparison of Riak and CouchDB.  The CouchDB version described is 1.2.x. The Riak version described is Riak 1.1.x. If you feel this comparison is unfaithful at all for whatever reason, please [fix it](https://github.com/basho/basho_docs/issues/new) or send an email to **docs@basho.com**.
 
 ## At A Very High Level
 

--- a/source/riak/references/appendices/comparisons/Riak-Compared-to-HBase.md
+++ b/source/riak/references/appendices/comparisons/Riak-Compared-to-HBase.md
@@ -8,7 +8,7 @@ index: true
 keywords: [comparisons, hbase]
 ---
 
-This is intended to be a brief, objective and technical comparison of Riak and HBase. The HBase version described is 0.94.x. The Riak version described is Riak 1.1.x. If you feel this comparison is unfaithful at all for whatever reason, please [fix it](https://github.com/basho/riak_wiki/issues/new) or send an email to **docs@basho.com**.
+This is intended to be a brief, objective and technical comparison of Riak and HBase. The HBase version described is 0.94.x. The Riak version described is Riak 1.1.x. If you feel this comparison is unfaithful at all for whatever reason, please [fix it](https://github.com/basho/basho_docs/issues/new) or send an email to **docs@basho.com**.
 
 ## At A Very High Level
 

--- a/source/riak/references/appendices/comparisons/Riak-Compared-to-MongoDB.md
+++ b/source/riak/references/appendices/comparisons/Riak-Compared-to-MongoDB.md
@@ -8,7 +8,7 @@ index: true
 keywords: [comparisons, mongodb]
 ---
 
-This is intended to be a brief, objective and technical comparison of Riak and MongoDB.  The MongoDB version described is 2.2.x. The Riak version described is Riak 1.1.x. If you feel this comparison is unfaithful at all for whatever reason, please [fix it](https://github.com/basho/riak_wiki/issues/new) or send an email to **docs@basho.com**.
+This is intended to be a brief, objective and technical comparison of Riak and MongoDB.  The MongoDB version described is 2.2.x. The Riak version described is Riak 1.1.x. If you feel this comparison is unfaithful at all for whatever reason, please [fix it](https://github.com/basho/basho_docs/issues/new) or send an email to **docs@basho.com**.
 
 ## At A Very High Level
 

--- a/source/riak/references/dynamo.html.erb
+++ b/source/riak/references/dynamo.html.erb
@@ -41,7 +41,7 @@ Riak specifics.  </p>
         </div>
         <p>In the right column, you&#39;ll find the paper reprinted in its entirety, images and all. 
 In this, the left column, you have Riak specifics that relate to a given section of the paper; 
-anything from links to the Riak wiki, to code references, to explanations of why and how
+anything from links to the Riak docs, to code references, to explanations of why and how
 we did what we did when we did it. There is also some work to do to make Riak more like Dynamo in some 
 ways. This is noted, too. </p>
       </td>
@@ -1188,7 +1188,7 @@ possibility of multiple versions of the same data (in order to never lose any up
         <p>As you&#39;ve probably figured out already, Riak uses vector clocks for object versioning, too.
 Here are a whole host of resources to keep you busy for a while:
 <ul>
-<li><a href ="http://wiki.basho.com/display/RIAK/Riak+Glossary#RiakGlossary-VectorClock">Vector Clocks on the Riak Wiki</a></li>
+<li>[[Vector Clock on Riak Glossary|Riak Glossary#Vector-Clock]]</li>
 <li><a href="http://blog.basho.com/2010/01/29/why-vector-clocks-are-easy/">Why Vector Clocks are Easy</a></li>
 <li><a href="http://blog.basho.com/2010/04/05/why-vector-clocks-are-hard/">Why Vector Clocks are Hard</a></li>
 <li><a href="http://en.wikipedia.org/wiki/Vector_clock">Vector Clocks on Wikipedia</a></li>
@@ -1332,8 +1332,8 @@ the request level if the developer deems it necessary for certain data.
 
 <p>Some more resources on R and W:
 <ul>
-<li><a href ="http://wiki.basho.com/display/RIAK/REST+API">Riak&#39;s REST API</a></li>
-<li><a href="http://wiki.basho.com/display/RIAK/An+Introduction+to+Riak#AnIntroductiontoRiak-ReadingData"> Reading and Writing Data</a></li>
+<li>[[Riak&#39;s REST API|HTTP API]]</li>
+<li>[[Reading and Writing Data|Basic Requests]]</a></li>
 </ul></p>
       </td>
       <td class=code>

--- a/source/riak/references/dynamo.roc
+++ b/source/riak/references/dynamo.roc
@@ -8,7 +8,7 @@
 
 # In the right column, you'll find the paper reprinted in its entirety, images and all. 
 # In this, the left column, you have Riak specifics that relate to a given section of the paper; 
-# anything from links to the Riak wiki, to code references, to explanations of why and how
+# anything from links to the Riak docs, to code references, to explanations of why and how
 # we did what we did when we did it. There is also some work to do to make Riak more like Dynamo in some 
 # ways. This is noted, too. 
 
@@ -723,7 +723,7 @@ possibility of multiple versions of the same data (in order to never lose any up
 # As you've probably figured out already, Riak uses vector clocks for object versioning, too.
 # Here are a whole host of resources to keep you busy for a while:
 # <ul>
-# <li><a href ="http://wiki.basho.com/display/RIAK/Riak+Glossary#RiakGlossary-VectorClock">Vector Clocks on the Riak Wiki</a></li>
+# <li>[[Vector Clock on Riak Glossary|Riak Glossary#Vector-Clock]]</li>
 # <li><a href="http://blog.basho.com/2010/01/29/why-vector-clocks-are-easy/">Why Vector Clocks are Easy</a></li>
 # <li><a href="http://blog.basho.com/2010/04/05/why-vector-clocks-are-hard/">Why Vector Clocks are Hard</a></li>
 # <li><a href="http://en.wikipedia.org/wiki/Vector_clock">Vector Clocks on Wikipedia</a></li>
@@ -825,8 +825,8 @@ the preference list are accessed.
 #
 # Some more resources on R and W:
 # <ul>
-# <li><a href ="http://wiki.basho.com/display/RIAK/REST+API">Riak's REST API</a></li>
-# <li><a href="http://wiki.basho.com/display/RIAK/An+Introduction+to+Riak#AnIntroductiontoRiak-ReadingData"> Reading and Writing Data</a></li>
+# <li>[[Riak&#39;s REST API|HTTP API]]</li>
+# <li>[[Reading and Writing Data|Basic Requests]]</a></li>
 # </ul>
 To maintain consistency among its replicas, Dynamo uses a consistency protocol similar to those used in 
 quorum systems. This protocol has two key configurable values: R and W. R is the minimum number of nodes 

--- a/source/riak/tutorials/fast-track/Loading-Data-and-Running-MapReduce-Queries.md
+++ b/source/riak/tutorials/fast-track/Loading-Data-and-Running-MapReduce-Queries.md
@@ -128,7 +128,7 @@ Map phases may also be passed static arguments by using the "arg" spec field.
 
 Reduce phases look exactly like map phases, but are labeled "reduce".
 
-<div class="info">For more information on map and reduce functions please refer to the [[MapReduce|MapReduce#Phasefunctions]] section of the wiki which includes a description of the arguments passed to these functions.</div>
+<div class="info">For more information on map and reduce functions please refer to the [[MapReduce|MapReduce#Phasefunctions]] section of the docs which includes a description of the arguments passed to these functions.</div>
 
 #### Link
 

--- a/source/riak/tutorials/installation/Installing-Riak-CS.md
+++ b/source/riak/tutorials/installation/Installing-Riak-CS.md
@@ -63,7 +63,7 @@ Replace `<stanchion-package.rpm>` with the actual file name for the package you 
 <div class="note"><div class="title">Note</div>CentOS enables Security-Enhanced Linux (SELinux) by default. If you encounter errors during installation, try disabling SELinux.</div>
 
 ## Installing Riak
-If you have not yet installed Riak, follow the [[Riak Installation|http://wiki.basho.com/Installation.html]] documentation to do so.
+If you have not yet installed Riak, follow the [[Riak Installation|Installation]] documentation to do so.
 
 ## What's Next?
 Once you've completed installation of Riak CS and Riak, you're ready to learn more about the [[Configuration of Riak CS|Configuration]].

--- a/source/riakee-index.md
+++ b/source/riakee-index.md
@@ -10,7 +10,7 @@ keywords: []
 simple: true
 ---
 
-<div class="info"><div class="title">Riak Enterprise Only</div>This documentation applies only to Riak Enterprise, Basho's commercial extension to <a href="http://wiki.basho.com/Riak.html">Riak</a>. To talk to us about using Riak Enterprise,  <a href="http://info.basho.com/Wiki_Contact.html" target="_blank">let us know</a>.</div>
+<div class="info"><div class="title">Riak Enterprise Only</div>This documentation applies only to Riak Enterprise, Basho's commercial extension to [[Riak]]. To talk to us about using Riak Enterprise,  <a href="http://info.basho.com/Wiki_Contact.html" target="_blank">let us know</a>.</div>
 
 Riak Enterprise is a commercially distributed product built on Riak (Apache 2.0-licensed) that extends Riak's capabilities with [[multi-datacenter replication|Multi Data Center Replication Architecture]], [[SNMP monitoring|SNMP Configuration]], [[JMX-Monitoring]], and 24x7 support. 
 

--- a/source/riakee/cookbooks/Multi-Data-Center-Replication-Operations.md
+++ b/source/riakee/cookbooks/Multi-Data-Center-Replication-Operations.md
@@ -286,7 +286,7 @@ Please see the definitions in the **Client Statistics** section.
 
 ## Bounded Queue
 
-   * The bounded queue is responsible for holding objects that are waiting to participate in real-time replication. Please see the [Riak EE MDC Replication Configuration](http://wiki.basho.com/Multi-Data-Center-Replication-Configuration.html) guide for more information. 
+   * The bounded queue is responsible for holding objects that are waiting to participate in real-time replication. Please see the [[Riak EE MDC Replication Configuration|Multi-Data-Center Replication Configuration]] guide for more information. 
    * Please note that these values are only available in Riak EE 1.2.1+.
    
   - **queue_pid** 


### PR DESCRIPTION
Fixed broken links to old riak_wiki and pointed to basho_docs repo.  

One question (hence the PR), do we want to keep calling it the Riak Wiki in the link text (and in general)?  I vote yes, as the setup we have for the new docs (github repo with pages generated by another tool), is basically the same, and calling it a wiki let's people know it's editable.  Thoughts? @coderoshi @brianshumate @PharkMillups @shanley @tsantero 
