### PR TITLE
Extend glossary to also be index

### DIFF
--- a/source/languages/en/riak/theory/concepts/glossary.md
+++ b/source/languages/en/riak/theory/concepts/glossary.md
@@ -28,7 +28,6 @@ time, potentially years. Furthermore, unlike the repair command, active anti-
 entropy is an automatic process, requiring no user intervention and is enabled
 by default in Riak 1.3.
 
-### References
 * [[Replication|Replication#Active-Anti-Entropy-AAE-]]
 
 ## Basho Bench
@@ -37,7 +36,6 @@ Basho Bench is a benchmarking tool created to conduct accurate and
 repeatable performance tests and stress tests, and produce performance
 graphs.
 
-### References
 * [[Basho Bench]]
 * [[GitHub repository|http://github.com/basho/basho_bench/]]
 
@@ -45,7 +43,6 @@ graphs.
 
 A Bucket is a container and keyspace for data stored in Riak, with a set of common properties for its contents (the number of replicas, or *n_val*, for instance).  Buckets are accessed at the top of the URL hierarchy under "riak", e.g. `/riak/bucket`.
 
-### References
 * [[Buckets]]
 * [[HTTP Bucket Operations|HTTP API#Bucket-Operations]]
 
@@ -53,7 +50,6 @@ A Bucket is a container and keyspace for data stored in Riak, with a set of comm
 
 A Riak cluster is a 160-bit integer space which is divided into equally-sized partitions. Each vnode in the Riak Ring is responsible for one of these partitions.
 
-### References
 * [[Clusters]]
 * [[Dynamo]]
 
@@ -61,7 +57,6 @@ A Riak cluster is a 160-bit integer space which is divided into equally-sized pa
 
 Consistent hashing is a technique used to limit the reshuffling of keys when a hash-table data structure is rebalanced (when slots are added or removed). Riak uses consistent hashing to organize its data storage and replication. Specifically, the vnodes in the Riak Ring responsible for storing each object are determined using the consistent hashing technique.
 
-### References
 * [[Clusters]]
 * [[Dynamo]]
 * [[Wikipedia:Consistent Hashing|http://en.wikipedia.org/wiki/Consistent_hashing]]
@@ -70,7 +65,6 @@ Consistent hashing is a technique used to limit the reshuffling of keys when a h
 
 Riak uses a "gossip protocol" to share and communicate ring state and bucket properties around the cluster.  Whenever a node changes its claim on the ring, it announces its change via this protocol.  Each node also periodically sends its current view of the ring state to a randomly-selected peer, in case any nodes missed previous updates.
 
-### References
 * [[Clusters]]
 * [[Adding and Removing Nodes|Adding and Removing Nodes#The-Node-Join-Process]]
 
@@ -80,14 +74,12 @@ Hinted handoff is a technique for dealing with node failure in the Riak cluster 
 
 Hinted handoff allows Riak to ensure database availability.  When a node fails, Riak can continue to handle requests as if the node were still there.
 
-### References
 * [[Recovering a Failed Node]]
 
 ## Key
 
 Keys are unique object identifiers in Riak and are scoped within buckets.
 
-### References
 * [[Keys and Objects]]
 * [[Developer Basics|The Basics]]
 
@@ -99,14 +91,12 @@ Keys are unique object identifiers in Riak and are scoped within buckets.
 
 Links are metadata attached to objects in Riak. These links make establishing relationships between objects in Riak as simple as adding a Link header to the request when storing the object.
 
-### References
 * [[Links]]
 
 ## MapReduce
 
 Riak's MapReduce gives developers the capability to perform more powerful queries over the data stored in their key/value data.
 
-### References
 * [[Using MapReduce]]
 * [[Advanced MapReduce]]
 
@@ -114,7 +104,6 @@ Riak's MapReduce gives developers the capability to perform more powerful querie
 
 A node is analogous to a physical server. Nodes run a certain number of vnodes, each of which claims a partition in the Riak Ring key space.
 
-### References
 * [[Clusters]]
 * [[Adding and Removing Nodes]]
 
@@ -122,7 +111,6 @@ A node is analogous to a physical server. Nodes run a certain number of vnodes, 
 
 An object is another name for a value.
 
-### References
 * [[Keys and Objects]]
 * [[Developer Basics|The Basics]]
 
@@ -130,7 +118,6 @@ An object is another name for a value.
 
 Partitions are the spaces into which a Riak cluster is divided. Each vnode in Riak is responsible for a partition. Data are stored on a set number of partitions determined by the *n_val* setting, with the target partitions chosen statically by applying consistent hashing to an object's key.
 
-### References
 * [[Clusters]]
 * [[Eventual Consistency]]
 * [[Cluster Capacity Planning|Cluster Capacity Planning#Ring-Size-Number-of-Partitions]]
@@ -142,7 +129,6 @@ Quorum in Riak has two meanings:
 * The quantity of replicas that must respond to a read or write request before it is considered successful. This is defined as a bucket property or as one of the relevant parameters to a single request (R,W,DW,RW).
 * A symbolic quantity for the above, `quorum`, which is equivalent to `n_val / 2 + 1`. With Riak's default settings, this is `2`.
 
-### References
 * [[Eventual Consistency]]
 * [[CAP Controls]]
 * [[Understanding Riak's Configurable Behaviors: Part 2|http://basho.com/riaks-config-behaviors-part-2/]]
@@ -151,14 +137,12 @@ Quorum in Riak has two meanings:
 
 Read repair is an anti-entropy mechanism Riak uses to optimistically update stale replicas when they reply to a read request with stale data.
 
-### References
 * [[More about Read Repair|Replication]]
 
 ## Replica
 
 Replicas are copies of data stored in Riak. The number of replicas required for both successful reads and writes is configurable in Riak and should be set based on your application's consistency and availability requirements.
 
-### References
 * [[Eventual Consistency]]
 * [[Understanding Riak's Configurable Behaviors: Part 2|http://basho.com/riaks-config-behaviors-part-2/]]
 
@@ -166,7 +150,6 @@ Replicas are copies of data stored in Riak. The number of replicas required for 
 
 Riak Core is the modular distributed systems framework that serves as the foundation for Riak's scalable architecture.
 
-### References
 * [[Riak Core|https://github.com/basho/riak_core]]
 * [[Where To Start With Riak Core|http://basho.com/where-to-start-with-riak-core/]]
 
@@ -174,14 +157,12 @@ Riak Core is the modular distributed systems framework that serves as the founda
 
 Riak KV is the key/value datastore for Riak.
 
-### References
 * [[Riak KV|https://github.com/basho/riak_kv]]
 
 ## Riak Pipe
 
 Riak Pipe is the processing layer that powers Riak's MapReduce. It's best described as "UNIX pipes for Riak."
 
-### References
 * [[Riak Pipe|https://github.com/basho/riak_pipe]]
 * [[Riak Pipe - the New MapReduce Power|http://basho.com/riak-pipe-the-new-mapreduce-power/]]
 * [[Riak Pipe - Riak's Distributed Processing Framework|http://vimeo.com/53910999]]
@@ -190,7 +171,6 @@ Riak Pipe is the processing layer that powers Riak's MapReduce. It's best descri
 
 Riak Search is a distributed, scalable, failure-tolerant, real-time, full-text search engine built around Riak Core and tightly integrated with Riak KV.
 
-### References
 * [[Using Search]]
 * [[Advanced Search]]
 
@@ -198,7 +178,6 @@ Riak Search is a distributed, scalable, failure-tolerant, real-time, full-text s
 
 The Riak Ring is a 160-bit integer space. This space is equally divided into partitions, each of which is claimed by a vnode, which themselves reside on actual physical server nodes.
 
-### References
 * [[Clusters]]
 * [[Dynamo]]
 * [[Cluster Capacity Planning|Cluster Capacity Planning#Ring-Size-Number-of-Partitions]]
@@ -207,7 +186,6 @@ The Riak Ring is a 160-bit integer space. This space is equally divided into par
 
 Secondary Indexing in Riak gives developers the ability to tag an object stored in Riak with one or more values which can then be queried.
 
-### References
 * [[Using Secondary Indexes]]
 * [[Advanced Secondary Indexes]]
 * [[Repairing Indexes]]
@@ -216,7 +194,6 @@ Secondary Indexing in Riak gives developers the ability to tag an object stored 
 
 Riak is most-easily described as a key/value store. In Riak, "values" are opaque BLOBS (binary large objects), identified with a unique key, that can be any type of data, though some programming advantages are gained by using JSON.
 
-### References
 * [[Keys and Objects]]
 * [[Developer Basics|The Basics]]
 
@@ -224,13 +201,11 @@ Riak is most-easily described as a key/value store. In Riak, "values" are opaque
 
 Riak utilizes vector clocks (or _vclock_) to handle version control. Since any node in a Riak cluster is able to handle a request, and not all nodes need to participate, data versioning is required to keep track of a current value. When a value is stored in Riak, it is tagged with a vector clock and establishes the initial version. When it is updated, the client provides the vector clock of the object being modified so that this vector clock can be extended to reflect the update.  Riak can then compare vector clocks on different versions of the object and determine certain attributes of the data.
 
-### References
 * [[Vector clocks]]
 
 ## Vnode
 
 Vnodes, or "virtual nodes" are responsible for claiming a partition in the Riak Ring, and they coordinate requests for these partitions. Vnodes reside on physical nodes in a Riak cluster, and the number of vnodes per physical node is determined by the total number of vnodes and the number of active physical nodes in the cluster. Riak balances the assignment of vnodes across the active physical nodes.
 
-### References
 * [[Clusters]]
 * [[Dynamo]]


### PR DESCRIPTION
To help with discoverability/findability, add key documents for each topic.

Also cross-reference the Concepts document, add basho_bench, and shorten the kv definition.

I want to make the list of references include icons to indicate where the referenced documents live (theory, ops, dev, Basho blog, GitHub) but that can wait for another PR. Barrett is working on the necessary design magic.
