### PR TITLE
References to Storage-Backends are broken.

### DIFF
--- a/source/languages/en/riak/references/appendices/Backend-API.md
+++ b/source/languages/en/riak/references/appendices/Backend-API.md
@@ -9,7 +9,7 @@ keywords: [api, backends]
 
 As of the 1.0 release, Riak's storage API has been overhauled and
 uniformly applied to all of the
-[[supported backends|Storage-Backends]]. This page presents the
+[[supported backends|Choosing a Backend]]. This page presents the
 details of the storage backend API in the form of
 [Erlang type specifications](http://www.erlang.org/doc/reference_manual/typespec.html)
 (specs). Specs are used by

--- a/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-Cassandra.md
+++ b/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-Cassandra.md
@@ -44,7 +44,7 @@ The table below gives a high level comparison of Riak and Cassandra features/cap
         <td>Storage Model</td>
         <td>Riak has a modular, extensible local storage system which lets you plug-in a backend store of your choice to suit your use case. The default backend is Bitcask.  
 			<ul>
-			  <li>[[Riak Supported Storage Backends|Storage-Backends]]</li>
+			  <li>[[Riak Supported Storage Backends|Choosing a Backend]]</li>
 			</ul>
 		
 		You can also write you own storage backend for Riak using our [[backend API|Backend API]].			

--- a/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-CouchDB.md
+++ b/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-CouchDB.md
@@ -43,7 +43,7 @@ The table below gives a high level comparison of Riak and CouchDB features/capab
         <td>Storage Model</td>
         <td>Riak has a modular, extensible local storage system which lets you plug-in a backend store of your choice to suit your use case. The default backend is Bitcask.  
 			<ul>
-			  <li>[[Riak Supported Storage Backends|Storage-Backends]]</li>
+			  <li>[[Riak Supported Storage Backends|Choosing a Backend]]</li>
 			</ul>
 		
 		You can also write your own storage backend for Riak using our [[backend API|Backend API]].			

--- a/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-Couchbase.md
+++ b/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-Couchbase.md
@@ -47,7 +47,7 @@ The table below gives a high level comparison of Riak and Couchbase features/cap
         <td>Storage Model</td>
         <td>Riak has a modular, extensible local storage system which lets you plug-in a backend store of your choice to suit your use case. The default backend is Bitcask.  
 			<ul>
-			  <li>[[Riak Supported Storage Backends|Storage-Backends]]</li>
+			  <li>[[Riak Supported Storage Backends|Choosing a Backend]]</li>
 			</ul>
 		
 		You can also write your own storage backend for Riak using our [[backend API|Backend API]].			

--- a/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-HBase.md
+++ b/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-HBase.md
@@ -44,7 +44,7 @@ The table below gives a high level comparison of Riak and HBase features and cap
         <td>Storage Model</td>
         <td>Riak has a modular, extensible local storage system which features pluggable backend stores designed to fit a variety of use cases. The default Riak backend store is Bitcask.
 			<ul>
-			  <li>[[Riak Supported Storage Backends|Storage-Backends]]</li>
+			  <li>[[Riak Supported Storage Backends|Choosing a Backend]]</li>
 			</ul>
 		You can also write your own storage backend for Riak using our [[backend API|Backend API]].
 	 </td>

--- a/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-MongoDB.md
+++ b/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-MongoDB.md
@@ -45,7 +45,7 @@ The table below gives a high level comparison of Riak and MongoDB features/capab
         <td>Storage Model</td>
         <td>Riak has a modular, extensible local storage system which lets you plug-in a backend store of your choice to suit your use case. The default backend is Bitcask.  
 			<ul>
-			  <li>[[Riak Supported Storage Backends|Storage-Backends]]</li>
+			  <li>[[Riak Supported Storage Backends|Choosing a Backend]]</li>
 			</ul>
 		
 		You can also write your own storage backend for Riak using our [[backend API|Backend API]].			


### PR DESCRIPTION
Replaced instances of "Storage-Backends" with "Choosing a Backend."
