### PR TITLE
Query tutorial wrongly linked to keywords

### DIFF
--- a/source/languages/en/riak/tutorials/querying/Basic-Operations.md
+++ b/source/languages/en/riak/tutorials/querying/Basic-Operations.md
@@ -8,7 +8,7 @@ audience: beginner
 keywords: [querying, api, http]
 prev: "[[Querying Riak]]"
 up:   "[[Querying Riak]]"
-next: "[[MapReduce]]"
+next: "[[MapReduce Overview]]"
 ---
 
 Most of the interactions you'll have with Riak will be setting or retrieving the value of a key. This section describes how to do that using the Riak [[HTTP API]], but the concepts apply equally to Riak's [[Protocol Buffers Client API|PBC API]] interface.

--- a/source/languages/en/riak/tutorials/querying/Secondary-Indexes.md
+++ b/source/languages/en/riak/tutorials/querying/Secondary-Indexes.md
@@ -6,7 +6,7 @@ document: tutorials
 toc: true
 audience: beginner
 keywords: [querying, 2i]
-prev: "[[MapReduce]]"
+prev: "[[MapReduce Overview]]"
 up:   "[[Querying Riak]]"
 next: "[[Searching|Riak Search]]"
 interest: [


### PR DESCRIPTION
This is just a quick navigation fix
