### PR TITLE
Added instructions for installing 1.3.0 on closed networks

### DIFF
--- a/source/languages/en/riak/tutorials/installation/Installing-Riak-from-Source.md
+++ b/source/languages/en/riak/tutorials/installation/Installing-Riak-from-Source.md
@@ -48,6 +48,16 @@ make rel
 ```
 
 {{/1.2.1}}
+{{#1.3.0}}
+
+```bash
+curl -O http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.3/1.3.0/riak-1.3.0.tar.gz
+tar zxvf riak-1.3.0.tar.gz
+cd riak-1.3.0
+make rel
+```
+
+{{/1.3.0}}
 
 <div class='note'> If you see the error `fatal: unable to connect to github.com` see the following instructions for building on systems with no internet availability </div>
 
@@ -56,9 +66,12 @@ The error `fatal: unable to connect to github.com` when building from source is 
 
 Download the following `leveldb` archive for the version of Riak you are using:
 
+  * **1.3.0**: `https://github.com/basho/leveldb/zipball/1.3.0`
   * **1.2.1**: `https://github.com/basho/leveldb/zipball/1.2.2p5`
   * **1.2.0**: `https://github.com/basho/leveldb/zipball/2aebdd9173a7840f9307e30146ac95f49fbe8e64`
   * **1.1.4**: `https://github.com/basho/leveldb/zipball/14478f170bbe3d13bc0119d41b70e112b3925453`
+
+{{#1.1.4-1.2.1}}
 
 The instructions going forward will assume Riak 1.2.0, replace the appropriate file for your version.
 
@@ -72,6 +85,28 @@ $ mv basho-leveldb-* leveldb
 $ cd ../../../
 $ make rel
 ```
+
+{{/1.1.4-1.2.1}}
+{{#1.3.0}}
+
+The instructions going forward will assume Riak 1.3.0, replace the appropriate file for your version.
+
+Deploy the file to the system with the build error and run the following commands.
+
+```bash
+$ mv 1.3.0 riak-1.3.0/deps/eleveldb/c_src/leveldb.zip
+$ cd riak-1.3.0/deps/eleveldb/c_src/
+$ unzip leveldb.zip
+$ mv basho-leveldb-* leveldb
+$ cd ../../
+$ cp -R lager riaknostic/deps
+$ cp -R getopt riaknostic/deps
+$ cp -R meck riaknostic/deps
+$ cd ../
+$ make rel
+```
+
+{{/1.3.0}}
 
 ### Installing from GitHub
 The [[Riak Github repository|http://github.com/basho/riak]] has much more information on building and installing Riak from source. To clone and and build Riak from source, follow these steps:


### PR DESCRIPTION
An attempt to resolve #215. Can you take them for a spin, @campariorange?

I went through the steps on my Mac with the internet connection disabled. Unsure if the version blocks to separate instructions for `1.1.4-1.2.1` and `1.3.0` work because `middleman` doesn't seem to be respecting them.
