### PR TITLE
Refer to lager_syslog README

### DIFF
--- a/source/languages/en/riak/community/faqs/logs.html.fml
+++ b/source/languages/en/riak/community/faqs/logs.html.fml
@@ -65,7 +65,7 @@ A:
 
 Q: Can I make Riak use syslog instead of file?
 A:
-  Yes. Please refer to the `lager_syslog` [README](https://github.com/basho/lager_syslog/blob/master/README.org).
+  Yes. Please refer to the [`lager_syslog` README](https://github.com/basho/lager_syslog/blob/master/README.org).
 
 <h2>Log Messages</h2>
 


### PR DESCRIPTION
Since syslog is now supported by lager, update the FAQ to point to the lager README. Resolves #231 

This is a very basic resolution of this issue but at least it corrects the FAQ.
