### PR TITLE
Eventual Consistency document overhaul

### DIFF
--- a/source/languages/en/riak/theory/concepts/Eventual-Consistency.md
+++ b/source/languages/en/riak/theory/concepts/Eventual-Consistency.md
@@ -54,7 +54,7 @@ A value of `quorum` indicates a majority of the `N` value (`N/2+1`, or
 There are additional configuration items that are closely related to
 the above which are not covered in this document: `notfound_ok`,
 `basic_quorum` and `dw`. See the
-[[Understanding Riak's Configurable Behaviors blog series|http://basho.com/understanding-riaks-configurable-behaviors-part-1/]]
+[Understanding Riak's Configurable Behaviors blog series](http://basho.com/understanding-riaks-configurable-behaviors-part-1/)
 for more on all of these parameters.
 
 See also [[Vector Clocks]] for a discussion of key configuration
@@ -170,5 +170,5 @@ whether the operation truly failed.</div>
 
 ## Further Reading
 
-* [[Understanding Riak's Configurable Behaviors blog series|http://basho.com/understanding-riaks-configurable-behaviors-part-1/]]
+* [Understanding Riak's Configurable Behaviors blog series](http://basho.com/understanding-riaks-configurable-behaviors-part-1/)
 * Werner Vogels, et. al.: [Eventually Consistent - Revisited](http://www.allthingsdistributed.com/2008/12/eventually_consistent.html)


### PR DESCRIPTION
Addresses issue #225 by tearing everything out and starting over.

Parts of the original document were simply wrong, and any document on eventual consistency that dives to a level where try-try-try is referenced is probably the wrong level of abstraction for the docs site, at least until we introduce a "really truly advanced" category of document.

I think this document can be expanded to cover more use cases/failure scenarios, but I think it gives a good idea of how things work without overwhelming the reader. I think. Feedback is welcome.
