### PR TITLE
Convert .rvmrc to .ruby-{version,gemset} files

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+basho_docs

--- a/.ruby-version
+++ b/.ruby-version
@@ -1,0 +1,1 @@
+default

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm use --create default@basho_docs


### PR DESCRIPTION
.rvmrc has security issues, and .ruby-\* work with other Ruby managers in addition to RVM.
