### PR TITLE
Remove incorrect statement on strong consistency + AAE

### DIFF
--- a/source/languages/en/riak/theory/concepts/strong-consistency.md
+++ b/source/languages/en/riak/theory/concepts/strong-consistency.md
@@ -71,7 +71,6 @@ Thus, likely outcomes from a write:
 The following Riak features are not currently available in strongly consistent buckets:
 
 * [[Secondary indexes|Using Secondary Indexes]]
-* [[Active Anti-Entropy|Riak Glossary#Active-Anti-Entropy-AAE]]
 * [[Riak Data Types|Using Data Types]]
 
 Strongly-consistent writes operate only on single keys. There is currently no support within Riak for strongly consistent operations against multiple keys, although it is always possible to incorporate write and read locks in an application that uses strongly-consistent Riak.


### PR DESCRIPTION
This commit removes the statement that AAE does not work with consistent data. This has not been true since 2.0 beta1.
