### PR TITLE
Title update of page on Fog and Riak CS broke navigation link

### DIFF
--- a/source/languages/en/global_nav.yml
+++ b/source/languages/en/global_nav.yml
@@ -280,7 +280,7 @@ riakcs:
       - "[[Querying Access Statistics]]"
       - "[[Querying Storage Statistics]]"
       - "[[Usage and Billing Data]]"
-      - "[[Ruby Fog|Fog on RiakCS]]"
+      - "[[Ruby Fog|Fog on Riak CS]]"
       - "[[APIs|RiakCS Storage API]]"
       - "[[FAQs|Riak CS FAQs]]"
       - "[[Release Notes|Riak CS Release Notes]]"


### PR DESCRIPTION
Changing the page title so that it read "Riak CS" instead of "RiakCS" caused the left-hand navigation to break.

See: https://github.com/basho/basho_docs/pull/316
