### PR TITLE
reformat-indexes info

### DIFF
--- a/source/languages/en/riak/cookbooks/Rolling-Upgrades.md
+++ b/source/languages/en/riak/cookbooks/Rolling-Upgrades.md
@@ -119,7 +119,7 @@ behalf. This data is transferred to the node when it becomes available.
 <div class="info"><div class="title">Note for Secondary Index users</div>
 If you use Riak's Secondary Indexes and are upgrading from a version prior to
 Riak version 1.3.1, you need to reformat the indexes using the 
-[riak-admin reformat-indexes](/references/Command-Line-Tools---riak-admin/#reformat-indexes) command. More details about reformatting indexes are available
+[[riak-admin reformat-indexes|Command-Line-Tools - riak-admin#reformat-indexes]] command. More details about reformatting indexes are available
  in the
 [release notes](https://github.com/basho/riak/blob/master/RELEASE-NOTES.md).
 </div>
@@ -224,7 +224,7 @@ behalf. This data is transferred to the node when it becomes available.
 <div class="info"><div class="title">Note for Secondary Index users</div>
 If you use Riak's Secondary Indexes and are upgrading from a version prior to
 Riak version 1.3.1, you need to reformat the indexes using the 
-[riak-admin reformat-indexes](/references/Command-Line-Tools---riak-admin/#reformat-indexes) command. More details about reformatting indexes are available
+[[riak-admin reformat-indexes|Command-Line-Tools - riak-admin#reformat-indexes]] command. More details about reformatting indexes are available
  in the
 [release notes](https://github.com/basho/riak/blob/master/RELEASE-NOTES.md).
 </div>
@@ -358,7 +358,7 @@ behalf. This data is transferred to the node when it becomes available.
 <div class="info"><div class="title">Note for Secondary Index users</div>
 If you use Riak's Secondary Indexes and are upgrading from a version prior to
 Riak version 1.3.1, you need to reformat the indexes using the 
-[riak-admin reformat-indexes](/references/Command-Line-Tools---riak-admin/#reformat-indexes) command. More details about reformatting indexes are available
+[[riak-admin reformat-indexes|Command-Line-Tools - riak-admin#reformat-indexes]] command. More details about reformatting indexes are available
  in the
 [release notes](https://github.com/basho/riak/blob/master/RELEASE-NOTES.md).
 </div>


### PR DESCRIPTION
a quick blurb should be added to the `riak-admin` and upgrading sections on "reformat-indexes" [1]. Reported by user on riak mailing list [2]

[1] https://github.com/basho/riak/blob/1.3/RELEASE-NOTES.md#2i-big-integer-encoding
[2] http://lists.basho.com/pipermail/riak-users_lists.basho.com/2013-May/012127.html
