### PR TITLE
Update Gemfile reference to RubyGems so that it uses HTTPS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 gem "middleman", "=3.0.6"
 gem "middleman-smusher"


### PR DESCRIPTION
Brought up by @seancribbs during the `basho_docs` education Mumble today.
