### PR TITLE
Add notes about statistics performance impact

### DIFF
--- a/source/languages/en/riak/dev/references/http/status.md
+++ b/source/languages/en/riak/dev/references/http/status.md
@@ -14,6 +14,19 @@ moved: {
 
 Reports about the performance and configuration of the Riak node to which it was requested. You must have the `{riak_kv_stat,true}` configuration setting in app.config for this endpoint to be active.
 
+## Performance
+
+{{#1.2.0-1.2.1}}
+Requests to the `/stats` endpoint should not be executed more than once
+a minute as statistics are recalculated every time the command is
+executed.
+{{/1.2.0-1.2.1}}
+
+{{#1.3.0+}}
+Repeated requests to the `/stats` endpoint do not have a negative
+performance impact as the statstics are cached internally in Riak.
+{{/1.3.0+}}
+
 ## Request
 
 ```bash

--- a/source/languages/en/riak/ops/running/nodes/inspecting.md
+++ b/source/languages/en/riak/ops/running/nodes/inspecting.md
@@ -20,7 +20,21 @@ riak-admin status
 
 `riak-admin status` is a subcommand of the `riak-admin` command that is included with every installation of Riak. The `status` subcommand provides data related to the current operating status for a node. The output of `riak-admin status` is categorized and detailed below.
 
-Please note, for some counters such as node_get_fsm_objsize a minimum of 5 transactions is required for statistics to be generated.
+Please note, for some counters such as `node_get_fsm_objsize` a minimum of 5 transactions is required for statistics to be generated.
+
+#### Performance
+
+{{#1.2.0-1.2.1}}
+The `riak-admin status` command should not be executed more than once a
+minute as statistics are recalculated every time the command is
+executed.
+{{/1.2.0-1.2.1}}
+
+{{#1.3.0+}}
+Repeated runs of the `riak-admin status` command does not have a
+negative performance impact as the statstics are cached internally in
+Riak.
+{{/1.3.0+}}
 
 ### Active Stats
 

--- a/source/languages/en/riakee/cookbooks/Multi-Data-Center-Replication-Statistics.md
+++ b/source/languages/en/riakee/cookbooks/Multi-Data-Center-Replication-Statistics.md
@@ -11,15 +11,28 @@ moved: {
 }
 ---
 
-The following definitions describe the output of `riak-repl status`. Please note that many of these statistics will only appear on the current leader node. Both Version 2 Replication and Version 3 Replication statistics are obtained by using the `riak-repl status` command.
+The following definitions describe the output of `riak-repl status`.
+Both Version 2 Replication and Version 3 Replication statistics are
+obtained by using the `riak-repl status` command.
 
-**All statistic counts will be reset to 0 upon restarting Riak Enterprise unless otherwise noted.**
+**Please note that many of these statistics will only appear on the
+current leader node.**
+
+**All statistic counts will be reset to 0 upon restarting Riak
+Enterprise unless otherwise noted.**
 
 Field | Description
 ------|------------
 `cluster_leader` {{1.3.0+}} | Which node is the current leader of the cluster
 connected_clusters {{1.3.0+}} | A list of all sink clusters to which this source is connected
 
+## Performance
+
+The `riak-repl status` command should not be executed more than once a
+minute as statistics are recalculated every time the command is
+executed, and some statistics require network communication between
+nodes. This performance note also applies to the HTTP `/riak-repl/stats`
+endpoint.
 
 ## Realtime Replication Statistics
 


### PR DESCRIPTION
Resolves issue #899 by providing some performance notes around running `riak-admin status`, `riak-repl status` and their HTTP counterparts.
