### PR TITLE
Fix description of "objects_sent"

### DIFF
--- a/source/riakee/cookbooks/Multi-Data-Center-Replication-Operations.md
+++ b/source/riakee/cookbooks/Multi-Data-Center-Replication-Operations.md
@@ -135,7 +135,7 @@ The following definitions describe the output of `riak-repl status`. Please note
 
 * **objects_sent**
 
-    The number of objects sent via real-time and fullsync replication.
+    The number of objects sent via real-time replication.
 
 * **server_bytes_recv**
 


### PR DESCRIPTION
According to https://help.basho.com/requests/3468, "objects_sent" is the number of realtime writes that have been forwarded to the other cluster, not the number of objects sent over fullsync.
