### PR TITLE
Fix error in somaxconn Linux tuning recommendations

### DIFF
--- a/source/languages/en/riak/ops/tuning/linux.md
+++ b/source/languages/en/riak/ops/tuning/linux.md
@@ -58,7 +58,7 @@ networking is the bottleneck.
 ```text
 vm.swappiness = 0
 net.ipv4.tcp_max_syn_backlog = 40000
-net.core.somaxconn=4000
+net.core.somaxconn=40000
 net.ipv4.tcp_timestamps = 0
 net.ipv4.tcp_sack = 1
 net.ipv4.tcp_window_scaling = 1


### PR DESCRIPTION
The Linux tuning recommendations suggest a net.core.somaxconn that is less than net.ipv4.tcp_max_syn_backlog.  This will result in the net.ipv4.tcp_max_syn_backlog value being silently truncated within the TCP stack as it must be less than or equal to net.core.somaxconn.  

See the last paragraph of the 'listen' man page: http://man7.org/linux/man-pages/man2/listen.2.html#NOTES
