### PR TITLE
Centralizing footer on home

### DIFF
--- a/source/css/common.css.scss
+++ b/source/css/common.css.scss
@@ -306,6 +306,12 @@ body {
   }
 }
 
+body.root {
+  footer.mastfooter {
+    margin: 25px auto;
+  }
+}
+
 
 /* =============================================================================
    Main Element Styles


### PR DESCRIPTION
In the home of docs, the footer looks align to left. This pull request just change it.
