### PR TITLE
Fix the quick start for v3 replication in the global navigation

### DIFF
--- a/source/languages/en/global_nav.yml
+++ b/source/languages/en/global_nav.yml
@@ -224,7 +224,7 @@ riakee:
           - "[[Architecture|Multi Data Center Replication v3 Architecture]]"
           - "[[Configuration|Multi Data Center Replication v3 Configuration]]"
           - "[[Operations|Multi Data Center Replication v3 Operations]]"
-          - "[[Quick Start|Multi Data Center Replication: v3 Quick Start]]"
+          - "[[Quick Start|Multi Data Center Replication v3 Quick Start]]"
           - "[[Scheduling Full Sync|Multi Data Center Replication v3 Scheduling Full Sync]]"
           - "[[SSL|Multi Data Center Replication v3 SSL]]"
           - "[[With NAT|Multi Data Center Replication v3 With NAT]]"

--- a/source/languages/en/riakee/cookbooks/Multi-Data-Center-Replication-v3-Quick-Start.md
+++ b/source/languages/en/riakee/cookbooks/Multi-Data-Center-Replication-v3-Quick-Start.md
@@ -1,5 +1,5 @@
 ---
-title: "Multi Data Center Replication Quick Start (v3)"
+title: "Multi Data Center Replication v3 Quick Start"
 project: riakee
 version: 1.3.0+
 document: cookbook


### PR DESCRIPTION
Made navigation references (or titles) consistent so that the v3 quick start link works.
