### PR TITLE
Generate old pages to redirect

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -47,6 +47,27 @@ ready do
     puts "== Indexing"
     build_yokozuna_index(sitemap.resources)
   end
+
+  if ENV.include?('OLDUNS')
+    puts "== Generating Olduns"
+    old_pages = {}
+    for resource in sitemap.resources
+      next unless resource.url =~ /\.(?:html)|\/$/
+      next if resource.url =~ /keywords/
+      next if %w{/404.html /index.html}.include?(resource.url)
+      next unless moved = (resource.metadata[:page] || {})['moved']
+
+      # for latest, redirect to url
+      old_pages[moved.values.first.to_s] = "#{resource.url}"
+    end
+
+    old_pages.each do |old_page, redir|
+      page "#{old_page}/index.html", :proxy => "/redirect.html", :directory_index => true, :ignore => true do
+        @project = 'riak'
+        @redir = redir
+      end
+    end
+  end
 end
 
 

--- a/source/redirect.erb
+++ b/source/redirect.erb
@@ -1,0 +1,17 @@
+---
+title: Redirect
+project: riak
+simple: true
+versions: false
+---
+
+<p>The page you're looking for has moved. You're being redirected to its new home.</p>
+<p>
+Please bookmark the correct page at 
+<%= link_to "/#{@project}/latest#{@redir}", "/latest#{@redir}" %>
+</p>
+
+<script>
+  function rdir(){ window.location = "/<%=@project%>/latest<%=@redir%>"; }
+  setTimeout(rdir, 3000);
+</script>


### PR DESCRIPTION
Since we've moved around so many pages, this script generates those old pages, and (delayed) redirects them to their new page counterparts, along with a reminder for users to update their bookmarks.
