### PR TITLE
add Riak Search related error

### DIFF
--- a/source/languages/en/riak/references/Errors.md
+++ b/source/languages/en/riak/references/Errors.md
@@ -264,6 +264,8 @@ exit with reason bad return value: {error,eaddrinuse} in context start_error | A
 exited with reason: eaddrnotavail in gen_server:init_it/6 line 320 | An error like this example can result when Riak cannot bind to the addresses specified in the configuration. In this case, you should verify HTTP and Protocol Buffers addresses in `app.config` and ensure that the ports being used are not in the privileged (1-1024) range as the `riak` user will not have access to such ports.
 gen_server riak_core_capability terminated with reason: no function clause matching orddict:fetch('riak@192.168.2.2', []) line 72 | Error output like this example can indicate that a previously running Riak node with an original `-name` value in `vm.args` has been modified by simply changing the value in `vm.args` and not properly through `riak-admin cluster replace`.
 ** Configuration error: [FRAMEWORK-MIB]: missing context.conf file => generating a default file | This error is commonly encountered when starting Riak Enterprise without prior SNMP configuration.
+RPC to 'node@example.com' failed: {'EXIT', {badarg, [{ets,lookup, [schema_table,<<"search-example">>], []} {riak_search_config,get_schema,1, [{file,"src/riak_search_config.erl"}, {line,69}]} ...| This error can be caused when attempting to use Riak Search without first enabling it in each node's `app.config`. See the [[Configuration Files]] documentation for more information on enabling Riak Search.
+
 
 ### More
 


### PR DESCRIPTION
Added a Riak Search related error

P.S. I wasn't able to use specific link text pointing directly to the `app.config` URL fragment as link pipe syntax doesn't work inside of the table syntax.

Also, I tried to use hub for the PR, but it wouldn't work this time around for some reason. :\
