### PR TITLE
Mac x86_64 download for Riak CS Control is missing from downloads page

### DIFF
--- a/data/downloads_gen.yml
+++ b/data/downloads_gen.yml
@@ -1786,10 +1786,17 @@ riak-cs-control:
             i386:
               file: riak-cs-control-1.0.0-OSX-i386.tar.gz
               static_file: http://s3.amazonaws.com/downloads.basho.com/riak-cs-control/1.0/1.0.0/osx/10.6/riak-cs-control-1.0.0-OSX-i386.tar.gz
-              file_size: 23214683
+              file_size: 23584728
               csum: riak-cs-control-1.0.0-OSX-i386.tar.gz.sha
               static_csum: http://s3.amazonaws.com/downloads.basho.com/riak-cs-control/1.0/1.0.0/osx/10.6/riak-cs-control-1.0.0-OSX-i386.tar.gz.sha
               csum_size: 104
+            x86_64:
+              file: riak-cs-control-1.0.0-OSX-x86_64.tar.gz
+              static_file: http://s3.amazonaws.com/downloads.basho.com/riak-cs-control/1.0/1.0.0/osx/10.6/riak-cs-control-1.0.0-OSX-x86_64.tar.gz
+              file_size: 23214508
+              csum: riak-cs-control-1.0.0-OSX-x86_64.tar.gz.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/riak-cs-control/1.0/1.0.0/osx/10.6/riak-cs-control-1.0.0-OSX-x86_64.tar.gz.sha
+              csum_size: 106
     rhel:
       versions:
         '5':

--- a/lib/downloads.rb
+++ b/lib/downloads.rb
@@ -50,7 +50,7 @@ class Downloads
 
   def self.pull_data(project, version)
     # don't pull for older versions, since they have a weird format
-    return if version.sub(/\.\w+$/, '').to_f <= 1.1
+    return if project != 'riak-cs-control' && version.sub(/\.\w+$/, '').to_f <= 1.1
     downloads_gen = YAML::load(File.open('data/downloads_gen.yml'))
     version_data = load_from_s3(project, version)
     (downloads_gen[project] ||= {})[version] = version_data


### PR DESCRIPTION
Only the 32bit version appears to exist: http://docs.basho.com/riakcs/latest/riakcs-downloads/#Riak-CS-Control-1-0-0
