### PR TITLE
Update source/languages/en/riak/cookbooks/Linux-Performance-Tuning.md

### DIFF
--- a/source/languages/en/riak/cookbooks/Linux-Performance-Tuning.md
+++ b/source/languages/en/riak/cookbooks/Linux-Performance-Tuning.md
@@ -35,7 +35,7 @@ to run as a production database server.
 
 Riak and the tools can consume a large number of open file handles during
 normal operation.  For stability, increasing the number of open-files limit
-is necessary.  See [[Open Files Limit|Open-Files-Limit]] for the details.
+is necessary.  See [[Open Files Limit]] for the details.
 
 ### Kernel and Network Tuning
 


### PR DESCRIPTION
- Added an h3 section called "Open Files Limit" right after the h2
  section "Linux Tuning", describing the need of increasing the
  open-files limit.

Explanation: the open-files limit issue should be a part of the tuning description,
because the limit increase is required for operating Riak instances properly,
as well as running the tools such as riak_bench. 
