### PR TITLE
Updated MDC tuning doc to refer to Linux Tunings page

### DIFF
--- a/source/languages/en/riakee/cookbooks/Multi-Data-Center-Replication-System-Tuning.md
+++ b/source/languages/en/riakee/cookbooks/Multi-Data-Center-Replication-System-Tuning.md
@@ -11,7 +11,7 @@ keywords: [mdc, repl, os]
 Depending on the size of your objects, and your replication latency needs, you may need to configure your kernel settings to optimize throughput.
 
 ## Linux
-Refer to the Kernel and Network Tuning section of [Linux Performance Tuning] (http://docs.basho.com/riak/latest/ops/tuning/linux/#Linux-Tuning)
+Refer to the Kernel and Network Tuning section of [[Linux Performance Tuning|Linux Performance Tuning#Linux-Tuning]]
 
 ## Solaris
 On Solaris the following settings are suggested.


### PR DESCRIPTION
MDC should not require specific network tunings of its own.  The tunings currently listed are also inferior to the updated documentation (check master, it may not yet be deployed).  I've updated the MDC tuning doc to refer to the Linux tunings page for this info.
