### PR TITLE
Fix default Keystone authentication port and add trailing slash

### DIFF
--- a/source/languages/en/riakcs/cookbooks/Using-Riak-CS-With-Keystone.md
+++ b/source/languages/en/riakcs/cookbooks/Using-Riak-CS-With-Keystone.md
@@ -115,11 +115,11 @@ can be set by adding the following the Riak CS configuration file:
 
 Riak CS also needs to know the authentication URL to use to
 communicate with Keystone. The default value is
-`"http://localhost:5000/v2.0"`. To override this value add the following
+`"http://localhost:35357/v2.0/"`. To override this value add the following
 to the Riak CS configuration file:
 
 ```
-{os_auth_url, "http://host.with.the.most.com/5000/v2.0"}
+{os_auth_url, "http://host.with.the.most.com:35357/v2.0/"}
 ```
 
 #### Keystone Resources


### PR DESCRIPTION
These two little guys caused me some grief. A reference to the line number in the Riak CS codebase where the defaults are set is below:

https://github.com/basho/riak_cs/blob/985b57db524f3c92481384b9dd14a7fc338fce7e/include/oos_api.hrl#L21
