### PR TITLE
Added more emphasis to query string authentication

### DIFF
--- a/source/languages/en/riakcs/cookbooks/Authentication.md
+++ b/source/languages/en/riakcs/cookbooks/Authentication.md
@@ -5,7 +5,7 @@ version: 1.2.0+
 document: cookbook
 toc: true
 audience: intermediate
-keywords: [operator authentication]
+keywords: [operator, authentication]
 ---
 
 ## Signing and Authenticating REST Requests


### PR DESCRIPTION
I wasn't aware that Riak CS supported query string authentication. The Riak CS Authentication page in the documentation references it briefly, but separating it out into its own sub-section seems worthwhile.
