### PR TITLE
Add 2 more settings that should be changed in ~/.s3cfg to match Riak CS' app.config

### DIFF
--- a/source/languages/en/riakcs/tutorials/fast-track/Testing-the-Installation.md
+++ b/source/languages/en/riakcs/tutorials/fast-track/Testing-the-Installation.md
@@ -35,12 +35,17 @@ We need to configure `s3cmd` to use our Riak CS server rather than S3 as well as
 
 If you are alread using s3cmd on your local machine the `-c` switch allows you to specify a .s3cfg file without overwriting anything you may have presently configured
 
-There are 4 default settings you should change:
+There are 4 default settings you should change interactively:
 
 * Access Key - use the Riak CS user access key you generated above.
 * Secret Key - use the Riak CS user secret key you generated above.
 * Proxy Server - use your Riak CS IP. If you followed the Virtual environment configuration, use `localhost`
 * Proxy Port - the default Riak CS port is 8080
+
+There are 2 more settings you should edit manually in the generated config file:
+
+* host_base - use your Riak CS hostname. If you followed the Virtual environment configuration, use `riakcs.dev`
+* host_bucket - adapt it based on your Riak CS hostname. If you followed the Virtual environment configuration, use `%(bucket)s.riakcs.dev`
 
 You should have copied your Access Key and Secret Key from the prior installation steps.
 
@@ -49,6 +54,12 @@ You should have copied your Access Key and Secret Key from the prior installatio
 Once `s3cmd` is configured, we can use it to create a test bucket:
 
     s3cmd -c ~/.s3cfgfasttrack mb s3://test-bucket
+
+You should see the following response:
+
+    Bucket 's3://test-bucket/' created
+
+If you see a "405 (Method Not Allowed)" error message, you probably need to check your "host_base" and "host_bucket" settings in `~/.s3cfgfasttrack`.
 
 We can see if it was created by typing:
 

--- a/source/languages/en/riakcs/tutorials/quick-start-riak-cs/index.md
+++ b/source/languages/en/riakcs/tutorials/quick-start-riak-cs/index.md
@@ -303,16 +303,27 @@ We need to configure `s3cmd` to use our Riak CS server rather than S3 as well as
 
     s3cmd --configure
 
-There are 4 default settings you should change:
+There are 4 default settings you should change interactively:
 
 * Access Key - use the Riak CS user access key you generated above.
 * Secret Key - use the Riak CS user secret key you generated above.
 * Proxy Server - use your Riak CS IP. Example: 10.0.2.10
 * Proxy Port - the default Riak CS port is 8080
 
+There are 2 more settings you should edit manually in the generated config file:
+
+* host_base - use your Riak CS hostname, configured as `cs_root_host` in Riak CS app.config. Example: `riakcs.dev`
+* host_bucket - adapt it based on your Riak CS hostname, configured as `cs_root_host` in Riak CS app.config. Example: `%(bucket)s.riakcs.dev`
+
 Once `s3cmd` is configured, we can use it to create a test bucket:
 
     s3cmd mb s3://test-bucket
+
+You should see the following response:
+
+    Bucket 's3://test-bucket/' created
+
+If you see a "405 (Method Not Allowed)" error message, you probably need to check your "host_base" and "host_bucket" settings in `~/.s3cfg`.
 
 We can see if it was created by typing:
 


### PR DESCRIPTION
See discussion here if needed: http://lists.basho.com/pipermail/riak-users_lists.basho.com/2013-March/011514.html

It appears the Riak CS Fast Track misses one step which is configuring the `host_base` and `host_bucket` parameters in `~/.s3cfg` config file. They default to Amazon S3 values, resulting in an error when you try to run certain operations on Riak CS (at least creating a new bucket with "s3cmd mb").

I tried to keep the wording coherent with the rest of the doc but feel free to improve it.

**NB** : I don't speak Japanese at all so I didn't update `source/languages/jp/riakcs/tutorials/quick-start-riak-cs/index.md`, which might be required before merging this pull request.

Thanks
