### PR TITLE
cleaning up installation docs/adding post installation notes

### DIFF
--- a/data/global_nav.yml
+++ b/data/global_nav.yml
@@ -84,6 +84,7 @@ riak:
           - "[[Windows Azure|Installing on Windows Azure]]"
           - "[[AWS Marketplace|Installing on AWS Marketplace]]"
           - "[[From Source|Installing Riak from Source]]"
+          - "[[Post Installation|Post Installation]]"
 
       - title: "Planning/Backends"
         sub:

--- a/source/riak/tutorials/installation/Installing-Riak-from-Source.md
+++ b/source/riak/tutorials/installation/Installing-Riak-from-Source.md
@@ -92,3 +92,10 @@ If you are running Riak on a platform not in the list above and need some help g
 
 ### Windows
 Riak is not currently supported on Microsoft Windows.
+
+## Next Steps?
+From here you might want to check out:
+
+* [[Post Installation Notes|Post Installation]]: for checking Riak health after installation
+* [[The Riak Fast Track]]: a guide for setting up a 3 node cluster and exploring Riak’s main features.
+* [[Basic Cluster Setup]]: a guide that will show you how to go from one node to bigger than Google!

--- a/source/riak/tutorials/installation/Installing-on-Debian-and-Ubuntu.md
+++ b/source/riak/tutorials/installation/Installing-on-Debian-and-Ubuntu.md
@@ -107,7 +107,7 @@ First, install Riak dependencies using apt:
 sudo apt-get install build-essential libc6-dev-i386 git
 ```
 
-Riak requires [Erlang](http://www.erlang.org/) R15B01. *Note: don't use Erlang version R15B02, for the moment, as it causes an [error with riak-admin status](https://github.com/basho/riak/issues/227) commands*. 
+Riak requires [Erlang](http://www.erlang.org/) R15B01. *Note: don't use Erlang version R15B02, for the moment, as it causes an [error with riak-admin status](https://github.com/basho/riak/issues/227) commands*.
 If Erlang is not already installed, install it before continuing (see:
 [[Installing Erlang]] for more information).
 
@@ -128,6 +128,7 @@ Next Steps?
 
 Now that Riak is installed, check out the following resources:
 
+-   [[Post Installation Notes|Post Installation]]: for checking Riak health after installation
 -   [[The Riak Fast Track]]: a
     guide for setting up a 3 node cluster and exploring Riak's main features.
 -   [[Basic Cluster Setup]]:

--- a/source/riak/tutorials/installation/Installing-on-FreeBSD.md
+++ b/source/riak/tutorials/installation/Installing-on-FreeBSD.md
@@ -115,6 +115,7 @@ gmake devrel
 ## Next Steps?
 From here you might want to check out:
 
+* [[Post Installation Notes|Post Installation]]: for checking Riak health after installation
 * [[The Riak Fast Track]]: a guide for setting up a 3 node cluster and exploring Riak’s main features.
 * [[Basic Cluster Setup]]: a guide that will show you how to go from one node to bigger than Google!
 

--- a/source/riak/tutorials/installation/Installing-on-Mac-OS-X.md
+++ b/source/riak/tutorials/installation/Installing-on-Mac-OS-X.md
@@ -55,7 +55,7 @@ You must have XCode tools installed from the CD that came with your Mac or from 
 
 <div class="note">Riak will not compile with Clang. Please make sure your default C/C++ compiler is GCC.</div>
 
-Riak requires [[Erlang|http://www.erlang.org/]] R15B01. *Note: don't use Erlang version R15B02, for the moment, as it causes an [error with riak-admin status](https://github.com/basho/riak/issues/227) commands*. 
+Riak requires [[Erlang|http://www.erlang.org/]] R15B01. *Note: don't use Erlang version R15B02, for the moment, as it causes an [error with riak-admin status](https://github.com/basho/riak/issues/227) commands*.
 
 If you do not have Erlang already installed, see [[Installing Erlang]]. Don't worry, it's easy!
 
@@ -73,5 +73,6 @@ If you get errors when building about "incompatible architecture", please verify
 ## Next Steps?
 From here you might want to check out:
 
+  * [[Post Installation|Post Installation Notes]]: for checking Riak health after installation
   * [[The Riak Fast Track]]: a guide for setting up a 4 node cluster and exploring Riak's main features.
   * [[Basic Cluster Setup]]: a guide that will show you how to go from one node to bigger than Google!

--- a/source/riak/tutorials/installation/Installing-on-RHEL-and-CentOS.md
+++ b/source/riak/tutorials/installation/Installing-on-RHEL-and-CentOS.md
@@ -89,5 +89,6 @@ You will now have a fresh build of Riak in the `rel/riak` directory.
 
 From here you might want to check out:
 
+* [[Post Installation|Post Installation Notes]]: for checking Riak health after installation
 * [[The Riak Fast Track]]: a guide for setting up a 3 node cluster and exploring Riak’s main features.
 * [[Basic Cluster Setup]]: a guide that will show you how to go from one node to bigger than Google!

--- a/source/riak/tutorials/installation/Installing-on-SUSE.md
+++ b/source/riak/tutorials/installation/Installing-on-SUSE.md
@@ -55,5 +55,6 @@ $ zypper mr -r Riak
 
 From here you might want to check out:
 
+* [[Post Installation Notes|Post Installation]]: for checking Riak health after installation
 * [[Riak Fast Track|The-Riak-Fast-Track]]: a guide for setting up a 4 node cluster and exploring Riak's main features.
 * [[Basic Cluster Setup|Basic Cluster Setup]]: a guide that will show you how to go from one node to bigger than Google!

--- a/source/riak/tutorials/installation/Installing-on-SmartOS.md
+++ b/source/riak/tutorials/installation/Installing-on-SmartOS.md
@@ -80,6 +80,7 @@ Next Steps?
 
 Now that Riak is installed, check out the following resources:
 
+-   [[Post Installation Notes|Post Installation]]: for checking Riak health after installation
 -   [[The Riak Fast Track]]: A
     guide for setting up a 4 node cluster and exploring Riak's main
     features.

--- a/source/riak/tutorials/installation/Post-Installation.md
+++ b/source/riak/tutorials/installation/Post-Installation.md
@@ -1,0 +1,143 @@
+---
+title: Post Installation Notes
+project: riak
+version: 0.10.0+
+document: tutorial
+audience: beginner
+keywords: [tutorial, installing, upgrading]
+prev: ["Installing Riak From Source", "Installing-Riak-from-Source.html"]
+up:   ["Installing and Upgrading", "index.html"]
+
+---
+
+After you've installed Riak, you might next wish to check the liveness of
+each node and ensure that requests are being properly served.
+
+The following are common ways to verify that your Riak nodes are operating
+correctly. After you've determined that your nodes are functioning and you're
+ready to put Riak to work, be sure to check out the resources in the
+**Now What?** section below.
+
+## Starting a Riak Node
+
+<div class="note"><div class="title">Note about source installations</div>
+<p>To start a Riak node that was installed by compiling the source code, you
+can add the Riak binary directory from the installation directory you've
+chosen to your PATH.</p> <p>For example, if you compiled Riak from source in
+the `/home/riak` directory, then you can add the binary directory
+(`/home/riak/rel/riak/bin`) to your PATH so that Riak commands can be
+used in the same manner as with a packaged installation.</p></div>
+
+To start a Riak node, use the `riak start` command:
+
+```bash
+riak start
+```
+
+A successful start will return no output. If there is a problem starting the
+node, an error message is printed to standard error.
+
+To run Riak with an attached interactive Erlang console:
+
+```bash
+riak console
+```
+
+A Riak node is typically started in console mode as part of debugging or
+troubleshooting to gather more detailed information from the Riak startup
+sequence. Note that if you start a Riak node in this manner, it is running as
+a foreground process which will be exited when the console is closed.
+
+You can close the console by issuing this command at the Erlang prompt:
+
+```erlang
+q().
+```
+
+Once your node has started, you can initially check that it is running with
+the `riak ping` command:
+
+```bash
+riak ping
+pong
+```
+
+The command will respond with **pong** if the node is running, or **pang** if
+it is unreachable for any reason.
+
+<div class="note"><div class="title">Open Files Limit</div>
+As you may have noticed, if you haven't adjusted your open files limit (`ulimit -n`), Riak will warn you at startup about the limit. You're advised
+to increase the operating system default open files limit when running Riak.
+You can read more about why in the [[Open Files Limit]] documentation.</div>
+
+## Does it work?
+
+One convenient means to test the readiness of an individual Riak node and
+its ability to read and write data is with the `riak-admin test` command:
+
+```bash
+riak-admin test
+```
+
+Successful output from `riak-admin test` looks like this:
+
+```text
+Attempting to restart script through sudo -H -u riak
+Successfully completed 1 read/write cycle to 'riak@127.0.0.1'
+```
+
+You can also test whether Riak is working by using the `curl` command-line
+tool. Now that you have Riak running on a node, try this command to retrieve
+the `test` bucket and its properties:
+
+```bash
+curl -v http://127.0.0.1:8098/riak/test
+```
+
+Replace `127.0.0.1` in the example above with your Riak node's IP address or
+fully qualified domain name; you should get a response from the command that
+looks like this:
+
+```text
+* About to connect() to 127.0.0.1 port 8098 (#0)
+*   Trying 127.0.0.1... connected
+* Connected to 127.0.0.1 (127.0.0.1) port 8098 (#0)
+> GET /riak/test HTTP/1.1
+> User-Agent: curl/7.21.6 (x86_64-pc-linux-gnu)
+> Host: 127.0.0.1:8098
+> Accept: */*
+>
+< HTTP/1.1 200 OK
+< Vary: Accept-Encoding
+< Server: MochiWeb/1.1 WebMachine/1.9.0 (someone had painted it blue)
+< Date: Wed, 26 Dec 2012 15:50:20 GMT
+< Content-Type: application/json
+< Content-Length: 422
+<
+* Connection #0 to host 127.0.0.1 left intact
+* Closing connection #0
+{"props":{"name":"test","allow_mult":false,"basic_quorum":false,
+ "big_vclock":50,"chash_keyfun":{"mod":"riak_core_util",
+ "fun":"chash_std_keyfun"},"dw":"quorum","last_write_wins":false,
+ "linkfun":{"mod":"riak_kv_wm_link_walker","fun":"mapreduce_linkfun"},
+ "n_val":3,"notfound_ok":true,"old_vclock":86400,"postcommit":[],"pr":0,
+ "precommit":[],"pw":0,"r":"quorum","rw":"quorum","small_vclock":50,
+ "w":"quorum","young_vclock":20}}
+```
+
+The above output shows a successful response (HTTP 200 OK) and additional
+details from the verbose option. The response also contains the bucket
+properties for Riak's test bucket.
+
+## Now what?
+
+You have a working Riak node!
+
+From here you might want to check out the following resources.
+
+* [[The Riak Fast Track]]: A guide for setting up a 3 node cluster and exploring Riak's main features.
+* Check out the [[Client Libraries]] to use Riak with your favorite programming language
+* Get some [[Sample Data]]
+* [[Add more nodes|Basic Cluster Setup]] to your Riak cluster
+* [[Learn about the high level concepts of Riak|Concepts]]
+* [[Learn more about day-to-day system operations|Operators]]

--- a/source/riak/tutorials/installation/index.md
+++ b/source/riak/tutorials/installation/index.md
@@ -8,7 +8,12 @@ keywords: [tutorial, installing, upgrading]
 next: ["Installing Erlang", "Installing-Erlang.html"]
 ---
 
-Click the link for your operating system to see instructions on how to install Riak. But first, you must [[Install Erlang|Installing Erlang]].
+Riak is supported on numerous popular operating systems and virtualized
+environments. The following information will help you to
+properly install or upgrade Riak in one of the supported environments.
+
+Click the link for your operating system or virtualized environment for
+detailed Riak installation instructions.
 
   * [[Debian and Ubuntu|Installing on Debian and Ubuntu]]
   * [[RHEL and CentOS|Installing on RHEL and CentOS]]
@@ -17,79 +22,13 @@ Click the link for your operating system to see instructions on how to install R
   * [[SUSE|Installing on SUSE]]
   * [[Windows Azure|Installing on Windows Azure]]
   * [[AWS Marketplace|Installing on AWS Marketplace]]
-  * [[From Source|Installing Riak from Source]] *(to be used on an unlisted-operating system)*
+  * [[From Source|Installing Riak from Source]] *(for unlisted-operating systems, requires [[Erlang installation|Installing Erlang]])*
 
 ### Upgrading
 
   * [[Rolling Upgrades]]
   * [[Upgrading from Riak Search]] {{<1.0.0}}
 
-### Cookbooks
+### Chef Cookbooks
 
   * [[Installing With Chef]]
-
-## Starting up
-
-To start up a Riak node, change directory as necessary to where you installed Riak (in the source directory, it's `rel/riak/bin` and run the riak command like so:
-
-```bash
-riak start
-```
-
-To run Riak with an interactive Erlang console:
-
-```bash
-riak console
-```
-
-Once your node has started, you can double-check that it is running using:
-
-```bash
-riak ping
-pong
-```
-
-The command will respond with **pong** if the node is running, or **pang** if it is not.
-
-<div class="note"><div class="title">Open Files Limit</div>
-As you may have noticed, if you haven't adjusted your ulimit settings, Riak will warn you. You're advised to raise your open files limit when running Riak. You can read more about why on the [[Open Files Limit]] page.</div>
-
-## Does it work?
-The easiest way to test whether Riak is working is to use the `curl` command-line tool. Now that you have Riak running on your local machine, run this command:
-
-```bash
-curl -v http://127.0.0.1:8098/riak/test
-```
-
-You should get a response that looks like this:
-
-```bash
-* About to connect() to 127.0.0.1 port 8098 (#0)
-*   Trying 127.0.0.1... connected
-* Connected to 127.0.0.1 (127.0.0.1) port 8098 (#0)
-GET /riak/test HTTP/1.1
-User-Agent: curl/7.19.4 (universal-apple-darwin10.0) libcurl/7.19.4 OpenSSL/0.9.8l zlib/1.2.3
-Host: 127.0.0.1:8098
-Accept: */*
-
-HTTP/1.1 200 OK
-Vary: Accept-Encoding
-Server: MochiWeb/1.1 WebMachine/1.6 (eat around the stinger)
-Date: Mon, 08 Mar 2010 16:42:49 GMT
-Content-Type: application/json
-Content-Length: 266
-
-* Connection #0 to host 127.0.0.1 left intact
-* Closing connection #0
-{"props":{"name":"test","allow_mult":false,"big_vclock":50,"chash_keyfun":{"mod":"riak_util","fun":"chash_std_keyfun"},"linkfun":{"mod":"raw_link_walker_resource","fun":"mapreduce_linkfun"},"n_val":3,"old_vclock":86400,"small_vclock":10,"young_vclock":20},"keys":[]}
-```
-
-## Now what?
-You have a working Riak system! From here you might want to check out:
-
-  * [[The Riak Fast Track]]: A guide for setting up a 3 node cluster and exploring Riak's main features.
-  * Check out the [[Client Libraries]] to use Riak with your favorite programming language
-  * Get some [[Sample Data]]
-  * [[Add more nodes|Basic Cluster Setup]] to your Riak cluster
-  * [[Learn about the high level concepts of Riak|Concepts]]
-  * [[Learn more about day-to-day system operations|Operators]]


### PR DESCRIPTION
I thought the following would help streamline our Installation page and content and perhaps make it a bit less confusing.
1. Added an introductory paragraph to the **Installation** page
2. Created a **Post Installation** page
3. Add the content from current **Installation** page to the new **Post Installation** page
4. Added links from OS-specific Installation pages to new **Post Installation** page
