### PR TITLE
Enable TOC for usage and billing data

### DIFF
--- a/source/languages/en/riakcs/cookbooks/Usage-and-Billing-Data.md
+++ b/source/languages/en/riakcs/cookbooks/Usage-and-Billing-Data.md
@@ -3,7 +3,7 @@ title: Usage and Billing Data
 project: riakcs
 version: 1.2.0+
 document: cookbook
-toc: false
+toc: true
 index: true
 audience: intermediate
 keywords: [developer]


### PR DESCRIPTION
The table of contents was disabled for the [Usage and Billing Data](http://docs.basho.com/riakcs/latest/cookbooks/Usage-and-Billing-Data/) section of the Riak CS documentation.

Enabling it seemed useful because now we can link to the subheadings more easily.
