### PR TITLE
Fixed missing path in URL to create a Riak CS user

### DIFF
--- a/source/languages/en/riakcs/cookbooks/configuration/Configuring-Riak-CS.md
+++ b/source/languages/en/riakcs/cookbooks/configuration/Configuring-Riak-CS.md
@@ -20,7 +20,7 @@ To create an account for the admin user, use an HTTP POST with the username you 
 
 ```
 curl -H 'Content-Type: application/json' \
-  -X POST http://localhost:8080/user \
+  -X POST http://localhost:8080/riak-cs/user \
   --data '{"email":"foobar@example.com", "name":"admin user"}'
 ```
 


### PR DESCRIPTION
Brought to our attention by Toby Corkindale on the mailing list.
