### PR TITLE
changed from growl_notify to libnotify

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,5 +23,5 @@ group :development do
   gem "thin", "~>1.4.1"
   gem "watchr", "~>0.7"
   gem "rb-fsevent", "~>0.9.1"
-  gem "libnotify", "~>0.0.3"
+  gem "libnotify", "~>0.8.0"
 end


### PR DESCRIPTION
growl_notify was causing an error while installing rb-appscript (0.6.1) (OSX install).  Followed the suggestion in,
http://stackoverflow.com/questions/9660919/error-while-installing-rb-appscript-gem

to switch to libnotify.  I'm assuming here that we still want to pass the same argument to libnotify as growl_notify...
