### PR TITLE
Fix some links.

### DIFF
--- a/source/languages/en/riak/theory/comparisons/couchdb.md
+++ b/source/languages/en/riak/theory/comparisons/couchdb.md
@@ -33,7 +33,7 @@ The table below gives a high level comparison of Riak and CouchDB features/capab
         <td>Data Model</td>
         <td>Riak stores key/value pairs in a higher level namespace called a bucket.
             <ul>
-              <li>[[Buckets, Keys, and Values|Concepts#Buckets%2C-Keys%2C-and-Values]] </li>
+              <li>[[Buckets, Keys, and Values|Concepts#Buckets-Keys-and-Values]] </li>
             </ul>
         </td>
         <td>CouchDB's data format is JSON stored as documents (self-contained records with no intrinsic relationships), grouped into "database" namespaces.
@@ -142,7 +142,7 @@ The table below gives a high level comparison of Riak and CouchDB features/capab
 
             The Riak APIs expose tunable consistency and availability parameters that let you select which level configuration is best for your use case. Replication is configurable at the bucket level when first storing data in Riak. Subsequent reads and writes to that data can have request-level parameters.
                 <ul>
-                    <li>[[Reading, Writing, and Updating Data|Concepts#Reading%2C-Writing%2C-and-Updating-Data]]</li>
+                    <li>[[Reading, Writing, and Updating Data|Concepts#Reading-Writing-and-Updating-Data]]</li>
                 </ul>
 
      </td>

--- a/source/languages/en/riak/theory/concepts/Buckets.md
+++ b/source/languages/en/riak/theory/concepts/Buckets.md
@@ -41,8 +41,8 @@ conflict. See [[Conflict resolution|Concepts#Conflict-resolution]].
 
 `all`, `quorum`, `one`, or an *integer* (default: `quorum`). Sets for reads and
 writes the number of responses required before an operation is considered
-successful. See [[Reading Data|Concepts#Reading-Data]] and [[Writing and
-Updating Data|Concepts#Writing and Updating Data]].
+successful. See [[Reading Data|Concepts#Reading-Writing-and-Updating-Data]] and [[Writing and
+Updating Data|Concepts#Reading-Writing-and-Updating-Data]].
 
 ### precommit
 


### PR DESCRIPTION
The `Reading-Data` and `Writing-Data` anchors no longer exist.
