### PR TITLE
Remove 'Content-Type' as request header on Upload Part since it never be used.

### DIFF
--- a/source/languages/en/riakcs/references/apis/storage/s3/RiakCS-Upload-Part.md
+++ b/source/languages/en/riakcs/references/apis/storage/s3/RiakCS-Upload-Part.md
@@ -41,13 +41,6 @@ Authorization: signatureValue
 * *Default*: None
 * *Constraints*: None
 
-**Content-Type** - A standard MIME type that describes the content format.
-
-* *Type*: String
-* *Default*: binary/octet-stream
-* *Valid Values*: 100-continue
-* *Constraints*: None
-
 **Expect** - When you use `100-continue` in your application, it doesn't send the request body until it receives an acknowledgment. That way, the body of the message isn't sent if the message is rejected based on the headers.
 
 * *Type*: String


### PR DESCRIPTION
Riak CS never handles 'Content-Type' header on Upload Part request. The description may get a end-user confused so unfortunately it seem better to remove this.

ref: http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html
