### PR TITLE
Old bug reference in Recovering a Failed Node

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     activesupport (3.2.11)
       i18n (~> 0.6)

--- a/source/languages/en/riak/cookbooks/Recovering-a-Failed-Node.md
+++ b/source/languages/en/riak/cookbooks/Recovering-a-Failed-Node.md
@@ -9,12 +9,8 @@ keywords: [troubleshooting]
 ---
 
 Restarting a node after a failure may result in a slower than normal
-startup time. The longer startup time associated with
-recovery may lead to other problems;
-[[bug #134|https://issues.basho.com/show_bug.cgi?id=134]], for
-example, describes an issue where Riak may begin sending requests
-(get, put, delete) to nodes before they are ready to accept
-requests. To avoid problems when recovering a failed node the
+startup time. The longer startup time associated with recovery may also lead
+to other problems. To avoid problems when recovering a failed node the
 following technique should be followed.
 
 ## General Recovery Notes


### PR DESCRIPTION
[Recovering a Failed Node](http://docs.basho.com/riak/latest/cookbooks/Recovering-a-Failed-Node/) documentation references ancient closed bug in introductory paragraph.

This should be removed.
