### PR TITLE
Note that Git is required as a source install dependency

### DIFF
--- a/source/languages/en/riak/tutorials/installation/Installing-Riak-from-Source.md
+++ b/source/languages/en/riak/tutorials/installation/Installing-Riak-from-Source.md
@@ -20,6 +20,9 @@ Riak requires [[Erlang|http://www.erlang.org/]] R15B01. *Note: don't use Erlang 
 
 If you do not have Erlang already installed, see [[Installing Erlang]]. Don't worry, it's easy!
 
+Riak depends on source code located in multiple Git repositories; ensure that
+Git is also installed on the target system before attempting the build.
+
 <div class='note'>Riak will not compile with Clang. Please make sure your default C/C++ compiler is GCC.</div>
 
 ## Installation


### PR DESCRIPTION
On a bare minimum installation of Debian (for example) it is possible to not have Git installed. In the [Dependenices](http://docs.basho.com/riak/latest/tutorials/installation/Installing-Riak-from-Source/#Dependencies) section of Installing Riak from Source, we should note that Git is a dependency.
