### PR TITLE
Add diag and verification of patches as post-installation/upgrade sanity checks

### DIFF
--- a/source/languages/en/riak/cookbooks/Rolling-Upgrades.md
+++ b/source/languages/en/riak/cookbooks/Rolling-Upgrades.md
@@ -396,3 +396,66 @@ commands:
 ```
 
 {{/1.1.0-}}
+
+## Basho Patches
+
+After upgrading, you should ensure that any custom patches contained in the
+`basho-patches` directory are examined to determine their application to
+the upgraded version. If you find that patches no longer apply to the upgraded
+version, you should remove them from the `basho-patches` directory prior to
+operating the node in production.
+
+The following table lists locations of the `basho-patches` directory for each
+supported operating system:
+
+<table style="width: 100%; border-spacing: 0px;">
+<tbody>
+<tr align="left" valign="top">
+<td style="padding: 15px; margin: 15px; border-width: 1px 0 1px 0; border-style: solid;"><strong>CentOS &amp; RHEL Linux</strong></td>
+<td style="padding: 15px; margin: 15px; border-width: 1px 0 1px 0; border-style: solid;">
+<p><tt>/usr/lib64/riak/lib/basho-patches</tt></p>
+</td>
+</tr>
+<tr align="left" valign="top">
+<td style="padding: 15px; margin: 15px; border-width: 1px 0 1px 0; border-style: solid;"><strong>Debian &amp; Ubuntu Linux</strong></td>
+<td style="padding: 15px; margin: 15px; border-width: 1px 0 1px 0; border-style: solid;">
+<p><tt>/usr/lib/riak/lib/basho-patches</tt></p>
+</td>
+</tr>
+<tr align="left" valign="top">
+<td style="padding: 15px; margin: 15px; border-width: 1px 0 1px 0; border-style: solid;"><strong>FreeBSD</strong></td>
+<td style="padding: 15px; margin: 15px; border-width: 1px 0 1px 0; border-style: solid;">
+<p><tt>/usr/local/lib/riak/lib/basho-patches</tt></p>
+</td>
+</tr>
+<tr align="left" valign="top">
+<td style="padding: 15px; margin: 15px; border-width: 1px 0 1px 0; border-style: solid;"><strong>SmartOS</strong></td>
+<td style="padding: 15px; margin: 15px; border-width: 1px 0 1px 0; border-style: solid;">
+<p><tt>/opt/local/lib/riak/lib/basho-patches</tt></p>
+</td>
+</tr>
+<tr align="left" valign="top">
+<td style="padding: 15px; margin: 15px; border-width: 1px 0 1px 0; border-style: solid;"><strong>Solaris 10</strong></td>
+<td style="padding: 15px; margin: 15px; border-width: 1px 0 1px 0; border-style: solid;">
+<p><tt>/opt/riak/lib/basho-patches</tt></p>
+</td>
+</tr>
+</tbody>
+</table>
+
+{{#1.3.0+}}
+## Riaknostic
+
+It is a good idea to also verify some basic configuration and general health
+of the Riak node after upgrading by using Riak's built-in diagnostic
+utility *Riaknostic*.
+
+Ensure that Riak is running on the node, and issue the following command:
+
+```
+riak-admin diag
+```
+
+Make the recommended changes from the command output to ensure optimal node
+operation.
+{{/1.3.0+}}

--- a/source/languages/en/riak/tutorials/installation/Post-Installation.md
+++ b/source/languages/en/riak/tutorials/installation/Post-Installation.md
@@ -128,6 +128,23 @@ The above output shows a successful response (HTTP 200 OK) and additional
 details from the verbose option. The response also contains the bucket
 properties for Riak's test bucket.
 
+{{#1.3.0+}}
+## Riaknostic
+
+It is a good idea to also verify some basic configuration and general health
+of the Riak node after installation by using Riak's built-in diagnostic
+utility *Riaknostic*.
+
+Ensure that Riak is running on the node, and issue the following command:
+
+```
+riak-admin diag
+```
+
+Make the recommended changes from the command output to ensure optimal node
+operation.
+{{/1.3.0+}}
+
 ## Now what?
 
 You have a working Riak node!

--- a/source/languages/en/riakee/cookbooks/Rolling-Upgrade-to-Enterprise.md
+++ b/source/languages/en/riakee/cookbooks/Rolling-Upgrade-to-Enterprise.md
@@ -18,3 +18,66 @@ Instructions for upgrading:
   6. Copy any customizations from your backed up vm.args to the riak_ee installed one, these files may be identical.
   7. The app.config file from riak_ee will be significantly different from your backed up one. While it will contain all of the same sections as your original, it will have many new ones. Copy the customizations from your original app.config file into the sections in the new one.
   8. Start Riak on the upgraded node.
+
+## Basho Patches
+
+After upgrading, you should ensure that any custom patches contained in the
+`basho-patches` directory are examined to determine their application to
+the upgraded version. If you find that patches no longer apply to the upgraded
+version, you should remove them from the `basho-patches` directory prior to
+operating the node in production.
+
+The following table lists locations of the `basho-patches` directory for each
+supported operating system:
+
+<table style="width: 100%; border-spacing: 0px;">
+<tbody>
+<tr align="left" valign="top">
+<td style="padding: 15px; margin: 15px; border-width: 1px 0 1px 0; border-style: solid;"><strong>CentOS &amp; RHEL Linux</strong></td>
+<td style="padding: 15px; margin: 15px; border-width: 1px 0 1px 0; border-style: solid;">
+<p><tt>/usr/lib64/riak/lib/basho-patches</tt></p>
+</td>
+</tr>
+<tr align="left" valign="top">
+<td style="padding: 15px; margin: 15px; border-width: 1px 0 1px 0; border-style: solid;"><strong>Debian &amp; Ubuntu Linux</strong></td>
+<td style="padding: 15px; margin: 15px; border-width: 1px 0 1px 0; border-style: solid;">
+<p><tt>/usr/lib/riak/lib/basho-patches</tt></p>
+</td>
+</tr>
+<tr align="left" valign="top">
+<td style="padding: 15px; margin: 15px; border-width: 1px 0 1px 0; border-style: solid;"><strong>FreeBSD</strong></td>
+<td style="padding: 15px; margin: 15px; border-width: 1px 0 1px 0; border-style: solid;">
+<p><tt>/usr/local/lib/riak/lib/basho-patches</tt></p>
+</td>
+</tr>
+<tr align="left" valign="top">
+<td style="padding: 15px; margin: 15px; border-width: 1px 0 1px 0; border-style: solid;"><strong>SmartOS</strong></td>
+<td style="padding: 15px; margin: 15px; border-width: 1px 0 1px 0; border-style: solid;">
+<p><tt>/opt/local/lib/riak/lib/basho-patches</tt></p>
+</td>
+</tr>
+<tr align="left" valign="top">
+<td style="padding: 15px; margin: 15px; border-width: 1px 0 1px 0; border-style: solid;"><strong>Solaris 10</strong></td>
+<td style="padding: 15px; margin: 15px; border-width: 1px 0 1px 0; border-style: solid;">
+<p><tt>/opt/riak/lib/basho-patches</tt></p>
+</td>
+</tr>
+</tbody>
+</table>
+
+{{#1.3.0+}}
+## Riaknostic
+
+It is a good idea to also verify some basic configuration and general health
+of the Riak node after upgrading by using Riak's built-in diagnostic
+utility *Riaknostic*.
+
+Ensure that Riak is running on the node, and issue the following command:
+
+```
+riak-admin diag
+```
+
+Make the recommended changes from the command output to ensure optimal node
+operation.
+{{/1.3.0+}}


### PR DESCRIPTION
It would be helpful to introduce a quick post upgrade sanity check in the form of running `riak-admin diag` on each node after upgrading.

It'd also be good to include a bit about checking the `basho-patches` directory for any patches which might not be desired for the new version and cleaning those out as recommended in #406.

The following docs would be affected:
- [Post Installation Notes](http://docs.basho.com/riak/latest/tutorials/installation/Post-Installation/)
- [Rolling Upgrades](http://docs.basho.com/riak/latest/cookbooks/Rolling-Upgrades/)
- [Rolling Upgrade to Enterprise](http://docs.basho.com/riakee/latest/cookbooks/Rolling-Upgrade-to-Enterprise/)
