### PR TITLE
made APIs top nav

### DIFF
--- a/data/global_nav.yml
+++ b/data/global_nav.yml
@@ -246,11 +246,14 @@ riakcs:
       - "[[Querying Access Statistics]]"
       - "[[Querying Storage Statistics]]"
       - "[[Usage and Billing Data]]"
+  - title: APIs
+    sub:
+      - "[[RiakCS Storage API]]"
   - title: "Shortcuts"
     class: "active"
     sub:
       - "[[FAQs|Riak CS FAQs]]"
-      - "[[APIs|RiakCS Storage API]]"
+      
 
 root:
   - title: "All Riak Projects"


### PR DESCRIPTION
Moved Storage API page from 'Shortcuts' to a top-level nav for more visibility.
