### PR TITLE
Clarify sibling creation.

### DIFF
--- a/source/languages/en/riak/theory/concepts/Vector-Clocks.md
+++ b/source/languages/en/riak/theory/concepts/Vector-Clocks.md
@@ -34,8 +34,8 @@ divergent changesets in an application specific manner.
 ## Siblings
 
 A _sibling_ is created when Riak is unable to resolve the canonical version of
-an object being stored.  If `allow_mult` is set to true on a bucket's
-properties, three scenarios will create siblings inside of a single object.
+an object being stored. These scenarios can create siblings inside of a single
+object.
 
 1. **Concurrent writes** If two writes occur simultaneously from
 clients with the same vector clock value, Riak will not be able to


### PR DESCRIPTION
Siblings can be created inside Riak regardless of the `allow_mult`
setting. The previous wording implies that `allow_mult = true` must be
set for this to happen.

Later on the document explains that only `last_write_wins = true` will prevent sibling creation inside of Riak.

Maybe we should use this ML message as a guide for reworking this?

http://lists.basho.com/pipermail/riak-users_lists.basho.com/2011-November/006325.html
