### PR TITLE
Add AAE upgrade warning to download

### DIFF
--- a/source/languages/en/riak/downloads.slim
+++ b/source/languages/en/riak/downloads.slim
@@ -15,6 +15,14 @@ body_id: downloads
 
 h1 Download #{project.capitalize} #{version}
 
+| {{#1.4.8}}
+
+.info
+  .title AAE 1.4.8 Upgrade Warning
+  p Upgrading to 1.4.8 fixes a bug with anti-active entropy which existed from 1.4.3 to 1.4.7. If you're upgrading to 1.4.8 from 1.4.3 or greater, delete your `data/anti_entropy` directories on each node before upgrading. This will avoid potentially large amounts of repair activity once correct hashes start being added.
+
+| {{/1.4.8}}
+
 p You should be able to find your operating system in the choices below.
 p If your OS is unlisted, you may download the [[source|Downloads#source]] at the bottom of this page, and follow the instructions to [[build Riak|Installing Riak from Source]].
 


### PR DESCRIPTION
People upgrading to 1.4.8 have run into AAE issues. This adds a warning to DL page.
