### PR TITLE
Add a list of projects to generate, verses simply versioned

### DIFF
--- a/data/downloads_gen.yml
+++ b/data/downloads_gen.yml
@@ -3890,6 +3890,178 @@ riak-cs:
               csum: riak-cs_1.4.3-1_amd64.deb.sha
               static_csum: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.3/ubuntu/precise/riak-cs_1.4.3-1_amd64.deb.sha
               csum_size: 92
+  1.4.4:
+    debian:
+      versions:
+        '6':
+          arch:
+            amd64:
+              file: riak-cs_1.4.4-1_amd64.deb
+              static_file: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/debian/6/riak-cs_1.4.4-1_amd64.deb
+              file_size: 22841922
+              csum: riak-cs_1.4.4-1_amd64.deb.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/debian/6/riak-cs_1.4.4-1_amd64.deb.sha
+              csum_size: 92
+        '7':
+          arch:
+            amd64:
+              file: riak-cs_1.4.4-1_amd64.deb
+              static_file: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/debian/7/riak-cs_1.4.4-1_amd64.deb
+              file_size: 22863892
+              csum: riak-cs_1.4.4-1_amd64.deb.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/debian/7/riak-cs_1.4.4-1_amd64.deb.sha
+              csum_size: 92
+    fedora:
+      versions:
+        '17':
+          arch:
+            src:
+              file: riak-cs-1.4.4-1.fc17.src.rpm
+              static_file: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/fedora/17/riak-cs-1.4.4-1.fc17.src.rpm
+              file_size: 4790618
+              csum: riak-cs-1.4.4-1.fc17.src.rpm.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/fedora/17/riak-cs-1.4.4-1.fc17.src.rpm.sha
+              csum_size: 95
+            x86_64:
+              file: riak-cs-1.4.4-1.fc17.x86_64.rpm
+              static_file: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/fedora/17/riak-cs-1.4.4-1.fc17.x86_64.rpm
+              file_size: 20480373
+              csum: riak-cs-1.4.4-1.fc17.x86_64.rpm.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/fedora/17/riak-cs-1.4.4-1.fc17.x86_64.rpm.sha
+              csum_size: 98
+    freebsd:
+      versions:
+        '9':
+          arch:
+            amd64:
+              file: riak-cs-1.4.4-FreeBSD-amd64.tbz
+              static_file: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/freebsd/9/riak-cs-1.4.4-FreeBSD-amd64.tbz
+              file_size: 27767559
+              csum: riak-cs-1.4.4-FreeBSD-amd64.tbz.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/freebsd/9/riak-cs-1.4.4-FreeBSD-amd64.tbz.sha
+              csum_size: 98
+    osx:
+      versions:
+        '10.8':
+          arch:
+            x86_64:
+              file: riak-cs-1.4.4-OSX-x86_64.tar.gz
+              static_file: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/osx/10.8/riak-cs-1.4.4-OSX-x86_64.tar.gz
+              file_size: 22968955
+              csum: riak-cs-1.4.4-OSX-x86_64.tar.gz.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/osx/10.8/riak-cs-1.4.4-OSX-x86_64.tar.gz.sha
+              csum_size: 98
+    rhel:
+      versions:
+        '5':
+          arch:
+            x86_64:
+              file: riak-cs-1.4.4-1.el5.x86_64.rpm
+              static_file: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/rhel/5/riak-cs-1.4.4-1.el5.x86_64.rpm
+              file_size: 23056186
+              csum: riak-cs-1.4.4-1.el5.x86_64.rpm.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/rhel/5/riak-cs-1.4.4-1.el5.x86_64.rpm.sha
+              csum_size: 97
+            src:
+              file: riak-cs-1.4.4-1.src.rpm
+              static_file: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/rhel/5/riak-cs-1.4.4-1.src.rpm
+              file_size: 4797188
+              csum: riak-cs-1.4.4-1.src.rpm.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/rhel/5/riak-cs-1.4.4-1.src.rpm.sha
+              csum_size: 90
+        '6':
+          arch:
+            src:
+              file: riak-cs-1.4.4-1.el6.src.rpm
+              static_file: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/rhel/6/riak-cs-1.4.4-1.el6.src.rpm
+              file_size: 4795472
+              csum: riak-cs-1.4.4-1.el6.src.rpm.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/rhel/6/riak-cs-1.4.4-1.el6.src.rpm.sha
+              csum_size: 94
+            x86_64:
+              file: riak-cs-1.4.4-1.el6.x86_64.rpm
+              static_file: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/rhel/6/riak-cs-1.4.4-1.el6.x86_64.rpm
+              file_size: 20624088
+              csum: riak-cs-1.4.4-1.el6.x86_64.rpm.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/rhel/6/riak-cs-1.4.4-1.el6.x86_64.rpm.sha
+              csum_size: 97
+    smartos:
+      versions:
+        '1.6':
+          arch:
+            x86_64:
+              file: riak_cs-1.4.4-SmartOS-x86_64.tgz
+              static_file: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/smartos/1.6/riak_cs-1.4.4-SmartOS-x86_64.tgz
+              file_size: 28432873
+              csum: riak_cs-1.4.4-SmartOS-x86_64.tgz.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/smartos/1.6/riak_cs-1.4.4-SmartOS-x86_64.tgz.sha
+              csum_size: 99
+        '1.8':
+          arch:
+            x86_64:
+              file: riak_cs-1.4.4-SmartOS-x86_64.tgz
+              static_file: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/smartos/1.8/riak_cs-1.4.4-SmartOS-x86_64.tgz
+              file_size: 29441672
+              csum: riak_cs-1.4.4-SmartOS-x86_64.tgz.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/smartos/1.8/riak_cs-1.4.4-SmartOS-x86_64.tgz.sha
+              csum_size: 99
+        '13.1':
+          arch:
+            x86_64:
+              file: riak_cs-1.4.4-SmartOS-x86_64.tgz
+              static_file: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/smartos/13.1/riak_cs-1.4.4-SmartOS-x86_64.tgz
+              file_size: 29440344
+              csum: riak_cs-1.4.4-SmartOS-x86_64.tgz.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/smartos/13.1/riak_cs-1.4.4-SmartOS-x86_64.tgz.sha
+              csum_size: 99
+    solaris:
+      versions:
+        '10':
+          arch:
+            x86_64:
+              file: BASHOriak-cs-1.4.4-Solaris10-x86_64.pkg.gz
+              static_file: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/solaris/10/BASHOriak-cs-1.4.4-Solaris10-x86_64.pkg.gz
+              file_size: 27398127
+              csum: BASHOriak-cs-1.4.4-Solaris10-x86_64.pkg.gz.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/solaris/10/BASHOriak-cs-1.4.4-Solaris10-x86_64.pkg.gz.sha
+              csum_size: 109
+    ubuntu:
+      versions:
+        lucid:
+          arch:
+            amd64:
+              file: riak-cs_1.4.4-1_amd64.deb
+              static_file: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/ubuntu/lucid/riak-cs_1.4.4-1_amd64.deb
+              file_size: 22849556
+              csum: riak-cs_1.4.4-1_amd64.deb.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/ubuntu/lucid/riak-cs_1.4.4-1_amd64.deb.sha
+              csum_size: 92
+        natty:
+          arch:
+            amd64:
+              file: riak-cs_1.4.4-1_amd64.deb
+              static_file: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/ubuntu/natty/riak-cs_1.4.4-1_amd64.deb
+              file_size: 22856468
+              csum: riak-cs_1.4.4-1_amd64.deb.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/ubuntu/natty/riak-cs_1.4.4-1_amd64.deb.sha
+              csum_size: 92
+        precise:
+          arch:
+            amd64:
+              file: riak-cs_1.4.4-1_amd64.deb
+              static_file: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/ubuntu/precise/riak-cs_1.4.4-1_amd64.deb
+              file_size: 22820392
+              csum: riak-cs_1.4.4-1_amd64.deb.sha
+              static_csum: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/ubuntu/precise/riak-cs_1.4.4-1_amd64.deb.sha
+              csum_size: 92
+    source:
+      versions:
+        any:
+          arch:
+            src:
+              file: riak-cs-1.4.4.tar.gz
+              static_file: http://s3.amazonaws.com/downloads.basho.com/riak-cs/1.4/1.4.4/riak-cs-1.4.4.tar.gz
+              file_size: 4790710
 stanchion:
   1.3.0:
     debian:

--- a/data/versions.yml
+++ b/data/versions.yml
@@ -17,15 +17,13 @@ riak:
   - ['1.3.0', '1.3.1', '1.3.2']
   - ['1.4.0', '1.4.1', '1.4.2', '1.4.6', '1.4.7']
   - ['2.0.0pre11']
-# java:
-#   - ['1.1.0']
 riakcscontrol:
   - ['1.0.0', '1.0.1', '1.0.2']
 # describes the latest version per project
+gen_projects: ['riak', 'riakcs', 'riakee']
 currents:
   riakee: '1.4.7'
   riakcs: '1.4.4'
   riak: '1.4.7'
-  # java: '1.1.0'
   riakcscontrol: '1.0.2'
   stanchion: '1.4.3'

--- a/lib/setup.rb
+++ b/lib/setup.rb
@@ -9,13 +9,15 @@ $versions = {}
 $only_projects = []
 $only_versions = []
 version_file = YAML::load(File.open('data/versions.yml'))
+$gen_projects = version_file['gen_projects'].map{|r| r.to_sym}
 for proj, vs in version_file['currents']
   proj = proj.upcase
+  proj_sym = proj.downcase.to_sym
   vs = ENV["#{proj}_VERSION"] if ENV["#{proj}_VERSION"].present?
   ENV["#{proj}_VERSION"] = vs if ENV["#{proj}_VERSION"].blank? 
-  $only_projects << proj.downcase
-  $only_versions << vs
-  $versions[proj.downcase.to_sym] = vs
+  $only_projects << proj_sym if $gen_projects.include?(proj_sym)
+  $only_versions << vs if $gen_projects.include?(proj_sym)
+  $versions[proj_sym] = vs
   puts "#{proj}_VERSION=#{ENV["#{proj}_VERSION"]}"
 end
 
@@ -26,6 +28,7 @@ if ENV['ONLY']
   }.uniq
 end
 
+$only_versions.uniq!
 $default_project = 'riak'
 
 %w{versionify production_check index sitemap_render_override

--- a/lib/versionify.rb
+++ b/lib/versionify.rb
@@ -134,6 +134,7 @@ module VersionDirs
             next
           elsif f =~ /^\.\/build\/(?:fonts|js|css)\//
             $versions.each do |proj, version|
+              next unless $only_versions.include?(version)
               move_to = f.sub(/\.\/build\//, "./build/#{proj.to_s}/#{version}/")
               copy(f, move_to)
             end

--- a/source/languages/en/riakcs/cookbooks/Riak-CS-Release-Notes.md
+++ b/source/languages/en/riakcs/cookbooks/Riak-CS-Release-Notes.md
@@ -8,6 +8,20 @@ audience: intermediate
 keywords: [developer]
 ---
 
+{{#1.4.4+}}
+
+## Riak CS 1.4.4
+
+[Riak CS 1.4.4 Release Notes](https://github.com/basho/riak_cs/blob/1.4.4/RELEASE-NOTES.md)
+
+## Bugs Fixed
+
+* Create basho-patches directory [riak_cs/775](https://github.com/basho/riak_cs/issues/775) .
+* `sum_bucket` timeout crashes all storage calculation is fixed by [riak_cs/759](https://github.com/basho/riak_cs/issues/759) .
+* Failure to throttle access archiver is fixed by [riak_cs/758](https://github.com/basho/riak_cs/issues/758) .
+* Access archiver crash is fixed by [riak_cs/747](https://github.com/basho/riak_cs/issues/747) .
+
+{{/1.4.4+}}
 {{#1.4.3+}}
 
 ## Riak CS 1.4.3

--- a/source/layouts/_primary.slim
+++ b/source/layouts/_primary.slim
@@ -59,7 +59,7 @@ aside#nav-container role="complementary"
               span(aria-hidden="true" data-icon="&#xe00a;" class="nav-icon")
             - if section['title'] == 'Riak CS Enterprise' || section['title'] == 'OpenStack Integration'
               span(aria-hidden="true" data-icon="&#xe008;" class="nav-icon")
-            - if section['title'] == 'References'
+            - if section['title'] =~ /References?/
               span(aria-hidden="true" data-icon="&#xf02d;" class="nav-icon")
           span.separator
             |


### PR DESCRIPTION
Without this PR, every addition to versions.yml `current` block generates directories and assumes they are documented projects. This doesn't make sense in secondary projects like Stanchion.

This also contains the 1.4.4 CS generated download data, and a minor patch to displaying Reference icon (which really should be fixed to use classes, not title names @barrettcox80. global_nav allows for custom css `class` names)
