### PR TITLE
Display version differences in dev mode

### DIFF
--- a/lib/downloads.rb
+++ b/lib/downloads.rb
@@ -59,10 +59,12 @@ class Downloads
 
   def self.data(project, version)
     @data ||= {}
-    return @data[project] if @data.include?(project)
+    if @data.include?(project) && @data[project].include?(version)
+      return @data[project][version]
+    end
     default_data = YAML::load(File.open('data/downloads_defaults.yml'))['default']['default']
     version_data = YAML::load(File.open('data/downloads_gen.yml'))[project][version]
-    @data[project] = rmerge(default_data, version_data)
+    (@data[project]||={})[version] = rmerge(default_data, version_data)
   end
 
   def self.load_from_s3(project, version)

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -34,7 +34,7 @@ module BashoDocsHelpers
   end
 
   def current_version(default_proj)
-    $versions[(data.page.project || default_proj).to_sym] || ENV['RIAK_VERSION']
+    SitemapRenderOverride.current_version || $versions[(data.page.project || default_proj).to_sym] || ENV['RIAK_VERSION']
   end
 
   def project_version_path(pa)

--- a/lib/setup.rb
+++ b/lib/setup.rb
@@ -9,8 +9,9 @@ $versions = {}
 version_file = YAML::load(File.open('data/versions.yml'))
 for proj, vs in version_file['currents']
   proj = proj.upcase
-  $versions[proj.downcase.to_sym] = vs
+  vs = ENV["#{proj}_VERSION"] if ENV["#{proj}_VERSION"].present?
   ENV["#{proj}_VERSION"] = vs if ENV["#{proj}_VERSION"].blank? 
+  $versions[proj.downcase.to_sym] = vs
   puts "#{proj}_VERSION=#{ENV["#{proj}_VERSION"]}"
 end
 

--- a/lib/sitemap_render_override.rb
+++ b/lib/sitemap_render_override.rb
@@ -4,6 +4,16 @@ require 'cgi'
 
 module SitemapRenderOverride
 
+  @@_current_version = nil
+  
+  def self.current_version=(v)
+    @@_current_version = v
+  end
+
+  def self.current_version
+    @@_current_version
+  end
+
   def sitemap_pages
     return $sitemap_pages if $sitemap_pages
     $sitemap_pages = {}
@@ -109,7 +119,10 @@ module SitemapRenderOverride
 
   def strip_versions!(data)
     project = (metadata[:page]["project"] || $default_project).to_sym
-    if version_str = $versions[project]
+    
+    version_str = SitemapRenderOverride.current_version || $versions[project]
+
+    if version_str
       # Ignore rcX if this is a pre-release
       version_str = version_str.sub(/rc\d+/i, '')
       version = Versionomy.parse(version_str)

--- a/lib/versionify.rb
+++ b/lib/versionify.rb
@@ -21,7 +21,10 @@ module Rack::Middleman
     def alter_route(env, var)
       unless env[var] =~ %r"\/((?:#{projects_regex}|shared)\/[^\/]+)\/?(index\.html)?$"
         if env.include?(var)
-          env[var] = env[var].sub(%r"\/(?:#{projects_regex}|shared)\/(?:[\d\.rc]+|latest)", '')
+          env[var] = env[var].sub(%r"\/(?:#{projects_regex}|shared)\/([\d\.rc]+|latest)", '')
+          # set as current page version
+          version = $1 == 'latest' ? nil : $1
+          SitemapRenderOverride.current_version = version
         end
       else
         env[var] = "/#{$1}/index.html"


### PR DESCRIPTION
Currently, choosing a version in the drop-down won't show that version, but instead always displays the current most recent version.
