### PR TITLE
To format consistently, to end tutorials coherently.

### DIFF
--- a/source/languages/en/riakcs/tutorials/fast-track/Testing-the-Installation.md
+++ b/source/languages/en/riakcs/tutorials/fast-track/Testing-the-Installation.md
@@ -17,7 +17,7 @@ up:   "[[The Riak CS Fast Track]]"
 The simplest way to test the installation is using the `s3cmd` script. We can install it on Ubuntu by typing:
 
 ``` bash
-$ sudo apt-get -y install s3cmd
+sudo apt-get -y install s3cmd
 ````
 
 For our OS X users, either use the package manager of your preference, or download the S3 cmd package at [[http://s3tools.org/download]].  You will need to extra the tar, change directories into the folder, and build the package.  The process should look something like:
@@ -34,7 +34,7 @@ You will be prompted to enter your system password.  Do so, and wait for the ins
 We need to configure `s3cmd` to use our Riak CS server rather than S3 as well as our user keys. To do that interactively, type:
 
 ``` bash
-$ s3cmd -c ~/.s3cfgfasttrack --configure
+s3cmd -c ~/.s3cfgfasttrack --configure
 ````
 
 If you are alread using s3cmd on your local machine the `-c` switch allows you to specify a .s3cfg file without overwriting anything you may have presently configured
@@ -71,7 +71,8 @@ $ s3cmd -c ~/.s3cfgfasttrack put test_file s3://test-bucket
 
 We can see if it was uploaded by typing:
 
-$ s3cmd -c ~/.s3cfgfasttrack ls s3://test-bucket
+``` bash
+s3cmd -c ~/.s3cfgfasttrack ls s3://test-bucket
 ```
 
 We can now download the test file:
@@ -83,7 +84,7 @@ $ ls -lah test_file #verify that the download was succesful
 ````
 
 ## What's Next
-If you have made it this far...congratulations! You now have a working Riak CS test instance (either virtual or local).  There is still a fair bit of learning to be done and the entire References section is useful, a few items that may be of particular interest are:
+If you have made it this far... congratulations! You now have a working Riak CS test instance (either virtual or local).  There is still a fair bit of learning to be done and the entire References section is useful, a few items that may be of particular interest are:
 
 * [[Details about API operations|Storage]]
 * [[Information about the Ruby Fog client|Fog]]


### PR DESCRIPTION
Fenced code blocks are pretty...especially when commands are multi-line or multi-step.

Also, when ending a tutorial simply trailing off into the distance...without a coherent conclusion...is
