### PR TITLE
Simplify secondary link generation

### DIFF
--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -28,7 +28,9 @@ module BashoDocsHelpers
     for keyword in keywords
       pages += $keyword_pages[keyword] || []
     end
-    pages.delete_if{|g| g.url == page.url }.to_a
+    project = (page.metadata[:page] || {})['project'] || $default_project
+    page_url = "/languages/#{I18n.locale.to_s}/#{project}#{page.url.sub(/\/$/, '.html')}"
+    pages.delete_if{|g| page_url == g.url }.to_a
   end
 
   def current_version(default_proj)

--- a/source/keywords.slim
+++ b/source/keywords.slim
@@ -1,10 +1,6 @@
 h1 Keyword: #{@keyword}
-
 ul.keywords
   - projects = (@pages || []).group_by {|page| page.metadata[:page]["project"]}
   - for project, pages in projects
     - for page in pages
-      - meta = page.metadata[:page]
-      - classname = project == $default_project ? '' : 'versioned'
-      li(class==project)
-        ==link_to meta["title"], project_version_path(page), :class => classname
+      li== "[[#{page.metadata[:page]['title']}]]"


### PR DESCRIPTION
The bottom "These May Also Interest You" links were posting duplicate links, as well as suggesting the current page to be of interest. The keywords page was hard-coding links, and I also just replaced that to just use wiki-style links.
