### PR TITLE
Adding missing "\" to curl command in fast-track link walking tutorial

### DIFF
--- a/source/languages/en/riak/tutorials/fast-track/Links-and-Link-Walking.md
+++ b/source/languages/en/riak/tutorials/fast-track/Links-and-Link-Walking.md
@@ -124,7 +124,7 @@ When you try this out yourself you'll notice that the output has gotten slightly
 As a final sugar sprinkle on top, we can make "dhh" friends with "davethomas" directly, so we have a real graph and not just a single path.
 
 ```
-$ curl -v -XPUT http://127.0.0.1:8091/riak/people/dhh
+$ curl -v -XPUT http://127.0.0.1:8091/riak/people/dhh \
   -H 'Link: </riak/people/davethomas>; riaktag="friend"' \
   -H "Content-Type: text/plain" \
   -d 'I drive a Zonda.'

--- a/source/languages/jp/riak/tutorials/fast-track/Links-and-Link-Walking.md
+++ b/source/languages/jp/riak/tutorials/fast-track/Links-and-Link-Walking.md
@@ -123,7 +123,7 @@ $ curl -v localhost:8091/riak/people/davethomas/_,friend,1/_,friend,_/
 いよいよ最後に、"davethomas" を直接 "dhh" の友人にします。これで本当の図が描かれましたが、このやり方は1つではありません。
 
 ```bash
-$ curl -v -XPUT http://127.0.0.1:8091/riak/people/dhh
+$ curl -v -XPUT http://127.0.0.1:8091/riak/people/dhh \
   -H 'Link: </riak/people/davethomas>; riaktag="friend"' \
   -H "content-type: text/plain" \
   -d 'I drive a Zonda.'


### PR DESCRIPTION
In the last `curl -XPUT` command where a link is added to the dhh object, the first line was missing its trailing `\`.  This fix makes copy-paste learning viable again :)
