### PR TITLE
Made the search hook copy/pastable

### DIFF
--- a/source/riak/cookbooks/Riak-Search---Indexing-and-Querying-Riak-KV-Data.md
+++ b/source/riak/cookbooks/Riak-Search---Indexing-and-Querying-Riak-KV-Data.md
@@ -29,9 +29,9 @@ bin/search-cmd install my_bucket_name
 Any other method you would normally use to set bucket properties can also be used to enable the Search precommit hook as well.  For example, using curl to install over HTTP:
 
 ```bash
-curl -XPUT -H "content-type:application/json" http://localhost:8098/riak/demo2 --data @-
+curl -XPUT -H "content-type:application/json" http://localhost:8098/riak/demo2 -d @- << EOF
 {"props":{"precommit":[{"mod":"riak_search_kv_hook","fun":"precommit"}]}}
-^D
+EOF
 ```
 
 Note, though, that you may want to read the bucket properties first, so you don't clobber any precommit hook already in place.


### PR DESCRIPTION
The old command assumed that you knew what about stdout and ^D.

This command lets you copy/paste it.
