### PR TITLE
The capacity planner seems wrong

### DIFF
--- a/source/js/docs/riak-bitcask-calculator.js
+++ b/source/js/docs/riak-bitcask-calculator.js
@@ -197,7 +197,7 @@ function update_calculations() {
                             " then Riak, using the Bitcask storage engine, will require at least:</p>" +
                             "<ul>" +
                             "<li>" + n + " nodes</li>" +
-                            "<li>" + format_bytes(r/n) + " of RAM total across all nodes</li>" +
+                            "<li>" + format_bytes(r/n) + " of RAM per node (" + format_bytes(r) + " total across all nodes)</li>" +
                             "<li> " + format_bytes(d/n) + " of storage space per node (" +
                             format_bytes(d) + " total storage space used across all nodes)</li></ul>"
                            );


### PR DESCRIPTION
http://docs.basho.com/riak/latest/references/appendices/Bitcask-Capacity-Planning/ seems to give results I don't expect. I'm attaching a screenshot. No matter what I put in the system memory textbox, the result tells me I need that amount of memory clusterwide, and tells me I need a ridiculous number of nodes.  This can't be right :)

![Untitled](https://f.cloud.github.com/assets/279875/119664/d4f2bb04-6caf-11e2-96f4-d306d1734fe1.png)
