### PR TITLE
Replace s3://test_bucket by s3://test-bucket in Riak CS docs

### DIFF
--- a/source/languages/en/riakcs/tutorials/fast-track/Testing-the-Installation.md
+++ b/source/languages/en/riakcs/tutorials/fast-track/Testing-the-Installation.md
@@ -48,7 +48,7 @@ You should have copied your Access Key and Secret Key from the prior installatio
 
 Once `s3cmd` is configured, we can use it to create a test bucket:
 
-    s3cmd -c ~/.s3cfgfasttrack mb s3://test_bucket
+    s3cmd -c ~/.s3cfgfasttrack mb s3://test-bucket
 
 We can see if it was created by typing:
 
@@ -57,15 +57,15 @@ We can see if it was created by typing:
 We can now upload a test file to that bucket:
 
     dd if=/dev/zero of=test_file bs=1m count=2 # Create a test file
-    s3cmd -c ~/.s3cfgfasttrack put test_file s3://test_bucket
+    s3cmd -c ~/.s3cfgfasttrack put test_file s3://test-bucket
 
 We can see if it was uploaded by typing:
 
-    s3cmd -c ~/.s3cfgfasttrack ls s3://test_bucket
+    s3cmd -c ~/.s3cfgfasttrack ls s3://test-bucket
 
 We can now download the test file:
 
     rm test_file # remove the local test file
-    s3cmd -c ~/.s3cfgfasttrack get s3://test_bucket/test_file
+    s3cmd -c ~/.s3cfgfasttrack get s3://test-bucket/test_file
 
 

--- a/source/languages/en/riakcs/tutorials/quick-start-riak-cs/index.md
+++ b/source/languages/en/riakcs/tutorials/quick-start-riak-cs/index.md
@@ -312,7 +312,7 @@ There are 4 default settings you should change:
 
 Once `s3cmd` is configured, we can use it to create a test bucket:
 
-    s3cmd mb s3://test_bucket
+    s3cmd mb s3://test-bucket
 
 We can see if it was created by typing:
 
@@ -321,16 +321,16 @@ We can see if it was created by typing:
 We can now upload a test file to that bucket:
 
     dd if=/dev/zero of=test_file bs=1M count=2 # Create a test file
-    s3cmd put test_file s3://test_bucket
+    s3cmd put test_file s3://test-bucket
 
 We can see if it was uploaded by typing:
 
-    s3cmd ls s3://test_bucket
+    s3cmd ls s3://test-bucket
 
 We can now download the test file:
 
     rm test_file # remove the local test file
-    s3cmd get s3://test_bucket/test_file
+    s3cmd get s3://test-bucket/test_file
 
 
 ## Installing Additional Nodes

--- a/source/languages/jp/riakcs/tutorials/quick-start-riak-cs/index.md
+++ b/source/languages/jp/riakcs/tutorials/quick-start-riak-cs/index.md
@@ -306,7 +306,7 @@ curl -H 'Content-Type: application/json' \
 
 `s3cmd` が設定されたら、テスト用のバケットを作成できるようになります:
 
-    s3cmd mb s3://test_bucket
+    s3cmd mb s3://test-bucket
 
 作成できたかどうかは、次のようにタイプします:
 
@@ -315,16 +315,16 @@ curl -H 'Content-Type: application/json' \
 これでテストファイルをバケットにアップロードできます:
 
     dd if=/dev/zero of=test_file bs=1M count=2 # Create a test file
-    s3cmd put test_file s3://test_bucket
+    s3cmd put test_file s3://test-bucket
 
 アップロードできたかどうかは、次のようにタイプします:
 
-    s3cmd ls s3://test_bucket
+    s3cmd ls s3://test-bucket
 
 テストファイルをダウンロードします:
 
     rm test_file # remove the local test file
-    s3cmd get s3://test_bucket/test_file
+    s3cmd get s3://test-bucket/test_file
 
 
 ## 追加のノードをインストールする


### PR DESCRIPTION
"test_bucket" doesn't seem to be a valid bucket name for Riak CS. s3cmd
throws the following error message:

```
% s3cmd mb s3://test_bucket 
ERROR: S3 error: 400 (InvalidBucketName): The specified bucket is not valid.
```

A run with the "--debug" option is a bit more explicit:

```
% s3cmd --debug mb s3://test_bucket  
DEBUG: ConfigParser: Reading file '/Users/jbbarth/.s3cfg'
DEBUG: ConfigParser: access_key->X2...17_chars...C
DEBUG: ConfigParser: bucket_location->US
DEBUG: ConfigParser: default_mime_type->binary/octet-stream
DEBUG: ConfigParser: delete_removed->False
DEBUG: ConfigParser: dry_run->False
DEBUG: ConfigParser: encoding->UTF-8
DEBUG: ConfigParser: encrypt->False
DEBUG: ConfigParser: follow_symlinks->False
DEBUG: ConfigParser: force->False
DEBUG: ConfigParser: get_continue->False
DEBUG: ConfigParser: gpg_command->None
DEBUG: ConfigParser: gpg_decrypt->%(gpg_command)s -d --verbose --no-use-agent --batch --yes --passphrase-fd %(passphrase_fd)s -o %(output_file)s %(input_file)s
DEBUG: ConfigParser: gpg_encrypt->%(gpg_command)s -c --verbose --no-use-agent --batch --yes --passphrase-fd %(passphrase_fd)s -o %(output_file)s %(input_file)s
DEBUG: ConfigParser: gpg_passphrase->...-3_chars...
DEBUG: ConfigParser: guess_mime_type->True
DEBUG: ConfigParser: human_readable_sizes->False
DEBUG: ConfigParser: list_md5->False
DEBUG: ConfigParser: log_target_prefix->
DEBUG: ConfigParser: preserve_attrs->True
DEBUG: ConfigParser: progress_meter->True
DEBUG: ConfigParser: proxy_host->localhost
DEBUG: ConfigParser: proxy_port->8080
DEBUG: ConfigParser: recursive->False
DEBUG: ConfigParser: recv_chunk->4096
DEBUG: ConfigParser: reduced_redundancy->False
DEBUG: ConfigParser: secret_key->lY...37_chars...=
DEBUG: ConfigParser: send_chunk->4096
DEBUG: ConfigParser: skip_existing->False
DEBUG: ConfigParser: socket_timeout->300
DEBUG: ConfigParser: urlencoding_mode->normal
DEBUG: ConfigParser: use_https->False
DEBUG: ConfigParser: verbosity->WARNING
DEBUG: Updating Config.Config cache_file -> 
DEBUG: Updating Config.Config encoding -> UTF-8
DEBUG: Updating Config.Config follow_symlinks -> False
DEBUG: Updating Config.Config verbosity -> 10
DEBUG: Unicodising 'mb' using UTF-8
DEBUG: Unicodising 's3://test_bucket' using UTF-8
DEBUG: Command: mb
DEBUG: SignHeaders: 'PUT\n\n\n\nx-amz-date:Thu, 21 Mar 2013 06:18:45 +0000\n/test_bucket/'
DEBUG: CreateRequest: resource[uri]=/
DEBUG: SignHeaders: 'PUT\n\n\n\nx-amz-date:Thu, 21 Mar 2013 06:18:45 +0000\n/test_bucket/'
DEBUG: Processing request, please wait...
DEBUG: Establishing connection
DEBUG: Unicodising "Bucket name 'test_bucket' contains disallowed character '_'. The only supported ones are: lowercase us-ascii letters (a-z), digits (0-9), dot (.) and hyphen (-)." using UTF-8
DEBUG: Unicodising "Bucket name 'test_bucket' contains disallowed character '_'. The only supported ones are: lowercase us-ascii letters (a-z), digits (0-9), dot (.) and hyphen (-)." using UTF-8
DEBUG: get_hostname(test_bucket): s3.amazonaws.com
DEBUG: format_uri(): http://s3.amazonaws.com/test_bucket/
DEBUG: Sending request method_string='PUT', uri='http://s3.amazonaws.com/test_bucket/', headers={'content-length': '0', 'Authorization': 'AWS X2GOEX5TVL8FAYMQIIYC:jmA1DtnClhesvzCLy9/34ztDfp8=', 'x-amz-date': 'Thu, 21 Mar 2013 06:18:45 +0000'}, body=(0 bytes)
DEBUG: Response: {'status': 400, 'headers': {'date': 'Thu, 21 Mar 2013 06:16:55 GMT', 'content-length': '192', 'content-type': 'application/xml', 'server': 'Riak CS'}, 'reason': 'Bad Request', 'data': '<?xml version="1.0" encoding="UTF-8"?><Error><Code>InvalidBucketName</Code><Message>The specified bucket is not valid.</Message><Resource>/test_bucket</Resource><RequestId></RequestId></Error>'}
DEBUG: S3Error: 400 (Bad Request)
DEBUG: HttpHeader: date: Thu, 21 Mar 2013 06:16:55 GMT
DEBUG: HttpHeader: content-length: 192
DEBUG: HttpHeader: content-type: application/xml
DEBUG: HttpHeader: server: Riak CS
DEBUG: ErrorXML: Code: 'InvalidBucketName'
DEBUG: ErrorXML: Message: 'The specified bucket is not valid.'
DEBUG: ErrorXML: Resource: '/test_bucket'
DEBUG: ErrorXML: RequestId: None
```

Maybe there's an option to fix this at Riak CS level, I got this messages trying to follow the Riak CS fast track, so I don't think I did anything particularly wrong but tell me if this is the case.

Thanks
