### PR TITLE
Ensure consistent use of 'indexes'

### DIFF
--- a/source/languages/en/riak/dev/data-modeling/session-storage.md
+++ b/source/languages/en/riak/dev/data-modeling/session-storage.md
@@ -18,7 +18,7 @@ Riak was originally created to serve as a highly scalable session store.   This 
 
 ## Complex Case
 
-Riak has other features that enable more complex session storage use cases.  The bitcask storage backend supports automatic expiry of keys, which frees application developers from implementing manual session expiry.  Riak's MapReduce system can also be used to perform analysis on large bodies of session data, for example to compute the average number of active users.  If sessions must be retrieved using multiple keys (e.g. a UUID or email address), Secondary Indices (2I) provides an easy solution.
+Riak has other features that enable more complex session storage use cases.  The bitcask storage backend supports automatic expiry of keys, which frees application developers from implementing manual session expiry.  Riak's MapReduce system can also be used to perform analysis on large bodies of session data, for example to compute the average number of active users.  If sessions must be retrieved using multiple keys (e.g. a UUID or email address), Secondary Indexes (2I) provides an easy solution.
 
 ## Community Examples
 

--- a/source/languages/en/riak/dev/taste-of-riak/querying-erlang.md
+++ b/source/languages/en/riak/dev/taste-of-riak/querying-erlang.md
@@ -241,11 +241,11 @@ Which returns:
                       undefined,undefined}}
 ```
 
-Boom, easy-peasy.  We used 2i's range feature to search for a range of values, and demonstrated binary indices.  
+Boom, easy-peasy.  We used 2i's range feature to search for a range of values, and demonstrated binary indexes.  
 
 So to recap:
 
-* You can use Secondary Indices to quickly lookup an object based on a secondary id other than the object's key. 
+* You can use Secondary Indexes to quickly lookup an object based on a secondary id other than the object's key.
 * Indices can have either Integer or Binary(String) keys
 * You can search for specific values, or a range of values
 * Riak will return a list of keys that match the index query

--- a/source/languages/en/riak/dev/taste-of-riak/querying-java.md
+++ b/source/languages/en/riak/dev/taste-of-riak/querying-java.md
@@ -8,12 +8,12 @@ audience: beginner
 keywords: [developers, client, 2i, search, linkwalking, java]
 ---
 
-Now that we've had a taste of the CRUD interface for Riak, let's look into three other ways of querying for data - Link Walking, Secondary Indices, and Riak Search.  
+Now that we've had a taste of the CRUD interface for Riak, let's look into three other ways of querying for data - Link Walking, Secondary Indexes, and Riak Search.  
 
 ###Links
 
 ###Secondary Indexes
 
-If you're coming from a SQL world, Secondary Indexes (2i) are a lot like SQL indexes.  They are a way to lookup objects based on a secondary key, or tag.  Ordinary Key/Value data is opaque to 2i, so we have to add entries to the indices at the application level.
+If you're coming from a SQL world, Secondary Indexes (2i) are a lot like SQL indexes.  They are a way to lookup objects based on a secondary key, or tag.  Ordinary Key/Value data is opaque to 2i, so we have to add entries to the indexes at the application level.
 
 ### Search

--- a/source/languages/en/riak/dev/taste-of-riak/querying-php.md
+++ b/source/languages/en/riak/dev/taste-of-riak/querying-php.md
@@ -8,12 +8,12 @@ audience: beginner
 keywords: [developers, client, 2i, search, linkwalking, php]
 ---
 
-Now that we've had a taste of the CRUD interface for Riak, let's look into three other ways of querying for data - Link Walking, Secondary Indices, and Riak Search.  
+Now that we've had a taste of the CRUD interface for Riak, let's look into three other ways of querying for data - Link Walking, Secondary Indexes, and Riak Search.  
 
 ###Links
 
 ###Secondary Indexes
 
-If you're coming from a SQL world, Secondary Indexes (2i) are a lot like SQL indexes.  They are a way to lookup objects based on a secondary key, or tag.  Ordinary Key/Value data is opaque to 2i, so we have to add entries to the indices at the application level.
+If you're coming from a SQL world, Secondary Indexes (2i) are a lot like SQL indexes.  They are a way to lookup objects based on a secondary key, or tag.  Ordinary Key/Value data is opaque to 2i, so we have to add entries to the indexes at the application level.
 
 ### Search

--- a/source/languages/en/riak/dev/taste-of-riak/querying-python.md
+++ b/source/languages/en/riak/dev/taste-of-riak/querying-python.md
@@ -8,12 +8,12 @@ audience: beginner
 keywords: [developers, client, 2i, search, linkwalking, python]
 ---
 
-Now that we've had a taste of the CRUD interface for Riak, let's look into three other ways of querying for data - Link Walking, Secondary Indices, and Riak Search.  
+Now that we've had a taste of the CRUD interface for Riak, let's look into three other ways of querying for data - Link Walking, Secondary Indexes, and Riak Search.  
 
 ###Links
 
 ###Secondary Indexes
 
-If you're coming from a SQL world, Secondary Indexes (2i) are a lot like SQL indexes.  They are a way to lookup objects based on a secondary key, or tag.  Ordinary Key/Value data is opaque to 2i, so we have to add entries to the indices at the application level.
+If you're coming from a SQL world, Secondary Indexes (2i) are a lot like SQL indexes.  They are a way to lookup objects based on a secondary key, or tag.  Ordinary Key/Value data is opaque to 2i, so we have to add entries to the indexes at the application level.
 
 ### Search

--- a/source/languages/en/riak/dev/taste-of-riak/querying-ruby.md
+++ b/source/languages/en/riak/dev/taste-of-riak/querying-ruby.md
@@ -176,7 +176,7 @@ If you're coming from a SQL world, Secondary Indexes (2i) are a lot like SQL ind
 end
 ```
 
-As you may have noticed, ordinary Key/Value data is opaque to 2i, so we have to add entries to the indices at the application level. 
+As you may have noticed, ordinary Key/Value data is opaque to 2i, so we have to add entries to the indexes at the application level. 
 Now let's find all of Jane Appleseed's processed orders, we'll look up the orders by searching the `saleperson_id_int` index for Jane's id of `9000`.
 
 ```ruby
@@ -202,12 +202,12 @@ Which returns:
 => ["1", "2"]
 ```
 
-Boom, easy-peasy.  We used 2i's range feature to search for a range of values, and demonstrated binary indices.  
+Boom, easy-peasy.  We used 2i's range feature to search for a range of values, and demonstrated binary indexes.  
 
 So to recap:
 
-* You can use Secondary Indices to quickly lookup an object based on a secondary id other than the object's key. 
-* Indices can have either Integer or Binary(String) keys
+* You can use Secondary Indexes to quickly lookup an object based on a secondary id other than the object's key. 
+* Indexes can have either Integer or Binary(String) keys
 * You can search for specific values, or a range of values
 * Riak will return a list of keys that match the index query
 

--- a/source/languages/en/riak/dev/taste-of-riak/querying.md
+++ b/source/languages/en/riak/dev/taste-of-riak/querying.md
@@ -8,7 +8,7 @@ audience: beginner
 keywords: [developers, client, 2i, search]
 ---
 
-Now that we've had a taste of the CRUD interface for Riak, let's look into a few ways to lay out and query our data - Secondary Indices and Key/Value.
+Now that we've had a taste of the CRUD interface for Riak, let's look into a few ways to lay out and query our data - Secondary Indexes and Key/Value.
 
 ###Configuration Changes
 Before we experiment with these methods, we will have to change our Riak instance's configuration a little bit.  
@@ -23,7 +23,7 @@ Open the `app.config` file in your favorite text editor.
 
 Search for the string `{riak_kv`, this will bring you to the configuration section for Riak's Key/Value component.
 Change the line `{storage_backend, riak_kv_bitcask_backend},` to `{storage_backend, riak_kv_eleveldb_backend},`.  
-This will make Riak use LevelDB for it's backend instead of Bitcask.  LevelDB supports Secondary Indices (2i), which we will be using for our examples.
+This will make Riak use LevelDB for it's backend instead of Bitcask.  LevelDB supports Secondary Indexes (2i), which we will be using for our examples.
 
 
 Save your app.config, and restart riak by executing `riak restart` from the command line.  

--- a/source/languages/en/riak/ops/building/installing/with-chef.md
+++ b/source/languages/en/riak/ops/building/installing/with-chef.md
@@ -169,7 +169,7 @@ default['riak']['config']['riak_sysmon']['busy_dist_port'] = true
 
 ### Index Merge
 
-Settings pertaining to Secondary Index and Riak Search indices.
+Settings pertaining to Secondary Index and Riak Search indexes.
 
 ```ruby
 default['riak']['config']['merge_index']['data_root'] = "/var/lib/riak/merge_index".to_erl_string


### PR DESCRIPTION
It looks like 'indexes' is the preferred pluralization throughout the
basho docs.
