### PR TITLE
Revisit max object size recommendation in Riak

### DIFF
--- a/source/languages/en/riak/cookbooks/Secondary-Indexes---Configuration.md
+++ b/source/languages/en/riak/cookbooks/Secondary-Indexes---Configuration.md
@@ -53,7 +53,7 @@ When using the HTTP interface, multi-valued indexes are specified by separating 
 
 ### Index Sizes
 
-The indexes on an object contribute to the overall size of an object. The number of indexes on an object is limited only by the maximum recommended Riak object size (~4-6MB). Basho has stress tested objects with 1000 index entries, but expect that most applications will use significantly fewer.
+The indexes on an object contribute to the overall size of an object. The number of indexes on an object is limited only by the maximum recommended Riak object size (not larger than 10MB). Basho has stress tested objects with 1000 index entries, but expect that most applications will use significantly fewer.
 
 The size of an individual index is also limited only by resources, but note that some HTTP proxies impose size limits on HTTP headers. Since indexes are encoded as HTTP headers when using the HTTP interface, this may affect the maximum index value size.
 

--- a/source/languages/en/riak/cookbooks/faqs/developing-faq.html.fml
+++ b/source/languages/en/riak/cookbooks/faqs/developing-faq.html.fml
@@ -177,8 +177,12 @@ A:
 
 Q: Is there a limit on the file size that can be stored on Riak?
 A:
-  There isn't a limit on object size, but we suggest you keep it below 50MB for performance reasons.  Other factors may limit the size of your upload as well.
-
+  There isn't a limit on object size, but we suggest you keep it below 10MB
+  for performance reasons. Variables such as network speed can directly
+  affect the maximum usable object size for a given cluster. You should use
+  a tool like [[Basho Bench]] to determine the performance of your cluster
+  with a given object size before moving to production use.
+  
 Q: Does the bucket name impact key storage size?
 A:
   The storage per key is 40 bytes plus the key size AND bucket name size.


### PR DESCRIPTION
On the FAQ [we advise](http://docs.basho.com/riak/latest/cookbooks/faqs/developing-faq/#is-there-a-limit-on-the-file-size-that-can-be-stor) to not store anything larger than 50MB. 

We contradict ourselves on the [2i config page](http://docs.basho.com/riak/latest/cookbooks/Secondary-Indexes---Configuration) and recommend 4-6MB. 

We need to get our story straight. :) 
