### PR TITLE
Additional instructions for Linux systems with PAM.

### DIFF
--- a/source/languages/en/riak/ops/tuning/open-files-limit.md
+++ b/source/languages/en/riak/ops/tuning/open-files-limit.md
@@ -48,15 +48,15 @@ sysctl fs.file-max
 fs.file-max = 50384
 ```
 
-As seen above, it is generally set high enough for Riak. If you have other things running on the system, you might want to consult the [[sysctl manpage|http://linux.die.net/man/8/sysctl]] for how to change that setting. However, what most needs to be changed is the per-user open files limit. This requires editing /etc/security/limits.conf, which you’ll need superuser access to change. If you installed Riak or Riak Search from a binary package, add lines for the riak user like so, substituting your desired hard and soft limits:
+As seen above, it is generally set high enough for Riak. If you have other things running on the system, you might want to consult the [[sysctl manpage|http://linux.die.net/man/8/sysctl]] for how to change that setting. However, what most needs to be changed is the per-user open files limit. This requires editing `/etc/security/limits.conf`, which you’ll need superuser access to change. If you installed Riak or Riak Search from a binary package, add lines for the riak user like so, substituting your desired hard and soft limits:
 
-On Ubuntu, if you’re always relying on the init scripts to start Riak, you can create the file /etc/default/riak and specify a manual limit like so:
+On Ubuntu, if you’re always relying on the init scripts to start Riak, you can create the file `/etc/default/riak` and specify a manual limit like so:
 
 ```bash
 ulimit -n 65536
 ```
 
-This file is automatically sourced from the init script, and the Riak process started by it will properly inherit this setting. As init scripts are always run as the root user, there’s no need to specifically set limits in /etc/security/limits.conf if you’re solely relying on init scripts.
+This file is automatically sourced from the init script, and the Riak process started by it will properly inherit this setting. As init scripts are always run as the root user, there’s no need to specifically set limits in `/etc/security/limits.conf` if you’re solely relying on init scripts.
 
 On CentOS/RedHat systems make sure to set a proper limit for the user you’re usually logging in with to do any kind of work on the machine, including managing Riak. On CentOS, sudo properly inherits the values from the executing user.
 
@@ -69,6 +69,8 @@ It can be helpful to enable PAM user limits so that non-root users, such as the 
   1. Edit `/etc/pam.d/common-session` and append the following line:
 
          session    required   pam_limits.so
+
+     If `/etc/pam.d/common-session-noninteractive` exists, append the same line as above.
 
   2. Save and close the file.
 


### PR DESCRIPTION
Added instructions to edit the
`/etc/pam.d/common-session-noninteractive` file when present to ensure
that `pam_limits.so` is appended to that file.

This has caused issues with Ubuntu users on the mailing list. Verified on a Ubuntu 12 LTS VM.
