### PR TITLE
Fix issue with bold text and rename ad banners.

### DIFF
--- a/source/css/common.css.scss
+++ b/source/css/common.css.scss
@@ -15,14 +15,12 @@
 
 .serif-italic {
   @extend .serif;
-  //font-family : 'GandhiSerifItalic', serif;
   font-style : italic;
 }
 
 .sans-bold {
-  //@extend .sans;
-  font-family : 'OpenSansBold', verdana, arial, sans-serif;
-  font-weight : normal;
+  @extend .sans;
+  font-weight : bold;
 }
 
 .sans-light {
@@ -84,14 +82,14 @@
 }
 
 .button-light-green {
-  padding       : 3px 8px;
-  background    : $subtleBlueGreen;
-  text-align    : center;
-  cursor        : pointer;
-  color         : $darkBlueGreen;
-  font-size     : 0.75rem;
-  font-family   : 'OpenSansBold', verdana, sans-serif;
-  border        : 1px solid $lightBlueGreen;
+  @extend .sans-bold;
+  padding    : 3px 8px;
+  background : $subtleBlueGreen;
+  text-align : center;
+  cursor     : pointer;
+  color      : $darkBlueGreen;
+  font-size  : 0.75rem;
+  border     : 1px solid $lightBlueGreen;
   @include allCorners();
   //@include transitionAll(all 0.5s ease);
 
@@ -235,9 +233,11 @@ body {
     p, div {
       b, strong {
         font-weight: bold;
-        font-family: serif;
-        font-size: 110%
       }
+    }
+
+    p b, p strong {
+      font-size: 110%;
     }
 
     @media screen and (max-width: 700px) {
@@ -281,8 +281,8 @@ body {
 
   &.root {
     div[role="main"] {
-      #ricon-ad,
-      a#ricon-ad-responsive {
+      #ricon-temp-banner,
+      a#ricon-temp-banner-responsive {
         position : fixed;
         top      : 0;
         left     : 0;
@@ -1136,8 +1136,7 @@ div[role="main"] {
         @extend .horizontal-rule;
         margin : 0 0 6px 0;
         padding : 0 0 6px 0;
-        font-size   : 0.9rem;
-        //font-weight : bold;
+        font-size : 0.9rem;
       }
 
       ul {
@@ -1174,7 +1173,7 @@ div[role="main"] {
     }
   }
 
-  #ricon-ad {
+  #ricon-temp-banner {
     position     : relative;
     height       : 56px;
     background   : rgba(190, 216, 220, 1.0);
@@ -1187,7 +1186,7 @@ div[role="main"] {
     color : rgba(68, 93, 90, 1.0);
     //rgba(209, 227, 229, 1.0)
 
-    .ad-text {
+    .temp-banner-text {
       padding-top : 15px;
       font-size   : 0.9rem;
     }
@@ -1206,7 +1205,7 @@ div[role="main"] {
     }
   }
 
-  a#ricon-ad-responsive {
+  a#ricon-temp-banner-responsive {
     display : none;
     @extend .sans-bold;
     

--- a/source/css/downloads.css.scss
+++ b/source/css/downloads.css.scss
@@ -104,8 +104,7 @@
       .title {
         display: block;
         color: white;
-        font-family: 'titillium', verdana, arial, sans-serif;
-        font-weight: bold;
+        @extend .sans-bold;
         font-size: 52px;
         letter-spacing: -0.02em;
         padding-right: 52px;

--- a/source/css/fonts.css.scss
+++ b/source/css/fonts.css.scss
@@ -64,13 +64,13 @@
 }
 
 @font-face {
-    font-family: 'OpenSansBold';
+    font-family: 'OpenSans';
     src: url('../fonts/opensans-bold-webfont-eot.eot');
     src: url('../fonts/opensans-bold-webfont-eot.eot?#iefix') format('embedded-opentype'),
          url('../fonts/opensans-bold-webfont-woff.woff') format('woff'),
          url('../fonts/opensans-bold-webfont-ttf.ttf') format('truetype'),
          url('../fonts/opensans-bold-webfont-svg.svg#opensans-bold') format('svg');
-    font-weight: normal;
+    font-weight: bold;
     font-style: normal;
     text-rendering: optimizeLegibility;
 }
@@ -102,13 +102,13 @@
 }
 
 @font-face {
-    font-family: 'GandhiSerifBold';
+    font-family: 'GandhiSerif';
     src: url('../fonts/gandhiserif-bold-webfont-eot.eot');
     src: url('../fonts/gandhiserif-bold-webfont-eot.eot?#iefix') format('embedded-opentype'),
          url('../fonts/gandhiserif-bold-webfont-woff.woff') format('woff'),
          url('../fonts/gandhiserif-bold-webfont-ttf.ttf') format('truetype'),
          url('../fonts/gandhiserif-bold-webfont-svg.svg#gandhiserif-bold') format('svg');
-    font-weight: normal;
+    font-weight: bold;
     font-style: normal;
     text-rendering: optimizeLegibility;
 }
@@ -126,13 +126,13 @@
 }
 */
 @font-face {
-    font-family: 'GandhiSerifBoldItalic';
+    font-family: 'GandhiSerif';
     src: url('../fonts/gandhiserif-bolditalic-webfont-eot.eot');
     src: url('../fonts/gandhiserif-bolditalic-webfont-eot.eot?#iefix') format('embedded-opentype'),
          url('../fonts/gandhiserif-bolditalic-webfont-woff.woff') format('woff'),
          url('../fonts/gandhiserif-bolditalic-webfont-ttf.ttf') format('truetype'),
          url('../fonts/gandhiserif-bolditalic-webfont-svg.svg#gandhiserif-bolditalic') format('svg');
-    font-weight: normal;
+    font-weight: bold;
     font-style: italic;
     text-rendering: optimizeLegibility;
 }

--- a/source/languages/en/index.slim
+++ b/source/languages/en/index.slim
@@ -10,8 +10,8 @@ skip_nav: true
 versions: false
 ---
 
-div#ricon-ad
-  div.ad-text
+div#ricon-temp-banner
+  div.temp-banner-text
     == I18n.t(:ricon_ad)
 h1.center-text.extra-large
   | Welcome&nbsp;

--- a/source/layouts/_header.slim
+++ b/source/layouts/_header.slim
@@ -1,7 +1,7 @@
 header.masthead
   #header
-    div#ricon-ad
-      div.ad-text
+    div#ricon-temp-banner
+      div.temp-banner-text
         == I18n.t(:ricon_ad)
     div#header-inner
       div#nav-toggle class="icon-reorder"
@@ -26,4 +26,4 @@ header.masthead
         div#nav-menu-arrow-back
       div.clear
       div.header-rule
-a#ricon-ad-responsive href="http://ricon-west-2013.eventbrite.com/" Register for RICON West
+a#ricon-temp-banner-responsive href="http://ricon-west-2013.eventbrite.com/" Register for RICON West


### PR DESCRIPTION
Fixed some issues in fonts.scss so that opensans regular and opensans bold
are now in the same font family.  Also, ghandi serif bold-italic is now in
the ghandi serif family. Using a "b" or a "strong" tag now causes fonts to
be bold and appropriately uses sans-serif or serif depending on context.

I also noticed that the ad banner's id was triggering my ad-block software.
I renamed all ID's that contained "ad" to contain "temp-banner" instead so
as not to trigger ad-block software.
