### PR TITLE
Update Riak and Cassandra comparison

### DIFF
--- a/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-Cassandra.md
+++ b/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-Cassandra.md
@@ -8,7 +8,7 @@ index: true
 keywords: [comparisons, cassandra]
 ---
 
-This is intended to be a brief, objective and technical comparison of Riak and Cassandra.  The Cassandra version described is 1.1.x. The Riak version described is Riak 1.1.x. If you feel this comparison is unfaithful at all for whatever reason, please [fix it](https://github.com/basho/basho_docs/issues/new) or send an email to **docs@basho.com**.
+This is intended to be a brief, objective and technical comparison of Riak and Cassandra.  The Cassandra version described is 1.2.x. The Riak version described is Riak 1.2.x. If you feel this comparison is unfaithful at all for whatever reason, please [fix it](https://github.com/basho/basho_docs/issues/new) or send an email to **docs@basho.com**.
 
 
 ## At A Very High Level
@@ -187,7 +187,7 @@ The table below gives a high level comparison of Riak and Cassandra features/cap
     </tr>
     <tr>
         <td>Graphical Monitoring/Admin Console</td>
-        <td>Starting with Riak 1.1.x, Riak ships with Riak Control, an open source graphical console for monitoring and managing Riak clusters.
+        <td>Riak ships with Riak Control, an open source graphical console for monitoring and managing Riak clusters.
 			<ul>
 				<li>[[Riak Control]]</li>
 				<li>[[Introducing Riak Control|http://basho.com/blog/technical/2012/02/22/Riak-Control/]]

--- a/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-CouchDB.md
+++ b/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-CouchDB.md
@@ -8,7 +8,7 @@ index: true
 keywords: [comparisons, couchdb]
 ---
 
-This is intended to be a brief, objective and technical comparison of Riak and CouchDB.  The CouchDB version described is 1.2.x. The Riak version described is Riak 1.1.x. If you feel this comparison is unfaithful at all for whatever reason, please [fix it](https://github.com/basho/basho_docs/issues/new) or send an email to **docs@basho.com**.
+This is intended to be a brief, objective and technical comparison of Riak and CouchDB.  The CouchDB version described is 1.2.x. The Riak version described is Riak 1.2.x. If you feel this comparison is unfaithful at all for whatever reason, please [fix it](https://github.com/basho/basho_docs/issues/new) or send an email to **docs@basho.com**.
 
 ## At A Very High Level
 
@@ -189,7 +189,7 @@ The table below gives a high level comparison of Riak and CouchDB features/capab
     </tr>
     <tr>
         <td>Graphical Monitoring/Admin Console</td>
-        <td>Starting with Riak 1.1.x, Riak ships with Riak Control, an open source graphical console for monitoring and managing Riak clusters.
+        <td>Riak ships with Riak Control, an open source graphical console for monitoring and managing Riak clusters.
 			<ul>
 				<li>[[Riak Control]]</li>
 				<li>[[Introducing Riak Control|http://basho.com/blog/technical/2012/02/22/Riak-Control/]]

--- a/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-Couchbase.md
+++ b/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-Couchbase.md
@@ -8,7 +8,7 @@ index: true
 keywords: [comparisons, couchbase]
 ---
 
-This is intended to be a brief, objective and technical comparison of Riak and Couchbase (i.e. Couchbase Server).  The Couchbase version described is 2.0. The Riak version described is Riak 1.1.x. If you feel this comparison is unfaithful at all for whatever reason, please [fix it](https://github.com/basho/basho_docs/issues/new) or send an email to **docs@basho.com**.
+This is intended to be a brief, objective and technical comparison of Riak and Couchbase (i.e. Couchbase Server).  The Couchbase version described is 2.0. The Riak version described is Riak 1.2.x. If you feel this comparison is unfaithful at all for whatever reason, please [fix it](https://github.com/basho/basho_docs/issues/new) or send an email to **docs@basho.com**.
 
 ## At A Very High Level
 
@@ -196,7 +196,7 @@ The table below gives a high level comparison of Riak and Couchbase features/cap
     </tr>
     <tr>
         <td>Graphical Monitoring/Admin Console</td>
-        <td>Starting with Riak 1.1.x, Riak ships with Riak Control, an open source graphical console for monitoring and managing Riak clusters.
+        <td>Riak ships with Riak Control, an open source graphical console for monitoring and managing Riak clusters.
 			<ul>
 				<li>[[Riak Control]]</li>
 				<li>[[Introducing Riak Control|http://basho.com/blog/technical/2012/02/22/Riak-Control/]]

--- a/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-DynamoDB.md
+++ b/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-DynamoDB.md
@@ -167,7 +167,7 @@ The table below gives a high level comparison of Riak and DynamoDB features/capa
     </tr>
     <tr>
         <td>Graphical Monitoring/Admin Console</td>
-        <td>Starting with Riak 1.1.x, Riak ships with Riak Control, an open source graphical console for monitoring and managing Riak clusters.
+        <td>Riak ships with Riak Control, an open source graphical console for monitoring and managing Riak clusters.
 			<ul>
 				<li>[[Riak Control]]</li>
 				<li>[[Introducing Riak Control|http://basho.com/blog/technical/2012/02/22/Riak-Control/]]

--- a/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-HBase.md
+++ b/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-HBase.md
@@ -8,7 +8,7 @@ index: true
 keywords: [comparisons, hbase]
 ---
 
-This is intended to be a brief, objective and technical comparison of Riak and HBase. The HBase version described is 0.94.x. The Riak version described is Riak 1.1.x. If you feel this comparison is unfaithful at all for whatever reason, please [fix it](https://github.com/basho/basho_docs/issues/new) or send an email to **docs@basho.com**.
+This is intended to be a brief, objective and technical comparison of Riak and HBase. The HBase version described is 0.94.x. The Riak version described is Riak 1.2.x. If you feel this comparison is unfaithful at all for whatever reason, please [fix it](https://github.com/basho/basho_docs/issues/new) or send an email to **docs@basho.com**.
 
 ## At A Very High Level
 
@@ -175,7 +175,7 @@ The table below gives a high level comparison of Riak and HBase features and cap
     </tr>
     <tr>
         <td>Graphical Monitoring/Admin Console</td>
-        <td>Starting with Riak 1.1.x, Riak ships with Riak Control, an open source graphical console for monitoring and managing Riak clusters.
+        <td>Riak ships with Riak Control, an open source graphical console for monitoring and managing Riak clusters.
 			<ul>
 				<li>[[Riak Control]]</li>
 				<li>[[Introducing Riak Control|http://basho.com/blog/technical/2012/02/22/Riak-Control/]]

--- a/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-MongoDB.md
+++ b/source/languages/en/riak/references/appendices/comparisons/Riak-Compared-to-MongoDB.md
@@ -8,7 +8,7 @@ index: true
 keywords: [comparisons, mongodb]
 ---
 
-This is intended to be a brief, objective and technical comparison of Riak and MongoDB.  The MongoDB version described is 2.2.x. The Riak version described is Riak 1.1.x. If you feel this comparison is unfaithful at all for whatever reason, please [fix it](https://github.com/basho/basho_docs/issues/new) or send an email to **docs@basho.com**.
+This is intended to be a brief, objective and technical comparison of Riak and MongoDB.  The MongoDB version described is 2.2.x. The Riak version described is Riak 1.2.x. If you feel this comparison is unfaithful at all for whatever reason, please [fix it](https://github.com/basho/basho_docs/issues/new) or send an email to **docs@basho.com**.
 
 ## At A Very High Level
 
@@ -197,7 +197,7 @@ The table below gives a high level comparison of Riak and MongoDB features/capab
     </tr>
     <tr>
         <td>Graphical Monitoring/Admin Console</td>
-        <td>Starting with Riak 1.1.x, Riak ships with Riak Control, an open source graphical console for monitoring and managing Riak clusters.
+        <td>Riak ships with Riak Control, an open source graphical console for monitoring and managing Riak clusters.
 			<ul>
 				<li>[[Riak Control]]</li>
 				<li>[[Introducing Riak Control|http://basho.com/blog/technical/2012/02/22/Riak-Control/]]


### PR DESCRIPTION
Riak and Cassandra are both out of date in [this](http://docs.basho.com/riak/1.2.1/references/appendices/comparisons/Riak-Compared-to-Cassandra/) comparison.
