### PR TITLE
Using Search datatype and Upgrading layout fix

### DIFF
--- a/source/languages/en/riak/ops/advanced/configs/search.md
+++ b/source/languages/en/riak/ops/advanced/configs/search.md
@@ -45,4 +45,3 @@ Riak Search runs a Solr process per node to manage its index and search function
 Concerning ports, be sure to take the necessary security precautions to prevent exposing the extra solr and JMX ports to the outside world.
 
 
-<!-- connecting to JMX -->


### PR DESCRIPTION
Added example to set properties on both types and buckets in the using search doc. Fixed the upgrading to 2.0 docs layout and links
