### PR TITLE
Bad link to "rolling upgrades" from "installing from source"

### DIFF
--- a/source/riak/tutorials/installation/Installing-Riak-from-Source.md
+++ b/source/riak/tutorials/installation/Installing-Riak-from-Source.md
@@ -7,7 +7,6 @@ audience: beginner
 keywords: [tutorial, installing, suse]
 prev: ["Installing on AWS Marketplace", "Installing-on-AWS-Marketplace.html"]
 up:   ["Installing and Upgrading", "index.html"]
-next: ["Rolling Upgrades", "Rolling-Upgrades.html"]
 ---
 
 Riak should be installed from source if you are building on a platform for which a package does not exist or you are interested in contributing to Riak.


### PR DESCRIPTION
The "next" navigation from http://docs.basho.com/riak/latest/tutorials/installation/Installing-Riak-from-Source/ points to http://docs.basho.com/riak/latest/Rolling-Upgrades.html, which doesn't exist. It should link to http://docs.basho.com/riak/latest/cookbooks/Rolling-Upgrades/, no?
