### PR TITLE
Crossref'd transfer-limit and handoff-concurrency

### DIFF
--- a/source/languages/en/riak/ops/advanced/configs/configuration-files.md
+++ b/source/languages/en/riak/ops/advanced/configs/configuration-files.md
@@ -146,7 +146,7 @@ When set to `true`, this option will disable the Nagle buffering algorithm for H
 * **gossip_interval**
 How often nodes in the cluster will share information about their ring state, in milliseconds. (default: `60000`)
 
-* **handoff_concurrency**
+* **handoff_concurrency** <a name="handoff_concurrency" id="handoff_concurrency"></a>
 Number of vnodes, per physical node, allowed to perform handoff at once. (default: `2`)
 
 * **handoff_port**

--- a/source/languages/en/riak/ops/running/tools/riak-admin.md
+++ b/source/languages/en/riak/ops/running/tools/riak-admin.md
@@ -237,7 +237,15 @@ riak-admin transfers
 
 ## transfer-limit
 
-Change the handoff_concurrency limit.
+Change the handoff_concurrency limit.  The value set by running this command will 
+only persist while the node is running.  If the node is restarted, the transfer-limit 
+will return to the default of 2 or the value specified in the 
+`[[handoff_concurrency|Configuration Files#handoff_concurrency]]`
+setting in the `riak_core` section of the `app.config` file.
+
+Running this command with no arguments will display the current transfer-limit for each
+node in the cluster.
+
 
 ```bash
 riak-admin transfer-limit <node> <limit>
@@ -247,7 +255,7 @@ riak-admin transfer-limit <node> <limit>
 
 <div class="note">
 <div class="title">Deprecation Notice</title></div>
-As of Riak version 1.2, the <tt>riak-admin force-remove</tt> command has been deprecated in favor of the new [[riak-admin cluster force-remove|riak-admin Command Line#cluster-force-remove]] command. The command can still be used by providing a <code>-f</code> option, however.
+As of Riak version 1.2, the <tt>riak-admin force-remove</tt> command has been deprecated in favor of the new `[[riak-admin cluster force-remove|riak-admin Command Line#cluster-force-remove]]` command. The command can still be used by providing a <code>-f</code> option, however.
 </div>
 
 Immediately removes a node from the cluster without ensuring handoff of its replicas. This is a dangerous command, and is designed to only be used in cases were the normal, safe leave behavior cannot be used -- e.g. when the node you are removing had a major hardware failure and is unrecoverable. Using this command will result in a loss of all replicas living on the removed node which will then need to be recovered through other means such as [[read repair|Replication#Read-Repair]]. It's recommended that you use the [[riak-admin leave|riak-admin Command Line#leave]] command whenever possible.


### PR DESCRIPTION
In response to issue #758, the following commit creates a cross
reference between the `riak-admin transfer-limit` and the
`handoff_concurrency` setting of the `riak_core` section of `app.config`
