### PR TITLE
Add Basho Package Repository info

### DIFF
--- a/source/riak/tutorials/installation/Installing-on-Debian-and-Ubuntu.md
+++ b/source/riak/tutorials/installation/Installing-on-Debian-and-Ubuntu.md
@@ -16,8 +16,36 @@ The following steps have been tested to work with Riak on Debian version 6.05 an
 
 Riak can be installed on Debian or Ubuntu based systems with a binary package or by [[compiling Riak from source code|Installing Riak from Source]].
 
+Installing From Apt-Get
+-----------------------
+
+If you wish to just install Riak and get on with your life, use `apt-get`.
+
+First you must get the signing key.
+
+```bash
+curl http://apt.basho.com/gpg/basho.apt.key | sudo apt-key add -
+```
+
+Then add the Basho repository to your apt sources list (and update them).
+
+```
+sudo bash -c "echo deb http://apt.basho.com lsb_release -sc main > /etc/apt/sources.list.d/basho.list"
+sudo apt-get update
+```
+
+Now install riak.
+
+```bash
+sudo apt-get install riak
+```
+
+That should be all.
+
 Installing From Package
 -----------------------
+
+If you wish to install the deb packages by hand follow these instructions.
 
 ### SSL Library Requirement for Ubuntu
 
@@ -31,7 +59,7 @@ To install the libssl version 0.9.8 package, execute the following
 command:
 
 ```bash
-    $ sudo apt-get install libssl0.9.8
+sudo apt-get install libssl0.9.8
 ```
 
 After the libssl package installation, proceed to installing Riak from
@@ -43,29 +71,29 @@ for the target platform:
 #### Ubuntu Lucid Lynx (10.04)
 
 ```bash
-    $ wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/ubuntu/lucid/riak_1.2.1-1_amd64.deb
-    $ sudo dpkg -i riak_1.2.1-1_amd64.deb
+wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/ubuntu/lucid/riak_1.2.1-1_amd64.deb
+sudo dpkg -i riak_1.2.1-1_amd64.deb
 ```
 
 #### Ubuntu Natty Narwhal (11.04)
 
 ```bash
-    $ wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/ubuntu/natty/riak_1.2.1-1_amd64.deb
-    $ sudo dpkg -i riak_1.2.1-1_amd64.deb
+wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/ubuntu/natty/riak_1.2.1-1_amd64.deb
+sudo dpkg -i riak_1.2.1-1_amd64.deb
 ```
 
 #### Ubuntu Precise Pangolin (12.04)
 
 ```bash
-    $ wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/ubuntu/precise/riak_1.2.1-1_amd64.deb
-    $ sudo dpkg -i riak_1.2.1-1_amd64.deb
+wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/ubuntu/precise/riak_1.2.1-1_amd64.deb
+sudo dpkg -i riak_1.2.1-1_amd64.deb
 ```
 
 ### Riak 32-bit Installation
 
 ```bash
-    $ wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/ubuntu/lucid/riak_1.2.1-1_i386.deb
-    $ sudo dpkg -i riak_1.2.1-1_i386.deb
+wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/ubuntu/lucid/riak_1.2.1-1_i386.deb
+sudo dpkg -i riak_1.2.1-1_i386.deb
 ```
 <div class="note"><div class="title">Upgrading Riak</div>If upgrading the Riak package, and the user named "riak" exists without a home directory, create a home directory (`/var/lib/riak`), and execute `chown riak:riak /var/lib/riak` before starting Riak.</div>
 
@@ -76,7 +104,7 @@ Installing Riak From Source
 First, install Riak dependencies using apt:
 
 ```bash
-    $ sudo apt-get install build-essential libc6-dev-i386 git
+sudo apt-get install build-essential libc6-dev-i386 git
 ```
 
 Riak requires [Erlang](http://www.erlang.org/) R15B01. *Note: don't use Erlang version R15B02, for the moment, as it causes an [error with riak-admin status](https://github.com/basho/riak/issues/227) commands*. 
@@ -86,10 +114,10 @@ If Erlang is not already installed, install it before continuing (see:
 With Erlang installed, proceed to downloading and installing Riak:
 
 ```bash
-    $ wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/riak-1.2.1.tar.gz
-    $ tar zxvf riak-1.2.1.tar.gz
-    $ cd riak-1.2.1
-    $ make rel
+wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/riak-1.2.1.tar.gz
+tar zxvf riak-1.2.1.tar.gz
+cd riak-1.2.1
+make rel
 ```
 
 If the build was successful, a fresh build of Riak will exist in the

--- a/source/riak/tutorials/installation/Installing-on-RHEL-and-CentOS.md
+++ b/source/riak/tutorials/installation/Installing-on-RHEL-and-CentOS.md
@@ -21,6 +21,17 @@ When installing Riak on CentOS or Redhat you can install from source or from our
 
 ### For Centos 5 / RHEL 5
 
+You can either install using yum *(recommended)*,
+
+```
+package=basho-release-5-1.noarch.rpm && \
+wget http://yum.basho.com/gpg/$package -O /tmp/$package && \
+sudo rpm -ivh /tmp/$package
+sudo yum install riak
+```
+
+...or install the rpm package manually.
+
 ```bash
 wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/rhel/5/riak-1.2.1-1.el5.x86_64.rpm
 sudo rpm -Uvh riak-1.2.1-1.el5.x86_64.rpm
@@ -28,12 +39,24 @@ sudo rpm -Uvh riak-1.2.1-1.el5.x86_64.rpm
 
 ### For Centos 6 / RHEL 6
 
+You can either install using yum *(recommended)*,
+
+```
+package=basho-release-6-1.noarch.rpm && \
+wget http://yum.basho.com/gpg/$package -O /tmp/$package && \
+sudo rpm -ivh /tmp/$package
+sudo yum install riak
+```
+
+...or install the rpm package manually.
+
 ```bash
 wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/rhel/6/riak-1.2.1-1.el6.x86_64.rpm
 sudo rpm -Uvh riak-1.2.1-1.el6.x86_64.rpm
 ```
 
 ## Installing From Source
+
 Riak requires [[Erlang|http://www.erlang.org/]] R15B01. *Note: don't use Erlang version R15B02, for the moment, as it causes an [error with riak-admin status](https://github.com/basho/riak/issues/227) commands*.
 
 If you do not have Erlang already installed, see our guide to [[Installing Erlang]]. Don’t worry, it’s easy!


### PR DESCRIPTION
The inestimable @jsmartin finally stepped up and built basho package repositories. 

http://basho.com/blog/technical/2012/10/16/Basho-Package-Repos-Now-Online/

We need to add this to the docs. Somewhere around "install" would probably be appropriate. 
