### PR TITLE
Override given version downloads.

### DIFF
--- a/data/downloads_defaults.yml
+++ b/data/downloads_defaults.yml
@@ -129,3 +129,124 @@ default:
         any:
           arch:
             src: {}
+stanchion:
+  1.3.1:
+    debian:
+      versions:
+        '6':
+          arch:
+            amd64:
+              file: stanchion_1.3.1.1-1_amd64.deb
+              static_file: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/debian/6/stanchion_1.3.1.1-1_amd64.deb
+              file_size: 21247788
+              csum: stanchion_1.3.1.1-1_amd64.deb.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/debian/6/stanchion_1.3.1.1-1_amd64.deb.sha
+              csum_size: 94
+    fedora:
+      versions:
+        '17':
+          arch:
+            x86_64:
+              file: stanchion-1.3.1.1-1.fc17.x86_64.rpm
+              static_file: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/fedora/17/stanchion-1.3.1.1-1.fc17.x86_64.rpm
+              file_size: 19014437
+              csum: stanchion-1.3.1.1-1.fc17.x86_64.rpm.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/fedora/17/stanchion-1.3.1.1-1.fc17.x86_64.rpm.sha
+              csum_size: 100
+    freebsd:
+      versions:
+        '9':
+          arch:
+            amd64:
+              file: stanchion-1.3.1.1-FreeBSD-amd64.tgz
+              static_file: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/freebsd/9/stanchion-1.3.1.1-FreeBSD-amd64.tgz
+              file_size: 26180929
+              csum: stanchion-1.3.1.1-FreeBSD-amd64.tgz.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/freebsd/9/stanchion-1.3.1.1-FreeBSD-amd64.tgz.sha
+              csum_size: 100
+    rhel:
+      versions:
+        '5':
+          arch:
+            x86_64:
+              file: stanchion-1.3.1.1-1.el5.x86_64.rpm
+              static_file: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/rhel/5/stanchion-1.3.1.1-1.el5.x86_64.rpm
+              file_size: 21432223
+              csum: stanchion-1.3.1.1-1.el5.x86_64.rpm.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/rhel/5/stanchion-1.3.1.1-1.el5.x86_64.rpm.sha
+              csum_size: 99
+        '6':
+          arch:
+            x86_64:
+              file: stanchion-1.3.1.1-1.el6.x86_64.rpm
+              static_file: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/rhel/6/stanchion-1.3.1.1-1.el6.x86_64.rpm
+              file_size: 19150880
+              csum: stanchion-1.3.1.1-1.el6.x86_64.rpm.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/rhel/6/stanchion-1.3.1.1-1.el6.x86_64.rpm.sha
+              csum_size: 99
+    smartos:
+      versions:
+        '1.8':
+          arch:
+            i386:
+              file: stanchion-1.3.1.1-SmartOS-i386.tgz
+              static_file: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/smartos/1.8/stanchion-1.3.1.1-SmartOS-i386.tgz
+              file_size: 27920644
+              csum: stanchion-1.3.1.1-SmartOS-i386.tgz.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/smartos/1.8/stanchion-1.3.1.1-SmartOS-i386.tgz.sha
+              csum_size: 99
+    solaris:
+      versions:
+        '10':
+          arch:
+            i386:
+              file: BASHOstanchion-1.3.1.1-Solaris10-i386.pkg.gz
+              static_file: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/solaris/10/BASHOstanchion-1.3.1.1-Solaris10-i386.pkg.gz
+              file_size: 25482189
+              csum: BASHOstanchion-1.3.1.1-Solaris10-i386.pkg.gz.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/solaris/10/BASHOstanchion-1.3.1.1-Solaris10-i386.pkg.gz.sha
+              csum_size: 109
+    ubuntu:
+      versions:
+        lucid:
+          arch:
+            amd64:
+              file: stanchion_1.3.1.1-1_amd64.deb
+              static_file: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/ubuntu/lucid/stanchion_1.3.1.1-1_amd64.deb
+              file_size: 21251450
+              csum: stanchion_1.3.1.1-1_amd64.deb.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/ubuntu/lucid/stanchion_1.3.1.1-1_amd64.deb.sha
+              csum_size: 94
+            i386:
+              file: stanchion_1.3.1.1-1_i386.deb
+              static_file: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/ubuntu/lucid/stanchion_1.3.1.1-1_i386.deb
+              file_size: 21017934
+              csum: stanchion_1.3.1.1-1_i386.deb.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/ubuntu/lucid/stanchion_1.3.1.1-1_i386.deb.sha
+              csum_size: 93
+        natty:
+          arch:
+            amd64:
+              file: stanchion_1.3.1.1-1_amd64.deb
+              static_file: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/ubuntu/natty/stanchion_1.3.1.1-1_amd64.deb
+              file_size: 21263640
+              csum: stanchion_1.3.1.1-1_amd64.deb.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/ubuntu/natty/stanchion_1.3.1.1-1_amd64.deb.sha
+              csum_size: 94
+        precise:
+          arch:
+            amd64:
+              file: stanchion_1.3.1.1-1_amd64.deb
+              static_file: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/ubuntu/precise/stanchion_1.3.1.1-1_amd64.deb
+              file_size: 21223446
+              csum: stanchion_1.3.1.1-1_amd64.deb.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/ubuntu/precise/stanchion_1.3.1.1-1_amd64.deb.sha
+              csum_size: 94
+    source:
+      versions:
+        any:
+          arch:
+            src:
+              file: stanchion-1.3.1.1.tar.gz
+              static_file: http://s3.amazonaws.com/downloads.basho.com/stanchion/1.3/1.3.1.1/stanchion-1.3.1.1.tar.gz
+              file_size: 2575643

--- a/lib/downloads.rb
+++ b/lib/downloads.rb
@@ -64,7 +64,8 @@ class Downloads
     end
     default_data = YAML::load(File.open('data/downloads_defaults.yml'))['default']['default']
     version_data = YAML::load(File.open('data/downloads_gen.yml'))[project][version]
-    (@data[project]||={})[version] = rmerge(default_data, version_data)
+    default_version_data = (YAML::load(File.open('data/downloads_defaults.yml'))[project]||{})[version] || {}
+    (@data[project]||={})[version] = rmerge(rmerge(default_data, version_data), default_version_data)
   end
 
   def self.load_from_s3(project, version)


### PR DESCRIPTION
Add the ability to override whatever the generated download links happen to be. This is necessary to allow spot patches to the download pages without incrementing the entire site version. Stanchion needed this to release a 1.3.1.1 download under the 1.3.1 documents page.
