### PR TITLE
Add latest Riak CS version - 1.4.5

### DIFF
--- a/source/languages/en/riakcs/cookbooks/Version-Compatibility.md
+++ b/source/languages/en/riakcs/cookbooks/Version-Compatibility.md
@@ -38,7 +38,13 @@ Riak version  | Stanchion version | Riak CS version
 1.3.0         | 1.3.0             | 1.3.0
 1.4.0         | 1.4.0             | 1.4.0
 1.4.1         | 1.4.0             | 1.4.0
-1.4.9         | 1.4.3             | 1.4.5
+1.4.x         | 1.5.0             | 1.4.5
+
+{{#1.5.0+}}
+**Note**: While Riak CS versions 1.5.0 and later will work with Riak
+1.4.x, we highly recommend running CS with at least Riak 1.4.8,
+preferably 1.4.10.
+{{/1.5.0+}}
 
 Basic functionality testing consists of account creation, object storage and
 retrieval, bucket listing operations, and Access Control List (ACL) enforcement


### PR DESCRIPTION
after CS 1.5.0 cut out I'll add 1.5.0 compatibility line.
