### PR TITLE
Standardize on "indexes".

### DIFF
--- a/source/languages/en/riak/dev/data-modeling/session-storage.md
+++ b/source/languages/en/riak/dev/data-modeling/session-storage.md
@@ -18,7 +18,7 @@ Riak was originally created to serve as a highly scalable session store.   This 
 
 ## Complex Case
 
-Riak has other features that enable more complex session storage use cases.  The bitcask storage backend supports automatic expiry of keys, which frees application developers from implementing manual session expiry.  Riak's MapReduce system can also be used to perform analysis on large bodies of session data, for example to compute the average number of active users.  If sessions must be retrieved using multiple keys (e.g. a UUID or email address), Secondary Indices (2I) provides an easy solution.
+Riak has other features that enable more complex session storage use cases.  The bitcask storage backend supports automatic expiry of keys, which frees application developers from implementing manual session expiry.  Riak's MapReduce system can also be used to perform analysis on large bodies of session data, for example to compute the average number of active users.  If sessions must be retrieved using multiple keys (e.g. a UUID or email address), Secondary Indexes (2I) provides an easy solution.
 
 ## Community Examples
 

--- a/source/languages/en/riak/ops/building/installing/with-chef.md
+++ b/source/languages/en/riak/ops/building/installing/with-chef.md
@@ -169,7 +169,7 @@ default['riak']['config']['riak_sysmon']['busy_dist_port'] = true
 
 ### Index Merge
 
-Settings pertaining to Secondary Index and Riak Search indices.
+Settings pertaining to Secondary Index and Riak Search indexes.
 
 ```ruby
 default['riak']['config']['merge_index']['data_root'] = "/var/lib/riak/merge_index".to_erl_string


### PR DESCRIPTION
We use "indexes" as the pluralization of index throughout the docs.

Related to PR #653 
