### PR TITLE
Tweak wording of PB API doc to reflect return_body

### DIFF
--- a/source/languages/en/riak/dev/references/protocol-buffers/dt-store.md
+++ b/source/languages/en/riak/dev/references/protocol-buffers/dt-store.md
@@ -90,7 +90,7 @@ message DtUpdateResp {
 }
 ```
 
-If a counter is updated, the response will include an integer as the `counter_value`; if a set is updated, a list of binaries will be return as the `set_value`; and if a map is updated, the returned `map_value` will be a `MapEntry` message. That message takes the following form:
+Assuming `return_body` is set to `true`: if a counter is updated, the response will include an integer as the `counter_value`; if a set is updated, a list of binaries will be return as the `set_value`; and if a map is updated, the returned `map_value` will be a `MapEntry` message. That message takes the following form:
 
 ```protobuf
 message MapEntry {


### PR DESCRIPTION
The last paragraph in this document strongly implies that `return_body` is always `true`, or at least defaults to that. Fix.

I'm not thrilled with the fix, but given that perhaps 8 people will ever read it...
