### PR TITLE
Add notes to add_paths setting for the Riak CS backend for lib vs lib64

### DIFF
--- a/source/languages/en/riakcs/cookbooks/configuration/Configuring-Riak.md
+++ b/source/languages/en/riakcs/cookbooks/configuration/Configuring-Riak.md
@@ -27,7 +27,7 @@ First, edit Riak's `app.config` file and find and delete the line containing the
 Next, expose the necessary Riak CS modules to Riak and instruct Riak to use the custom multi backend. Continue editing Riak's `app.config` file, and add this to the `riak_kv` section:
 
 ```
-{add_paths, ["/usr/lib/riak-cs/lib/riak_cs-X.Y.Z/ebin"]},
+{add_paths, ["/usr/lib/riak-cs/lib/riak_cs-{{VERSION}}/ebin"]},
 {storage_backend, riak_cs_kv_multi_backend},
 {multi_backend_prefix_list, [{<<"0b:">>, be_blocks}]},
 {multi_backend_default, be_default},
@@ -44,7 +44,10 @@ Next, expose the necessary Riak CS modules to Riak and instruct Riak to use the 
 
 where **X.Y.Z** is the version of Riak CS you have installed.
 
-Note that this assumes Riak and Riak CS packages are installed on the same machine. If the Riak CS package is not installed on the Riak box, then the files `riak-cs-machine:/usr/lib64/riak-cs/lib/riak_cs-X.Y.Z/ebin/*` must be copied to the Riak box, with the copy destination added to the `add_paths` directive.
+This assumes Riak and Riak CS packages are installed on the same machine. If the Riak CS package is not installed on the Riak box, then the files `riak-cs-machine:/usr/lib/riak-cs/lib/riak_cs-X.Y.Z/ebin/*` must be copied to the Riak box, with the copy destination added to the `add_paths` directive.
+
+<div class="note"><div class="title">Note</div> The path for `add_paths` may
+be `/usr/lib/riak-cs` or `/usr/lib64/riak-cs` depending on your operating system.</div>
 
 Next, add this to the **riak_core** section of `app.config`:
 

--- a/source/languages/en/riakcs/cookbooks/faqs/riak-cs.html.fml
+++ b/source/languages/en/riakcs/cookbooks/faqs/riak-cs.html.fml
@@ -24,7 +24,7 @@ A: You can specify the location of **all** Riak CS bucket data by changing the s
   [[Configuring Riak for CS]] section, it looks like this:
 
   ```erlang
-  {add_paths, ["/usr/lib/riak-cs/lib/riak_moss-X.Y.Z/ebin"]},
+  {add_paths, ["/usr/lib/riak-cs/lib/riak_cs-{{VERSION}}/ebin"]},
   {storage_backend, riak_cs_kv_multi_backend},
   {multi_backend_prefix_list, [{<<"0b:">>, be_blocks}]},
   {multi_backend_default, be_default},

--- a/source/languages/en/riakcs/tutorials/fast-track/Building-a-Local-Test-Environment.md
+++ b/source/languages/en/riakcs/tutorials/fast-track/Building-a-Local-Test-Environment.md
@@ -118,7 +118,7 @@ Change the following line in `/etc/riak/app.config`
 to
 
 ```
-{{#1.4.0-}}{add_paths, ["/usr/lib64/riak-cs/lib/riak_cs-{{VERSION}}/ebin"]},{{/1.4.0-}}{{#1.4.0+}}{add_paths, ["/usr/lib/riak-cs/lib/riak_cs-{{VERSION}}/ebin"]},{{/1.4.0+}}
+{add_paths, ["/usr/lib/riak-cs/lib/riak_cs-{{VERSION}}/ebin"]},
 {storage_backend, riak_cs_kv_multi_backend},
 {multi_backend_prefix_list, [{<<"0b:">>, be_blocks}]},
 {multi_backend_default, be_default},
@@ -132,6 +132,8 @@ to
     ]}
 ]},
 ```
+<div class="note"><div class="title">Note</div> The path for `add_paths` may
+be `/usr/lib/riak-cs` or `/usr/lib64/riak-cs` depending on your operating system.</div>
 
 Next, we set our interface IP addresses in the app.config files. In a production environment, you will likely have multiple NICs, but for this test cluster, we are going to assume one NIC with an example IP address of 10.0.2.10.
 


### PR DESCRIPTION
Depending on the operating system, paths to the Riak CS backend could be:

```
/usr/lib/riak-cs
```

Or:

```
/usr/lib64/riak-cs
```
