### PR TITLE
move v3 repl cluster connect information

### DIFF
--- a/source/languages/en/riakee/cookbooks/Multi-Data-Center-Replication-v3-Operations.md
+++ b/source/languages/en/riakee/cookbooks/Multi-Data-Center-Replication-v3-Operations.md
@@ -19,7 +19,7 @@ All commands need to be run only once on a single node of a cluster for the chan
 
 #### `clustername`
 
-Set the `clustername` for all nodes in a Riak cluster. The IP and port to connect to can be found in the `app.config` of the remote cluster, under `riak_core` » `cluster_mgr`.
+Set the `clustername` for all nodes in a Riak cluster.
 
 * Without a parameter, returns the current name of the cluster
 * With a parameter, names the current cluster
@@ -36,7 +36,7 @@ To **get** the `clustername`:
 
 #### `connect`
 
-The `connect` command establishes communications from a source cluster to a sink cluster of the same ring size. The `host:port` of the sink cluster is used for this.
+The `connect` command establishes communications from a source cluster to a sink cluster of the same ring size. The `host:port` of the sink cluster is used for this. The IP and port to connect to can be found in the `app.config` of the remote cluster, under `riak_core` » `cluster_mgr`.
 
 The `host` can be either an IP address
 


### PR DESCRIPTION
Move information provided about where to find IP and port connection
information for repl clusters from the "clustername" section to the
"connect" section of the repl v3 operations doc.
