### PR TITLE
Correct some of the misconceptions about how to run Riak in Classic-EC2 (not VPC).

### DIFF
--- a/source/languages/en/riak/ops/advanced/configs/configuration-files.md
+++ b/source/languages/en/riak/ops/advanced/configs/configuration-files.md
@@ -63,6 +63,9 @@ Note that lines prefixed with `%%` are comments
 
     %% binds to a specific IPv6 interface
     {pb_ip, {65152,0,0,0,64030,57343,65250,15801}}
+
+    %% binds to all IPv4 address(es)
+    {pb_ip, "0.0.0.0"}
     ```
     {{/1.3.0+}}
 
@@ -414,7 +417,7 @@ Erlang Runtime Configuration Options
 #### -name
 Name of the Erlang node. (default: `riak@127.0.0.1`)
 
-The default value, riak@127.0.0.1 will work for running Riak locally, but for distributed (multi-node) use, the portion of the name after the "@" should be changed to the IP address of the machine on which the node is running.
+The default value, riak@127.0.0.1 will work for running Riak locally, but for distributed (multi-node) use, the portion of the name after the "@" should be changed to the Hostname (FQDN) or IP address of the machine on which the node is running.
 
 If you have properly-configured DNS, the short-form of this name can be used (for example: "riak"). The name of the node will then be "riak@Host.Domain".
 

--- a/source/languages/en/riak/ops/building/basic-cluster-setup.md
+++ b/source/languages/en/riak/ops/building/basic-cluster-setup.md
@@ -66,6 +66,11 @@ becomes
 
     {pb_ip,   "192.168.1.10" },
 
+<div class="info">
+<strong>Wildcard IP Address</strong>
+<p>Note that you may use the address "0.0.0.0" for these listen parameters if your server may change local addresses (such as in AWS)</p>
+</div>
+
 
 Next edit the `etc/vm.args` file and change the `-name` to the correct hostname:
 
@@ -78,7 +83,7 @@ becomes
 <div class="info">
 <strong>Node Names</strong>
 <p>Use fully qualified domain names (FQDNs) rather than IP addresses
-for the cluster member node names. For example, "riak@cluster.example.com" and "riak@192.168.1.10" are both acceptable node naming schemes, but using the FQDN style is preferred.</p>
+for the cluster member node names. For example, "riak@cluster.example.com" and "riak@192.168.1.10" are both acceptable node naming schemes, but using the FQDN style is preferred. This is because the FQDN's IP address can be changed easily using DNS.</p>
 <p>Once a node has been started, in order to change the name you must either remove ring files from the data directory, [[riak-admin reip|riak-admin Command Line#reip]] the node, or [[riak-admin cluster force-replace|riak-admin Command Line#cluster-force-replace]] the node.
 </p>
 </div>

--- a/source/languages/en/riak/ops/building/installing/aws-marketplace.md
+++ b/source/languages/en/riak/ops/building/installing/aws-marketplace.md
@@ -55,6 +55,8 @@ You will need need to launch at least 3 instances to form a Riak cluster.  When 
 
  You can find more information on connecting to an instance on the official [Amazon EC2 instance guide] (http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/AccessingInstances.html).
 
+ *WARNING:* The following clustering setup will *not* be resilient to instance restarts unless deployed in Amazon VPC. For hints on how to deploy in Classic EC2, see [/ops/tuning/aws] (AWS Tuning)
+
 1. On the first node obtain the internal IP address:
 
     ```text


### PR DESCRIPTION
I blew innumerable hours trying to set up a VPC environment for my Riak cluster, then ran into serious problems with my other systems there (Riak was fine!) - so I finally went back to Classic EC2, and worked out some of the kinks with how to do that in a way that makes sense and is durable.

I've tried to take a first pass at modifying the documentation to match with what I've discovered.

One point I'm really curious about - the "binding to 0.0.0.0" concept - I noticed it's not featured at all in the documentation, but the Riak AMI seems to do it. I've mentioned it at least briefly in the documentation, but I figured either:

a) It's a bad idea - if so, we should talk about why.
or 
b) It's totally fine - in which case, why doesn't this feature more prominently?

I can totally get why the default install doesn't open itself up (binding to localhost) - Riak open to the world would _not_ be good.
