### PR TITLE
Add links to Riak books

### DIFF
--- a/source/languages/en/riak/references/appendices/community/Overviews-and-Introductions.md
+++ b/source/languages/en/riak/references/appendices/community/Overviews-and-Introductions.md
@@ -57,7 +57,17 @@ This is a sample of the slide decks used in presentations given by Riak Core Dev
 
 ## Publications
 
-The following papers give background information on distributed systems and relevant aspects of Riak's architecture.
+If you're looking for some reading material on Riak, then start here.
+
+This is a partial list publications that cover both introductions to using
+Riak, and influences on Riak's design and architectural decisions.
+
+## Books
+
+* [A Little Riak Book](http://littleriakbook.com/)
+* [Riak Handbook](http://riakhandbook.com/)
+
+## Articles and Papers
 
 * [[Amazon's Dynamo Paper|http://www.allthingsdistributed.com/2007/10/amazons_dynamo.html]]
 * [[Distributed Systems: Principles and Paradigms|http://www.amazon.com/Distributed-Systems-Principles-Andrew-Tanenbaum/dp/0130888931]]
@@ -67,4 +77,3 @@ The following papers give background information on distributed systems and rele
 * [[Towards Robust Distributed Systems|http://www.cs.berkeley.edu/~brewer/cs262b-2004/PODC-keynote.pdf]]
 * [[Brewer's Conjecture and the Feasibility of Consistent Available Partition-Tolerant Web Services|http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.20.1495]]
 * [[(White paper) Big Data's Effect on Data Management|http://info.basho.com/DataWP.html]]
-

--- a/source/languages/en/riak/references/appendices/community/Publications.md
+++ b/source/languages/en/riak/references/appendices/community/Publications.md
@@ -1,5 +1,5 @@
 ---
-title: Book and Articles
+title: Books and Articles
 project: riak
 version: 0.10.0+
 document: appendix
@@ -7,7 +7,17 @@ toc: true
 keywords: [community, resources]
 ---
 
-If you're looking for some reading material on Riak, here is where to start. This is a partial list of papers, book titles, and other publications that influenced Riak's design and architectural decisions. 
+If you're looking for some reading material on Riak, then start here.
+
+This is a partial list publications that cover both introductions to using
+Riak, and influences on Riak's design and architectural decisions.
+
+## Books
+
+* [A Little Riak Book](http://littleriakbook.com/)
+* [Riak Handbook](http://riakhandbook.com/)
+
+## Articles and Papers
 
 * [[Amazon's Dynamo Paper|http://www.allthingsdistributed.com/2007/10/amazons_dynamo.html]]
 * [[Distributed Systems: Principles and Paradigms|http://www.amazon.com/Distributed-Systems-Principles-Andrew-Tanenbaum/dp/0130888931]]
@@ -16,3 +26,5 @@ If you're looking for some reading material on Riak, here is where to start. Thi
 * [[Elements of Distributed Computing|http://www.amazon.com/Elements-Distributed-Computing-Vijay-Garg/dp/0471036005/ref=pd_bxgy_b_img_c]]
 * [[Towards Robust Distributed Systems|http://www.cs.berkeley.edu/~brewer/cs262b-2004/PODC-keynote.pdf]]
 * [[Brewer's Conjecture and the Feasibility of Consistent Available Partition-Tolerant Web Services|http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.20.1495]]
+* [[(White paper) Big Data's Effect on Data Management|http://info.basho.com/DataWP.html]]
+


### PR DESCRIPTION
Need to add links on appropriate pages, such as the [Community Resources](http://docs.basho.com/riak/latest/references/appendices/community/#Resources) pages to all currently published Riak books
