### PR TITLE
Conflicting comment delimiters in Riak-CS Configuring Riak doc

### DIFF
--- a/source/languages/en/riakcs/cookbooks/configuration/Configuring-Riak.md
+++ b/source/languages/en/riakcs/cookbooks/configuration/Configuring-Riak.md
@@ -116,7 +116,7 @@ Riak `vm.args` configuration file, which is located in the `/etc/riak` or `/opt/
 ```erlang
 ## This setting is not present in default Riak installations, so
 ## it should be added.  In some cases, a value of 128000 may be
-%% appropriate.
+## appropriate.
 +zdbbl 96000
 
 ## This setting is present in default Riak installations, so


### PR DESCRIPTION
In http://docs.basho.com/riakcs/latest/cookbooks/configuration/Configuring-Riak/ we use two different comment delimiters in the vm.args snippet.  We should change the %% to a ##.
