### PR TITLE
WIP: Riak CS 1.5.0 docs

### DIFF
--- a/source/languages/en/riakcs-index.md
+++ b/source/languages/en/riakcs-index.md
@@ -43,9 +43,9 @@ Riak CS is open source and [[free for download|Download Riak CS]].
 </td>
 </tr>
 <tr>
-<td><strong>Multi-Datacenter Replication<br><i>(Enterprise Edition Only)</i></strong>{{1.3.0+}}</td>
+<td><strong>Multi-Datacenter Replication<br><em>(Enterprise Edition Only)</em></strong>{{1.3.0+}}</td>
 <td>
-<p>Riak CS [[Enterprise Edition|Riak Enterprise]] provides Multi-Datacenter Replication for active backups, disaster recovery, and data locality. Provide low-latency storage wherever your users are and maintain availability even in the event of site failure.</p>
+<p>Riak CS [[Enterprise Edition|Riak Enterprise]] provides Multi-Datacenter Replication for active backups, disaster recovery, and data locality. This enables you to provide low-latency storage for your users wherever they are and to maintain availability even in the event of site failure.</p>
 </td>
 </tr>
 </tbody>

--- a/source/languages/en/riakcs/tutorials/fast-track/Building-a-Local-Test-Environment.md
+++ b/source/languages/en/riakcs/tutorials/fast-track/Building-a-Local-Test-Environment.md
@@ -319,9 +319,9 @@ same Riak CS machine where the `anonymous_user_creation` configuration
 option was enabled:
 
 ```curl
-curl -H 'Content-Type: application/json' \
-  -X POST http://localhost:8080/riak-cs/user \
-  --data '{"email":"admin@admin.com", "name":"admin"}'
+curl -XPOST http://localhost:8080/riak-cs/user \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin@admin.com", "name":"admin"}'
 ```
 
 The output of this command will be a JSON object that looks something like this:

--- a/source/languages/en/riakcs/tutorials/fast-track/Testing-the-Installation.md
+++ b/source/languages/en/riakcs/tutorials/fast-track/Testing-the-Installation.md
@@ -77,18 +77,33 @@ We can see if it was properly uploaded by typing:
 s3cmd -c ~/.s3cfgfasttrack ls s3://test-bucket
 ```
 
-We can now download the test file:
+We can now download the test file. First, let's remove the file we generated previously:
 
 ``` bash
-# remove the local test file
 rm test_file
-# download from Riak CS
+```
+
+Now, we can download the `test_file`stored in Riak CS:
+
+```bash
 s3cmd -c ~/.s3cfgfasttrack get s3://test-bucket/test_file
-# verify that the download was successful
+```
+
+We should immediately see output like this:
+
+```
+s3://test-bucket/test_file -> ./test_file  [1 of 1]
+ 2097152 of 2097152   100% in    0s    59.63 MB/s  done
+```
+
+To verify that the file has been downloaded into the current directory:
+
+```bash
 ls -lah test_file
 ```
 
 ## What's Next
+
 If you have made it this far, congratulations! You now have a working Riak CS test instance (either virtual or local). There is still a fair bit of learning to be done, so make sure and check out the Reference section (click "Reference" on the nav on the left side of this page). A few items that may be of particular interest:
 
 * [[Details about API operations|RiakCS S3 Storage API]]


### PR DESCRIPTION
Addressing issue #1178. I'll reproduce the list of items in that issue here:
- [x] Multi-bag (multi-PB) support (tech preview)
- [x]  riak-cs-debug
- [x]  riak-cs-admin
- [x]  riak-cs-stanchion
- [ ] Syslog support through lager_syslog
- [ ] S3 API changes (COPY (tech preview), multi-DELETE, Cache Control headers)
- [x] Garbage collection improvements
- [ ] Configuration option(s) for features that can only be used with Riak 1.5
- [x] Update version compatibility page => #1063
- [ ] Fix CS install docs (especially for Mac OS X)
- [ ] New default value for ‘gc_paginated_indexes’

Time permitting
- [ ] Address ‘connection_pools’ attributes (https://github.com/basho/riak_cs/issues/752)
- [ ] Add kernel tuning advice (https://github.com/basho/riak_cs/issues/660)

https://github.com/basho/riak_cs/blob/release/1.5/RELEASE-NOTES.md#riak-cs-150-release-notes
