### PR TITLE
Update HTTP query URL

### DIFF
--- a/source/languages/en/riak/dev/using/search.md
+++ b/source/languages/en/riak/dev/using/search.md
@@ -301,7 +301,7 @@ After the schema, index, association, population/extraction/indexing has taken p
 The basic query parameter is `q` via HTTP, or the first parameter of your chosen driver's `search` function. All Distributed Solr queries are supported, which actually includes most of the single-node solr queries. This example is searching for all documents where the `name_s` value begins with *Lion* by means of a glob (wildcard) match.
 
 ```curl
-curl "$RIAK_HOST/search/famous?wt=json&q=name_s:Lion*" | jsonpp
+curl "$RIAK_HOST/search/query/famous?wt=json&q=name_s:Lion*" | jsonpp
 ```
 ```ruby
 results = client.search("famous", "name_s:Lion*")
@@ -392,7 +392,7 @@ Searches within a [range](https://cwiki.apache.org/confluence/display/solr/The+S
 To find the ages of all famous cats who are 30 or younger: `age_i:[0 TO 30]`. If you wanted to find all cats 30 or older, you could include a glob as a top end of the range: `age_i:[30 TO *]`.
 
 ```curl
-curl "$RIAK_HOST/search/famous?wt=json&q=age_i:%5B30%20TO%20*%5D" | jsonpp
+curl "$RIAK_HOST/search/query/famous?wt=json&q=age_i:%5B30%20TO%20*%5D" | jsonpp
 ```
 ```ruby
 client.search("famous", "age_i:[30 TO *]")
@@ -411,7 +411,7 @@ riakc_pb_socket:search(Pid, <<"famous">>, <<"age_i:[30 TO *]">>),
 You can perform logical conjunctive, disjunctive, and negative operations on query elements as, repectively, `AND`, `OR` and `NOT`. Let's say we want to see who is capable of being a US Senator (at least 30 years old, and a leader). It requires a conjunctive query: `leader_b:true AND age_i:[25 TO *]`.
 
 ```curl
-curl "$RIAK_HOST/search/famous?wt=json&q=leader_b:true%20AND%20age_i:%5B25%20TO%20*%5D" | jsonpp
+curl "$RIAK_HOST/search/query/famous?wt=json&q=leader_b:true%20AND%20age_i:%5B25%20TO%20*%5D" | jsonpp
 ```
 ```ruby
 client.search("famous", "leader_b:true AND age_i:[30 TO *]")
@@ -460,7 +460,7 @@ ROWS_PER_PAGE=2
 PAGE=2
 START=$(($ROWS_PER_PAGE * ($PAGE-1)))
 
-curl "$RIAK_HOST/search/famous?wt=json&q=*:*&start=$START&rows=$ROWS_PER_PAGE" | jsonpp
+curl "$RIAK_HOST/search/query/famous?wt=json&q=*:*&start=$START&rows=$ROWS_PER_PAGE" | jsonpp
 ```
 ```ruby
 ROWS_PER_PAGE=2
@@ -529,7 +529,7 @@ curl -XPOST "$RIAK_HOST/mapred" \
 Cats age about 7 times faster than humans, so to calculate an age in "cat years", you can multiply the cat's age by 7 using the `product` function. It's only one out of many built-in [Solr Functions](https://cwiki.apache.org/confluence/display/solr/Function+Queries#FunctionQueries-AvailableFunctions).
 
 ```curl
-curl "$RIAK_HOST/search/famous?wt=json&q=*:*&fl=_yz_rk,age_i:product(age_i,7)" | jsonpp
+curl "$RIAK_HOST/search/query/famous?wt=json&q=*:*&fl=_yz_rk,age_i:product(age_i,7)" | jsonpp
 ```
  -->
 


### PR DESCRIPTION
The query URL changed from `/search/Index` to `/search/query/Index` in
basho/yokozuna#394.
