### PR TITLE
Fixed link from RiakCS Storage API -> RiakCS S3 Storage API

### DIFF
--- a/source/languages/en/riakcs/tutorials/fast-track/Testing-the-Installation.md
+++ b/source/languages/en/riakcs/tutorials/fast-track/Testing-the-Installation.md
@@ -91,6 +91,6 @@ ls -lah test_file
 ## What's Next
 If you have made it this far, congratulations! You now have a working Riak CS test instance (either virtual or local). There is still a fair bit of learning to be done, so make sure and check out the Reference section (click "Reference" on the nav on the left side of this page). A few items that may be of particular interest:
 
-* [[Details about API operations|RiakCS Storage API]]
+* [[Details about API operations|RiakCS S3 Storage API]]
 * [[Information about the Ruby Fog client|Fog on Riak CS]]
 * [[Release Notes]]

--- a/source/languages/en/riakcs/tutorials/fast-track/What-is-Riak-CS.md
+++ b/source/languages/en/riakcs/tutorials/fast-track/What-is-Riak-CS.md
@@ -20,7 +20,7 @@ Riak CS is built on Riak. When an object is uploaded, Riak CS breaks the object 
 
 In a Riak CS system, any node can respond to client requests - there is no master node and each node has the same responsibilities. Since data is replicated (three replicas per object by default), and other nodes automatically take over the responsibility of failed or non-communicative nodes, data remains available even in the event of node failure or network partition.
 
-When an object is uploaded via the [[storage API|RiakCS Storage API]], Riak CS breaks the object into smaller chunks that are streamed, written, and replicated in Riak. Each chunk is associated with metadata for later retrieval. The diagram below provides a visualization. 
+When an object is uploaded via the [[storage API|RiakCS S3 Storage API]], Riak CS breaks the object into smaller chunks that are streamed, written, and replicated in Riak. Each chunk is associated with metadata for later retrieval. The diagram below provides a visualization. 
 
 ![Riak CS Chunking](/images/Riak-CS-Overview.png)
 


### PR DESCRIPTION
Incorrect link present in two pages of the RiakCS Fast Track.
