### PR TITLE
Changed Scheduling V3 Fullsync doc from 1.3.0+ to 1.4.0+

### DIFF
--- a/source/languages/en/riakee/cookbooks/Multi-Data-Center-Replication-v3-Scheduling-Full-Sync.md
+++ b/source/languages/en/riakee/cookbooks/Multi-Data-Center-Replication-v3-Scheduling-Full-Sync.md
@@ -1,7 +1,7 @@
 ---
 title: "Multi Data Center Replication v3: Scheduling Fullsync"
 project: riakee
-version: 1.3.0+
+version: 1.4.0+
 document: cookbook
 toc: true
 audience: intermediate


### PR DESCRIPTION
Updated Version for MDC V3 Fullsync Scheduling doc for issue #623
