### PR TITLE
riak-admin cluster commit not mentioned in "adding nodes" section.

### DIFF
--- a/source/languages/en/riak/cookbooks/Adding-and-Removing-Nodes.md
+++ b/source/languages/en/riak/cookbooks/Adding-and-Removing-Nodes.md
@@ -177,6 +177,8 @@ Transfers resulting from cluster changes: 51
   13 transfers from 'riak@192.168.2.2' to 'riak@192.168.2.6'
 ```
 
+If the plan is to your liking, submit the changes by typing `riak-admin cluster commit`.
+
 The Node Join Process
 ---------------------
 

--- a/source/languages/jp/riak/cookbooks/Adding-and-Removing-Nodes.md
+++ b/source/languages/jp/riak/cookbooks/Adding-and-Removing-Nodes.md
@@ -177,6 +177,8 @@ Transfers resulting from cluster changes: 51
   13 transfers from 'riak@192.168.2.2' to 'riak@192.168.2.6'
 ```
 
+If the plan is to your liking, submit the changes by typing `riak-admin cluster commit`.
+
 The Node Join Process
 ---------------------
 


### PR DESCRIPTION
The section in the docs about [adding nodes in 1.2.1](http://docs.basho.com/riak/1.2.1/cookbooks/Adding-and-Removing-Nodes/#Joining-Nodes-to-Form-a-Cluster) does not mention issuing a `cluster commit` command. Even if you read through ["The Node Join Process"](http://docs.basho.com/riak/1.2.1/cookbooks/Adding-and-Removing-Nodes/#The-Node-Join-Process) it does not mention commit. 

You must read to the "Removing Nodes" section before commit is mentioned, so if I was a new user I might not read that section and be really puzzled why my nodes aren't joining.
