### PR TITLE
Add a new tag to transclude version values

### DIFF
--- a/lib/sitemap_render_override.rb
+++ b/lib/sitemap_render_override.rb
@@ -120,12 +120,28 @@ module SitemapRenderOverride
   def strip_versions!(data)
     project = (metadata[:page]["project"] || $default_project).to_sym
     
-    version_str = SitemapRenderOverride.current_version || $versions[project]
+    raw_version_str = SitemapRenderOverride.current_version || $versions[project]
 
-    if version_str
+    if raw_version_str
       # Ignore rcX if this is a pre-release
-      version_str = version_str.sub(/rc\d+/i, '')
+      version_str = raw_version_str.sub(/rc\d+/i, '')
       version = Versionomy.parse(version_str)
+
+      # Create a version placeholder
+      data.gsub!(/\{\{VERSION\}\}/) do
+        raw_version_str
+      end
+      data.gsub!(/\{\{V.V.V\}\}/) do
+        version_str
+      end
+      vv_version_str = version_str.gsub(/^(\d+\.\d+).*?$/, '\1')
+      data.gsub!(/\{\{V.V\}\}/) do
+        vv_version_str
+      end
+      v_version_str = vv_version_str.gsub(/^(\d+)\..*?$/, '\1')
+      data.gsub!(/\{\{V\}\}/) do
+        v_version_str
+      end
 
       # if it's a different version, remove the entire block
       data.gsub!(/\{\{\#([^\}]+)\}\}(.*?)\{\{\/(\1)\}\}/m) do

--- a/source/languages/en/riak/tutorials/installation/Installing-Riak-from-Source.md
+++ b/source/languages/en/riak/tutorials/installation/Installing-Riak-from-Source.md
@@ -31,62 +31,27 @@ The following instructions generate a complete, self-contained build of Riak in 
 ### Installing from source package
 Download the Riak source package from the [[Download Center|http://basho.com/resources/downloads/]] and build:
 
-{{#1.2.0}}
-
 ```bash
-curl -O http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.0/riak-1.2.0.tar.gz
-tar zxvf riak-1.2.0.tar.gz
-cd riak-1.2.0
+curl -O http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/riak-{{V.V.V}}.tar.gz
+tar zxvf riak-{{V.V.V}}.tar.gz
+cd riak-{{V.V.V}}
 make rel
 ```
-
-{{/1.2.0}}
-{{#1.2.1}}
-
-```bash
-curl -O http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/riak-1.2.1.tar.gz
-tar zxvf riak-1.2.1.tar.gz
-cd riak-1.2.1
-make rel
-```
-
-{{/1.2.1}}
-{{#1.3.0}}
-
-```bash
-curl -O http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.3/1.3.0/riak-1.3.0.tar.gz
-tar zxvf riak-1.3.0.tar.gz
-cd riak-1.3.0
-make rel
-```
-
-{{/1.3.0}}
-
-{{#1.3.1}}
-
-```bash
-curl -O http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.3/1.3.1/riak-1.3.1.tar.gz
-tar zxvf riak-1.3.1.tar.gz
-cd riak-1.3.1
-make rel
-```
-
-{{/1.3.1}}
 
 <div class='note'> If you see the error `fatal: unable to connect to github.com` see the following instructions for building on systems with no internet availability </div>
 
 ### Installation on Closed Networks
 The error `fatal: unable to connect to github.com` when building from source is caused by building on a system with no network connection to Github. Either the port is turned off for security reasons, or the source build is happening on a computer with no outside internet access.  To rectify this problem, an additional file will need to be deployed along with the source tarball.
 
-Download the following `leveldb` archive for the version of Riak you are using:
+Download the following `leveldb` archive for Riak version {{VERSION}}:
 
-  * **1.3.1**: `https://github.com/basho/leveldb/zipball/1.3.0`
-  * **1.3.0**: `https://github.com/basho/leveldb/zipball/1.3.0`
-  * **1.2.1**: `https://github.com/basho/leveldb/zipball/1.2.2p5`
-  * **1.2.0**: `https://github.com/basho/leveldb/zipball/2aebdd9173a7840f9307e30146ac95f49fbe8e64`
-  * **1.1.4**: `https://github.com/basho/leveldb/zipball/14478f170bbe3d13bc0119d41b70e112b3925453`
+{{#1.3.0+}}`https://github.com/basho/leveldb/zipball/{{V.V}}.0`{{/1.3.0+}}
 
-{{#1.1.4-1.2.1}}
+{{#1.2.1}}`https://github.com/basho/leveldb/zipball/1.2.2p5`{{/1.2.1}}
+{{#1.2.0}}`https://github.com/basho/leveldb/zipball/2aebdd9173a7840f9307e30146ac95f49fbe8e64`{{/1.2.0}}
+{{#1.2.0-}}`https://github.com/basho/leveldb/zipball/14478f170bbe3d13bc0119d41b70e112b3925453`{{/1.2.0-}}
+
+{{#1.3.0-}}
 
 The instructions going forward will assume Riak 1.2.0, replace the appropriate file for your version.
 
@@ -101,7 +66,7 @@ $ cd ../../../
 $ make rel
 ```
 
-{{/1.1.4-1.2.1}}
+{{/1.3.0-}}
 {{#1.3.0+}}
 
 The instructions going forward will assume Riak 1.3.0, replace the appropriate file for your version.

--- a/source/languages/en/riak/tutorials/installation/Installing-on-Debian-and-Ubuntu.md
+++ b/source/languages/en/riak/tutorials/installation/Installing-on-Debian-and-Ubuntu.md
@@ -80,185 +80,75 @@ for the target platform:
 
 #### Ubuntu Lucid Lynx (10.04)
 
-{{#1.0.3}}
+{{#1.2.0-}}
 
 ```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.0/1.0.3/riak_1.0.3-1_amd64.deb
-sudo dpkg -i riak_1.0.3-1_amd64.deb
+wget http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/riak_{{V.V.V}}-1_amd64.deb
+sudo dpkg -i riak_{{V.V.V}}-1_amd64.deb
 ```
 
-{{/1.0.3}}
-{{#1.1.4}}
+{{/1.2.0-}}
+{{#1.2.0+}}
 
 ```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.1/1.1.4/riak_1.1.4-1_amd64.deb
-sudo dpkg -i riak_1.1.4-1_amd64.deb
+wget http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/ubuntu/lucid/riak_{{V.V.V}}-1_amd64.deb
+sudo dpkg -i riak_{{V.V.V}}-1_amd64.deb
 ```
 
-{{/1.1.4}}
-{{#1.2.0}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/ubuntu/lucid/riak_1.2.0-1_amd64.deb
-sudo dpkg -i riak_1.2.1-0_amd64.deb
-```
-
-{{/1.2.0}}
-{{#1.2.1}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/ubuntu/lucid/riak_1.2.1-1_amd64.deb
-sudo dpkg -i riak_1.2.1-1_amd64.deb
-```
-
-{{/1.2.1}}
-{{#1.3.0}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.3/1.3.0/ubuntu/lucid/riak_1.3.0-1_amd64.deb
-sudo dpkg -i riak_1.3.0-1_amd64.deb
-```
-
-{{/1.3.0}}
-{{#1.3.1}}
-
-```bash
-wget http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.1/ubuntu/lucid/riak_1.3.1-1_amd64.deb
-sudo dpkg -i riak_1.3.1-1_amd64.deb
-```
-
-{{/1.3.1}}
+{{/1.2.0+}}
 
 #### Ubuntu Natty Narwhal (11.04)
 
-{{#1.0.3}}
+{{#1.2.0-}}
 
 ```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.0/1.0.3/riak_1.0.3-1_amd64.deb
-sudo dpkg -i riak_1.0.3-1_amd64.deb
+wget http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/riak_{{V.V.V}}-1_amd64.deb
+sudo dpkg -i riak_{{V.V.V}}-1_amd64.deb
 ```
 
-{{/1.0.3}}
-{{#1.1.4}}
+{{/1.2.0-}}
+{{#1.2.0+}}
 
 ```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.1/1.1.4/riak_1.1.4-1_amd64.deb
-sudo dpkg -i riak_1.1.4-1_amd64.deb
+wget http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/ubuntu/natty/riak_{{V.V.V}}-1_amd64.deb
+sudo dpkg -i riak_{{V.V.V}}-1_amd64.deb
 ```
 
-{{/1.1.4}}
-{{#1.2.0}}
+{{/1.2.0+}}
 
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.0/ubuntu/natty/riak_1.2.0-1_amd64.deb
-sudo dpkg -i riak_1.2.0-1_amd64.deb
-```
-
-{{/1.2.0}}
-{{#1.2.1}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/ubuntu/natty/riak_1.2.1-1_amd64.deb
-sudo dpkg -i riak_1.2.1-1_amd64.deb
-```
-
-{{/1.2.1}}
-{{#1.3.0}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.3/1.3.0/ubuntu/natty/riak_1.3.0-1_amd64.deb
-sudo dpkg -i riak_1.3.0-1_amd64.deb
-```
-
-{{/1.3.0}}
-{{#1.3.1}}
-
-```bash
-wget http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.1/ubuntu/natty/riak_1.3.1-1_amd64.deb
-sudo dpkg -i riak_1.3.1-1_amd64.deb
-```
-
-{{/1.3.1}}
 
 #### Ubuntu Precise Pangolin (12.04)
 
-{{#1.0.3}}
+{{#1.2.0-}}
 
 ```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.0/1.0.3/riak_1.0.3-1_amd64.deb
-sudo dpkg -i riak_1.0.3-1_amd64.deb
+wget http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/riak_{{V.V.V}}-1_amd64.deb
+sudo dpkg -i riak_{{V.V.V}}-1_amd64.deb
 ```
 
-{{/1.0.3}}
-{{#1.1.4}}
+{{/1.2.0-}}
+{{#1.2.0+}}
 
 ```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.1/1.1.4/riak_1.1.4-1_amd64.deb
-sudo dpkg -i riak_1.1.4-1_amd64.deb
+wget http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/ubuntu/precise/riak_{{V.V.V}}-1_amd64.deb
+sudo dpkg -i riak_{{V.V.V}}-1_amd64.deb
 ```
 
-{{/1.1.4}}
-{{#1.2.0}}
+{{/1.2.0+}}
 
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.0/ubuntu/precise/riak_1.2.0-1_amd64.deb
-sudo dpkg -i riak_1.2.0-1_amd64.deb
-```
 
-{{/1.2.0}}
-{{#1.2.1}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/ubuntu/precise/riak_1.2.1-1_amd64.deb
-sudo dpkg -i riak_1.2.1-1_amd64.deb
-```
-
-{{/1.2.1}}
-{{#1.3.0}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.3/1.3.0/ubuntu/precise/riak_1.3.0-1_amd64.deb
-sudo dpkg -i riak_1.3.0-1_amd64.deb
-```
-
-{{/1.3.0}}
-{{#1.3.1}}
-
-```bash
-wget http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.1/ubuntu/precise/riak_1.3.1-1_amd64.deb
-sudo dpkg -i riak_1.3.1-1_amd64.deb
-```
-
-{{/1.3.1}}
+{{#1.2.1+}}
 
 ### Riak 32-bit Installation
 
-{{#1.2.1}}
-
 ```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/ubuntu/lucid/riak_1.2.1-1_i386.deb
-sudo dpkg -i riak_1.2.1-1_i386.deb
+wget http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/ubuntu/lucid/riak_{{V.V.V}}-1_i386.deb
+sudo dpkg -i riak_{{V.V.V}}-1_i386.deb
 ```
-{{/1.2.1}}
-{{#1.3.0}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.3/1.3.0/ubuntu/lucid/riak_1.3.0-1_i386.deb
-sudo dpkg -i riak_1.3.0-1_i386.deb
-```
-
-{{/1.3.0}}
-{{#1.3.1}}
-
-```bash
-wget http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.1/ubuntu/lucid/riak_1.3.1-1_i386.deb
-sudo dpkg -i riak_1.3.1-1_i386.deb
-```
-
-{{/1.3.1}}
 
 <div class="note"><div class="title">Upgrading Riak</div>If upgrading the Riak package, and the user named "riak" exists without a home directory, create a home directory (`/var/lib/riak`), and execute `chown riak:riak /var/lib/riak` before starting Riak.</div>
 
+{{/1.2.1+}}
 
 Installing Riak From Source
 ---------------------------
@@ -275,68 +165,12 @@ If Erlang is not already installed, install it before continuing (see:
 
 With Erlang installed, proceed to downloading and installing Riak:
 
-{{#1.0.3}}
-
 ```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.0/1.0.3/riak-1.0.3.tar.gz
-tar zxvf riak-1.0.3.tar.gz
-cd riak-1.0.3
+wget http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/riak-{{V.V.V}}.tar.gz
+tar zxvf riak-{{V.V.V}}.tar.gz
+cd riak-{{V.V.V}}
 make rel
 ```
-
-{{/1.0.3}}
-{{#1.1.4}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.1/1.1.4/riak-1.1.4.tar.gz
-tar zxvf riak-1.1.4.tar.gz
-cd riak-1.1.4
-make rel
-```
-
-{{/1.1.4}}
-{{#1.2.0}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.0/riak-1.2.0.tar.gz
-tar zxvf riak-1.2.0.tar.gz
-cd riak-1.2.0
-make rel
-```
-
-{{/1.2.0}}
-{{#1.2.1}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/riak-1.2.1.tar.gz
-tar zxvf riak-1.2.1.tar.gz
-cd riak-1.2.1
-make rel
-```
-
-{{/1.2.1}}
-
-{{#1.3.0}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.3/1.3.0/riak-1.3.0.tar.gz
-tar zxvf riak-1.3.0.tar.gz
-cd riak-1.3.0
-make rel
-```
-
-{{/1.3.0}}
-{{#1.3.1}}
-
-```bash
-wget http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.1/riak-1.3.1.tar.gz
-tar zxvf riak-1.3.1.tar.gz
-cd riak-1.3.1
-make rel
-```
-
-{{/1.3.1}}
-
 
 If the build was successful, a fresh build of Riak will exist in the
 `rel/riak` directory.

--- a/source/languages/en/riak/tutorials/installation/Installing-on-FreeBSD.md
+++ b/source/languages/en/riak/tutorials/installation/Installing-on-FreeBSD.md
@@ -29,46 +29,12 @@ The Riak binary package also depends on a packaged version of OpenSSL. Prior to 
 
 ### Installation
 
-{{#1.2.0}}
-
 You can install the Riak binary package on FreeBSD remotely using the
-`pkg_add` remote option. For this example, we're installing `riak-1.2.0-FreeBSD-amd64.tbz`.
+`pkg_add` remote option. For this example, we're installing `riak-{{V.V.V}}-FreeBSD-amd64.tbz`.
 
 ```bash
-sudo pkg_add -r http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.0/freebsd/9/riak-1.2.0-FreeBSD-amd64.tbz
+sudo pkg_add -r http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/freebsd/9/riak-{{V.V.V}}-FreeBSD-amd64.tbz
 ```
-
-{{/1.2.0}}
-{{#1.2.1}}
-
-You can install the Riak binary package on FreeBSD remotely using the
-`pkg_add` remote option. For this example, we're installing `riak-1.2.1-FreeBSD-amd64.tbz`.
-
-```bash
-sudo pkg_add -r http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/freebsd/9/riak-1.2.1-FreeBSD-amd64.tbz
-```
-
-{{/1.2.1}}
-{{#1.3.0}}
-
-You can install the Riak binary package on FreeBSD remotely using the
-`pkg_add` remote option. For this example, we're installing `riak-1.3.0-FreeBSD-amd64.tbz`.
-
-```bash
-sudo pkg_add -r http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.3/1.3.0/freebsd/9/riak-1.3.0-FreeBSD-amd64.tbz
-```
-
-{{/1.3.0}}
-{{#1.3.1}}
-
-You can install the Riak binary package on FreeBSD remotely using the
-`pkg_add` remote option. For this example, we're installing `riak-1.3.1-FreeBSD-amd64.tbz`.
-
-```bash
-sudo pkg_add -r http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.1/freebsd/9/riak-1.3.1-FreeBSD-amd64.tbz
-```
-
-{{/1.3.1}}
 
 When Riak is installed, a message is displayed with information about the installation and available documentation.
 
@@ -95,20 +61,9 @@ Man pages are available for riak(1), riak-admin(1), and search-cmd(1)
 
 If instead of this message, you receive an error during installation regarding OpenSSL, similar to this one:
 
-{{#1.2.0}}
-
 ```text
-Package dependency openssl-1.0.0_7 for /tmp/riak-1.2.0-FreeBSD-amd64.tbz not found!
+Package dependency openssl-1.0.0_7 for /tmp/riak-{{V.V.V}}-FreeBSD-amd64.tbz not found!
 ```
-
-{{/1.2.0}}
-{{#1.2.1}}
-
-```text
-Package dependency openssl-1.0.0_7 for /tmp/riak-1.2.1-FreeBSD-amd64.tbz not found!
-```
-
-{{/1.2.1}}
 
 Be sure that you've installed the required OpenSSL version from packages or the ports collection as described in the **Prerequisites and Dependencies** section.
 

--- a/source/languages/en/riak/tutorials/installation/Installing-on-Mac-OS-X.md
+++ b/source/languages/en/riak/tutorials/installation/Installing-on-Mac-OS-X.md
@@ -25,53 +25,37 @@ The following steps are known to work with Mac OS X 10.5 and 10.6. You can insta
 ## From Precompiled Tarballs
 To run Riak from our precompiled tarball, run these commands for the appropriate platform:
 
-{{#1.0.3}}
+{{#1.2.0-}}
+
 ### 64-bit
 
 ```bash
-curl -O http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.0/1.0.3/riak-1.0.3-osx-x86_64.tar.gz
-tar xzvf riak-1.0.3-osx-x86_64.tar.gz
+curl -O http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/riak-{{V.V}}-osx-x86_64.tar.gz
+tar xzvf riak-{{V.V.V}}-osx-x86_64.tar.gz
 ```
 
 ### 32-bit
 
 ```bash
-curl -O http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.0/1.0.3/riak-1.0.3-osx-i386.tar.gz
-tar xzvf riak-1.0.3-osx-i386.tar.gz
+curl -O http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/riak-{{V.V.V}}-osx-i386.tar.gz
+tar xzvf riak-{{V.V.V}}-osx-i386.tar.gz
 ```
 
-{{/1.0.3}}
-{{#1.1.4}}
-
-### 64-bit
-
-```bash
-curl -O http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.1/1.1.4/riak-1.1.4-osx-x86_64.tar.gz
-tar xzvf riak-1.1.4-osx-x86_64.tar.gz
-```
-
-### 32-bit
-
-```bash
-curl -O http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.1/1.1.4/riak-1.1.4-osx-i386.tar.gz
-tar xzvf riak-1.1.4-osx-i386.tar.gz
-```
-
-{{/1.1.4}}
+{{/1.2.0-}}
 {{#1.2.0}}
 
 ### 64-bit
 
 ```bash
-curl -O http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.0/osx/10.4/riak-1.2.0-osx-x86_64.tar.gz
-tar xzvf riak-1.2.0-osx-x86_64.tar.gz
+curl -O http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/osx/10.4/riak-{{V.V.V}}-osx-x86_64.tar.gz
+tar xzvf riak-{{V.V.V}}-osx-x86_64.tar.gz
 ```
 
 ### 32-bit
 
 ```bash
-curl -O http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.0/osx/10.4/riak-1.2.0-osx-i386.tar.gz
-tar xzvf riak-1.2.0-osx-i386.tar.gz
+curl -O http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/osx/10.4/riak-{{V.V.V}}-osx-i386.tar.gz
+tar xzvf riak-{{V.V.V}}-osx-i386.tar.gz
 ```
 
 {{/1.2.0}}
@@ -80,52 +64,36 @@ tar xzvf riak-1.2.0-osx-i386.tar.gz
 ### 64-bit
 
 ```bash
-curl -O http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/osx/10.4/riak-1.2.1-osx-x86_64.tar.gz
-tar xzvf riak-1.2.1-osx-x86_64.tar.gz
+curl -O http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/osx/10.4/riak-{{V.V.V}}-osx-x86_64.tar.gz
+tar xzvf riak-{{V.V.V}}-osx-x86_64.tar.gz
 ```
 
 ### 32-bit
 
 ```bash
-curl -O http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/osx/10.4/riak-1.2.1-osx-i386.tar.gz
-tar xzvf riak-1.2.1-osx-i386.tar.gz
+curl -O http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/osx/10.4/riak-{{V.V.V}}-osx-i386.tar.gz
+tar xzvf riak-{{V.V.V}}-osx-i386.tar.gz
 ```
 
 {{/1.2.1}}
-{{#1.3.0}}
+{{#1.3.0+}}
 
 ### 64-bit
 
 ```bash
-curl -O http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.0/osx/10.6/riak-1.3.0-osx-x86_64.tar.gz
-tar xzvf riak-1.3.0-osx-x86_64.tar.gz
+curl -O http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/osx/10.6/riak-{{V.V.V}}-osx-x86_64.tar.gz
+tar xzvf riak-{{V.V.V}}-osx-x86_64.tar.gz
 ```
 
 ### 32-bit
 
 ```bash
-curl -O http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.0/osx/10.6/riak-1.3.0-osx-i386.tar.gz
-tar xzvf riak-1.3.0-osx-i386.tar.gz
+curl -O http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/osx/10.6/riak-{{V.V.V}}-osx-i386.tar.gz
+tar xzvf riak-{{V.V.V}}-osx-i386.tar.gz
 ```
 
-{{/1.3.0}}
-{{#1.3.1}}
+{{/1.3.0+}}
 
-### 64-bit
-
-```bash
-curl -O http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.1/osx/10.6/riak-1.3.1-osx-x86_64.tar.gz
-tar xzvf riak-1.3.1-osx-x86_64.tar.gz
-```
-
-### 32-bit
-
-```bash
-curl -O http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.1/osx/10.6/riak-1.3.1-osx-i386.tar.gz
-tar xzvf riak-1.3.1-osx-i386.tar.gz
-```
-
-{{/1.3.1}}
 After the release is untarred you will be able to cd into the riak directory and execute bin/riak start to start the Riak node.
 
 ## Homebrew
@@ -151,67 +119,12 @@ If you do not have Erlang already installed, see [[Installing Erlang]]. Don't wo
 
 Next, download and unpack the source distribution.
 
-{{#1.0.3}}
-
 ```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.0/1.0.3/riak-1.0.3.tar.gz
-tar zxvf riak-1.0.3.tar.gz
-cd riak-1.0.3
+wget http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/riak-{{V.V.V}}.tar.gz
+tar zxvf riak-{{V.V.V}}.tar.gz
+cd riak-{{V.V.V}}
 make rel
 ```
-
-{{/1.0.3}}
-{{#1.1.4}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.1/1.1.4/riak-1.1.4.tar.gz
-tar zxvf riak-1.1.4.tar.gz
-cd riak-1.1.4
-make rel
-```
-
-{{/1.1.4}}
-{{#1.2.0}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.0/riak-1.2.0.tar.gz
-tar zxvf riak-1.2.0.tar.gz
-cd riak-1.2.0
-make rel
-```
-
-{{/1.2.0}}
-{{#1.2.1}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/riak-1.2.1.tar.gz
-tar zxvf riak-1.2.1.tar.gz
-cd riak-1.2.1
-make rel
-```
-
-{{/1.2.1}}
-
-{{#1.3.0}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.3/1.3.0/riak-1.3.0.tar.gz
-tar zxvf riak-1.3.0.tar.gz
-cd riak-1.3.0
-make rel
-```
-
-{{/1.3.0}}
-{{#1.3.1}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.3/1.3.0/riak-1.3.0.tar.gz
-tar zxvf riak-1.3.1.tar.gz
-cd riak-1.3.1
-make rel
-```
-
-{{/1.3.1}}
 
 If you get errors when building about "incompatible architecture", please verify that you built Erlang with the same architecture as your system (Snow Leopard and higher - 64bit, everything else - 32bit).
 

--- a/source/languages/en/riak/tutorials/installation/Installing-on-RHEL-and-CentOS.md
+++ b/source/languages/en/riak/tutorials/installation/Installing-on-RHEL-and-CentOS.md
@@ -33,54 +33,22 @@ sudo yum install riak
 
 ...or install the rpm package manually.
 
-{{#1.0.3}}
+{{#1.2.0-}}
 
 ```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.0/1.0.3/riak-1.0.3-1.el5.x86_64.rpm
-sudo rpm -Uvh riak-1.0.3-1.el5.x86_64.rpm
+wget http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/riak-{{V.V.V}}-1.el5.x86_64.rpm
+sudo rpm -Uvh riak-{{V.V.V}}-1.el5.x86_64.rpm
 ```
 
-{{/1.0.3}}
-{{#1.1.4}}
+{{/1.2.0-}}
+{{#1.2.0+}}
 
 ```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.1/1.1.4/riak-1.1.4-1.el5.x86_64.rpm
-sudo rpm -Uvh riak-1.1.4-1.el5.x86_64.rpm
+wget http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/rhel/5/riak-{{V.V.V}}-1.el5.x86_64.rpm
+sudo rpm -Uvh riak-{{V.V.V}}-1.el5.x86_64.rpm
 ```
 
-{{/1.1.4}}
-{{#1.2.0}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.0/rhel/5/riak-1.2.0-1.el5.x86_64.rpm
-sudo rpm -Uvh riak-1.2.0-1.el5.x86_64.rpm
-```
-
-{{/1.2.0}}
-{{#1.2.1}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/rhel/5/riak-1.2.1-1.el5.x86_64.rpm
-sudo rpm -Uvh riak-1.2.1-1.el5.x86_64.rpm
-```
-
-{{/1.2.1}}
-{{#1.3.0}}
-
-```bash
-wget http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.0/rhel/5/riak-1.3.0-1.el5.x86_64.rpm
-sudo rpm -Uvh riak-1.3.0-1.el5.x86_64.rpm
-```
-
-{{/1.3.0}}
-{{#1.3.1}}
-
-```bash
-wget http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.1/rhel/5/riak-1.3.1-1.el5.x86_64.rpm
-sudo rpm -Uvh riak-1.3.1-1.el5.x86_64.rpm
-```
-
-{{/1.3.1}}
+{{/1.2.0+}}
 
 ### For Centos 6 / RHEL 6
 
@@ -93,54 +61,22 @@ sudo yum install riak
 
 ...or install the rpm package manually.
 
-{{#1.0.3}}
+{{#1.2.0-}}
 
 ```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.0/1.0.3/riak-1.0.3-1.el6.x86_64.rpm
-sudo rpm -Uvh riak-1.0.3-1.el6.x86_64.rpm
+wget http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/riak-{{V.V.V}}-1.el6.x86_64.rpm
+sudo rpm -Uvh riak-{{V.V.V}}-1.el6.x86_64.rpm
 ```
 
-{{/1.0.3}}
-{{#1.1.4}}
+{{/1.2.0-}}
+{{#1.2.0+}}
 
 ```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.1/1.1.4/riak-1.1.4-1.el6.x86_64.rpm
-sudo rpm -Uvh riak-1.1.4-1.el6.x86_64.rpm
+wget http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/rhel/6/riak-{{V.V.V}}-1.el6.x86_64.rpm
+sudo rpm -Uvh riak-{{V.V.V}}-1.el6.x86_64.rpm
 ```
 
-{{/1.1.4}}
-{{#1.2.0}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.0/rhel/6/riak-1.2.0-1.el6.x86_64.rpm
-sudo rpm -Uvh riak-1.2.0-1.el6.x86_64.rpm
-```
-
-{{/1.2.0}}
-{{#1.2.1}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/rhel/6/riak-1.2.1-1.el6.x86_64.rpm
-sudo rpm -Uvh riak-1.2.1-1.el6.x86_64.rpm
-```
-
-{{/1.2.1}}
-{{#1.3.0}}
-
-```bash
-wget http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.0/rhel/6/riak-1.3.0-1.el6.x86_64.rpm
-sudo rpm -Uvh riak-1.3.0-1.el6.x86_64.rpm
-```
-
-{{/1.3.0}}
-{{#1.3.1}}
-
-```bash
-wget http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.1/rhel/6/riak-1.3.1-1.el6.x86_64.rpm
-sudo rpm -Uvh riak-1.3.1-1.el6.x86_64.rpm
-```
-
-{{/1.3.1}}
+{{/1.2.0+}}
 
 
 ## Installing From Source
@@ -164,67 +100,12 @@ sudo yum install gcc gcc-c++ glibc-devel make git
 
 Now we can download and install Riak:
 
-{{#1.0.3}}
-
 ```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.0/1.0.3/riak-1.0.3.tar.gz
-tar zxvf riak-1.0.3.tar.gz
-cd riak-1.0.3
+wget http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/riak-{{V.V.V}}.tar.gz
+tar zxvf riak-{{V.V.V}}.tar.gz
+cd riak-{{V.V.V}}
 make rel
 ```
-
-{{/1.0.3}}
-{{#1.1.4}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.1/1.1.4/riak-1.1.4.tar.gz
-tar zxvf riak-1.1.4.tar.gz
-cd riak-1.1.4
-make rel
-```
-
-{{/1.1.4}}
-{{#1.2.0}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.0/riak-1.2.0.tar.gz
-tar zxvf riak-1.2.0.tar.gz
-cd riak-1.2.0
-make rel
-```
-
-{{/1.2.0}}
-{{#1.2.1}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/riak-1.2.1.tar.gz
-tar zxvf riak-1.2.1.tar.gz
-cd riak-1.2.1
-make rel
-```
-
-{{/1.2.1}}
-
-{{#1.3.0}}
-
-```bash
-wget http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.3/1.3.0/riak-1.3.0.tar.gz
-tar zxvf riak-1.3.0.tar.gz
-cd riak-1.3.0
-make rel
-```
-
-{{/1.3.0}}
-{{#1.3.1}}
-
-```bash
-wget http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.1/riak-1.3.1.tar.gz
-tar zxvf riak-1.3.1.tar.gz
-cd riak-1.3.1
-make rel
-```
-
-{{/1.3.1}}
 
 You will now have a fresh build of Riak in the `rel/riak` directory.
 

--- a/source/languages/en/riak/tutorials/installation/Installing-on-SmartOS.md
+++ b/source/languages/en/riak/tutorials/installation/Installing-on-SmartOS.md
@@ -69,55 +69,55 @@ Download your version of the Riak binary package for SmartOS{{#1.3.0}} *(below w
 {{#1.2.1-}}
 
 ```bash
-curl -o /tmp/riak-1.2.0-SmartOS-i386.tgz http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.0/smartos/11/riak-1.2.0-SmartOS-i386.tgz
+curl -o /tmp/riak-{{V.V.V}}-SmartOS-i386.tgz http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/smartos/11/riak-{{V.V.V}}-SmartOS-i386.tgz
 ```
 
 Next, install the package:
 
 ```
-pkg_add /tmp/riak-1.2.0-SmartOS-i386.tgz
+pkg_add /tmp/riak-{{V.V.V}}-SmartOS-i386.tgz
 ```
 
 {{/1.2.1-}}
 {{#1.2.1}}
 
 ```bash
-curl -o /tmp/riak-1.2.1-SmartOS-i386.tgz http://downloads.basho.com.s3-website-us-east-1.amazonaws.com/riak/1.2/1.2.1/smartos/11/riak-1.2.1-SmartOS-i386.tgz
+curl -o /tmp/riak-{{V.V.V}}-SmartOS-i386.tgz http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/smartos/11/riak-{{V.V.V}}-SmartOS-i386.tgz
 ```
 
 Next, install the package:
 
 ```
-pkg_add /tmp/riak-1.2.1-SmartOS-i386.tgz
+pkg_add /tmp/riak-{{V.V.V}}-SmartOS-i386.tgz
 ```
 
 {{/1.2.1}}
 {{#1.3.0}}
 
 ```bash
-curl -o /tmp/riak-1.3.0-SmartOS-i386.tgz http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.0/smartos/1.6/riak-1.3.0-SmartOS-i386.tgz
+curl -o /tmp/riak-{{V.V.V}}-SmartOS-i386.tgz http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/smartos/1.6/riak-{{V.V.V}}-SmartOS-i386.tgz
 ```
 
 Next, install the package:
 
 ```
-pkg_add /tmp/riak-1.3.0-SmartOS-i386.tgz
+pkg_add /tmp/riak-{{V.V.V}}-SmartOS-i386.tgz
 ```
 
 {{/1.3.0}}
-{{#1.3.1}}
+{{#1.3.1+}}
 
 ```bash
-curl -o /tmp/riak-1.3.1-SmartOS-i386.tgz http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.1/smartos/1.8/riak-1.3.1-SmartOS-i386.tgz
+curl -o /tmp/riak-{{V.V.V}}-SmartOS-i386.tgz http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/smartos/1.8/riak-{{V.V.V}}-SmartOS-i386.tgz
 ```
 
 Next, install the package:
 
 ```
-pkg_add /tmp/riak-1.3.1-SmartOS-i386.tgz
+pkg_add /tmp/riak-{{V.V.V}}-SmartOS-i386.tgz
 ```
 
-{{/1.3.1}}
+{{/1.3.1+}}
 
 After installing the package, enable the Riak and Erlang Port Mapper Daemon (epmd) services:
 

--- a/source/languages/en/riak/tutorials/installation/Installing-on-Solaris.md
+++ b/source/languages/en/riak/tutorials/installation/Installing-on-Solaris.md
@@ -45,62 +45,16 @@ Note that you must restart to have the above settings take effect.
 
 Download your version of the Riak binary package for Solaris 10:
 
-{{#1.2.1-}}
-
 ```bash
-curl -o /tmp/BASHOriak-1.2.0-1-Solaris10-i386.pkg.gz http://s3.amazonaws.com/downloads.basho.com/riak/1.2/1.2.0/solaris/10/BASHOriak-1.2.0-1-Solaris10-i386.pkg.gz
+curl -o /tmp/BASHOriak-{{V.V.V}}-1-Solaris10-i386.pkg.gz http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/solaris/10/BASHOriak-{{V.V.V}}-1-Solaris10-i386.pkg.gz
 ```
 
 Next, install the package:
 
 ```bash
-gunzip /tmp/BASHOriak-1.2.0-1-Solaris10-i386.pkg.gz
-pkgadd /tmp/BASHOriak-1.2.0-1-Solaris10-i386.pkg
+gunzip /tmp/BASHOriak-{{V.V.V}}-1-Solaris10-i386.pkg.gz
+pkgadd /tmp/BASHOriak-{{V.V.V}}-1-Solaris10-i386.pkg
 ```
-
-{{/1.2.1-}}
-{{#1.2.1}}
-
-```bash
-curl -o /tmp/BASHOriak-1.2.1-1-Solaris10-i386.pkg.gz http://s3.amazonaws.com/downloads.basho.com/riak/1.2/1.2.1/solaris/10/BASHOriak-1.2.1-1-Solaris10-i386.pkg.gz
-```
-
-Next, install the package:
-
-```bash
-gunzip /tmp/BASHOriak-1.2.1-1-Solaris10-i386.pkg.gz
-pkgadd -d BASHOriak-1.2.1-1-Solaris10-i386.pkg
-```
-
-{{/1.2.1}}
-{{#1.3.0}}
-
-```bash
-curl -o /tmp/BASHOriak-1.3.0-1-Solaris10-i386.pkg.gz http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.0/solaris/10/BASHOriak-1.3.0-1-Solaris10-i386.pkg.gz
-```
-
-Next, install the package:
-
-```bash
-gunzip /tmp/BASHOriak-1.3.0-1-Solaris10-i386.pkg.gz
-pkgadd -d /tmp/BASHOriak-1.3.0-1-Solaris10-i386.pkg
-```
-
-{{/1.3.0}}
-{{#1.3.1}}
-
-```bash
-curl -o /tmp/BASHOriak-1.3.1-1-Solaris10-i386.pkg.gz http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.1/solaris/10/BASHOriak-1.3.1-1-Solaris10-i386.pkg.gz
-```
-
-Next, install the package:
-
-```bash
-gunzip /tmp/BASHOriak-1.3.1-1-Solaris10-i386.pkg.gz
-pkgadd -d /tmp/BASHOriak-1.3.1-1-Solaris10-i386.pkg
-```
-
-{{/1.3.1}}
 
 After installing the package, be sure to include `/opt/riak/bin` in the
 appropriate user's PATH. After doing so, you can then start Riak:


### PR DESCRIPTION
I've added a version directive. {{VERSION}}, {{V.V.V}}, {{V.V}} and {{V}} are replaced in a file by the version number of the given cardinality (major.minor.dot). {{VERSION}} is just a clearer way of denoting {{V.V.V}}.

eg. if your markdown text contained

```
You can download Riak version {{VERSION}} from
http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{V.V.V}}/riak-{{V.V.V}}.tar.gz
```

it wil be replaced by this in Riak version 1.2.1

```
You can download Riak version 1.2.1 from
http://s3.amazonaws.com/downloads.basho.com/riak/1.2/1.2.1/riak-1.2.1.tar.gz
```
