### PR TITLE
Standardize URLs to final version

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -33,6 +33,7 @@ ready do
     if new_path =~ /(#{projects_regex})\-index\.html/
       project = $1
       version = $versions[project.to_sym]
+      version = version.sub(/(\d+[.]\d+[.]\d+).*/, "\\1")
       page "/#{project}/#{version}/index.html", :proxy => proxy, :directory_index => false, :ignore => true
     else
       project = new_path.scan(/^[^\/]+/).first

--- a/data/downloads_gen.yml
+++ b/data/downloads_gen.yml
@@ -3429,6 +3429,7 @@ riak:
               file: riak-2.0.0beta1.tar.gz
               static_file: http://s3.amazonaws.com/downloads.basho.com/riak/2.0/2.0.0beta1/riak-2.0.0beta1.tar.gz
               file_size: 16023456
+  2.0.0beta5: 
 riak-cs:
   1.2.1: 
   1.3.0:

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -50,6 +50,7 @@ module BashoDocsHelpers
     url = pa.url.sub(/\.html/, '/')
     url.sub!(%r"languages\/\w+\/#{projects_regex}\/", '')
     if project != current_project
+      version = version.sub(/(\d+[.]\d+[.]\d+).*/, "\\1")
       url = "/#{project}/#{version}#{url}"
     end
     url

--- a/lib/sitemap_render_override.rb
+++ b/lib/sitemap_render_override.rb
@@ -225,7 +225,7 @@ module SitemapRenderOverride
 
     # shared resources (css, js, images, etc) are put under /shared/version
     if version_str || project == :root
-      version_str ||= $versions[:riak]
+      version_str = (version_str || $versions[:riak]).sub(/(\d+[.]\d+[.]\d+).*/, "\\1")
       data.gsub!(/(\<(?:script|link)\s.*?(?:href|src)\s*\=\s*["'])([^"'>]+)(["'][^\>]*>)/mu) do
         base, href, cap = $1, $2, $3
         href.gsub!(/\.{2}\//, '')

--- a/lib/versionify.rb
+++ b/lib/versionify.rb
@@ -127,6 +127,7 @@ module VersionDirs
             # $versions.values.uniq.each do |version|
             $only_versions.each do |version|
               # key = f.sub(/\.\/build\//, "shared/#{version}/")
+              version = version.sub(/(\d+[.]\d+[.]\d+).*/, "\\1")
               move_to = f.sub(/\.\/build\//, "./build/shared/#{version}/")
               copy(f, move_to)
             end
@@ -135,6 +136,7 @@ module VersionDirs
           elsif f =~ /^\.\/build\/(?:fonts|js|css)\//
             $versions.each do |proj, version|
               next unless $only_versions.include?(version)
+              version = version.sub(/(\d+[.]\d+[.]\d+).*/, "\\1")
               move_to = f.sub(/\.\/build\//, "./build/#{proj.to_s}/#{version}/")
               copy(f, move_to)
             end
@@ -154,6 +156,7 @@ module VersionDirs
             next
           else
             version = $versions[project.to_sym]
+            version = version.sub(/(\d+[.]\d+[.]\d+).*/, "\\1")
             move_to = f.sub(/\.\/build\//, "./build/#{project}/#{version}/")
           end
 

--- a/source/js/standalone/version-bar.coffee.erb
+++ b/source/js/standalone/version-bar.coffee.erb
@@ -108,6 +108,7 @@ $ ->
         vsp = window.parseVersion(vsi)
         if window.inVersionRange(vsp, range)
           current = window.compareVersions(currentVersion, vsp) == 0
+          vsi = vsi.replace(/(\d+[.]\d+[.]\d+).*/, '$1')
           vData = {active:true, firstInBlock:firstInBlock, current:current, href:"/#{project}/#{vsi}#{base_url}", text:vsi}
 
           for vr_link in moved_ranges_obj
@@ -116,12 +117,16 @@ $ ->
 
           lists.unshift(vData)
         else
+          vsi = vsi.replace(/(\d+[.]\d+[.]\d+).*/, '$1')
           lists.unshift({active:false, firstInBlock:firstInBlock, current:false, href:"#", text:vsi})
         firstInBlock = false
     lists
 
   version = $('meta[name=version]').attr('content')
   return unless version?
+
+  version = version.replace(/(\d+[.]\d+[.]\d+).*/, '$1')
+
   $("body").addClass("ver-#{version.replace(/\./g, '-')}")
 
   versionsEl = $('.mainarticle .versions')
@@ -165,13 +170,13 @@ $ ->
     " class=\"#{classStr} versions-#{blockCount}#{firstInBlock(li)}\""
 
   liLink = (li)->
-    "<a class=\"versioned\" href=\"#{li.href}\">#{li.text.replace('pre', 'p')}</a>"
+    "<a class=\"versioned\" href=\"#{li.href}\">#{li.text}</a>"
 
   output = ""
   output += "<div id=\"version-ddown-button\" class=\"unselected\">"
   output += "<div class=\"version-ddown-title\">Version</div>"
   output += "<div class=\"version-ddown-number\">"
-  output += "#{version.replace('pre', 'p')}"
+  output += "#{version}"
   output += "</div>"
   output += "<div class=\"version-ddown-arrow\"></div>"
   output += "</div>"
@@ -186,7 +191,6 @@ $ ->
   pageToLatest = window.compareVersions(latestVersion, currentVersion)
   if pageToLatest != 0
     latestUrl = document.URL.replace("/#{version}/", "/latest/")
-    short_version = version.replace(/(\d+\.\d+\.\d+)(.+)?/, "$1")
     if pageToLatest < 0
       halert_header = "This documentation is for an older version of Riak"
     else if pageToLatest > 0
@@ -198,7 +202,7 @@ $ ->
     halert += "<p><a href=\"#{latestUrl}\">"
     halert += "View the documentation for the latest version</a>"
     halert += "<span class=\"extra-alert-text\"> or select from the drop down on the left.</span>"
-    halert += "</p></div><div class=\"version-icon-alert-version-num\">#{short_version}</div>"
+    halert += "</p></div><div class=\"version-icon-alert-version-num\">#{version}</div>"
     halert += "<meta content=\"#{version}\" itemprop=\"version\">"
     halert += "<div class=\"clear\"></div></div>"
     versionsEl.after(halert)

--- a/source/languages/en/en.yml
+++ b/source/languages/en/en.yml
@@ -18,8 +18,8 @@ en:
   next: Next
   toc_contents: Contents
   footer: "This work is licensed under a <a href=\"http://creativecommons.org/licenses/by/3.0/\" target=\"_blank\">Creative Commons Attribution 3.0 Unported License</a>"
-  banner_ad: "Riak 2.0 Beta 1 is now available. <a class=\"register\" href=\"http://docs.basho.com/riak/2.0.0beta1/downloads/\">Download Here</a>"
-  banner_ad_mobile: "<a href=\"http://docs.basho.com/riak/2.0.0beta1/downloads/\">Download Riak 2.0 Beta 1</a>"
+  banner_ad: "Riak 2.0 RC 1 is now available. <a class=\"register\" href=\"http://docs.basho.com/riak/2.0.0/downloads/\">Download Here</a>"
+  banner_ad_mobile: "<a href=\"http://docs.basho.com/riak/2.0.0/downloads/\">Download Riak 2.0 RC 1</a>"
   alert_version_title_older: "This documentation is for an older version of Riak"
   alert_version_title_unreleased: "This documentation is for an unreleased version of Riak"
   alert_version_link_text: "View the documentation for the latest version"


### PR DESCRIPTION
Currently URL paths point to the specific version (eg `/riak/2.0.0beta1/`). Alter this to use the final URL (eg `/riak/2.0.0/`). This allows us to document in-development versions with unchanging URLs.
