### PR TITLE
Fixed inline call to `lsb_release` in command to add APT Basho repository

### DIFF
--- a/source/riak/tutorials/installation/Installing-on-Debian-and-Ubuntu.md
+++ b/source/riak/tutorials/installation/Installing-on-Debian-and-Ubuntu.md
@@ -29,7 +29,7 @@ curl http://apt.basho.com/gpg/basho.apt.key | sudo apt-key add -
 Then add the Basho repository to your apt sources list (and update them).
 
 ```
-sudo bash -c "echo deb http://apt.basho.com lsb_release -sc main > /etc/apt/sources.list.d/basho.list"
+sudo bash -c "echo deb http://apt.basho.com $(lsb_release -sc) main > /etc/apt/sources.list.d/basho.list"
 sudo apt-get update
 ```
 


### PR DESCRIPTION
Fixed inline call to `lsb_release` in command to add Basho repository to APT sources list:

``` bash
hector@eazy-e:~$ lsb_release -sc
precise
hector@eazy-e:~$ bash -c "echo deb http://apt.basho.com $(lsb_release -sc) main"
deb http://apt.basho.com precise main
```

Credit goes to `flazz` in IRC for identifying this issue.
