### PR TITLE
fix typo in advanced/2i

### DIFF
--- a/source/languages/en/riak/dev/advanced/2i.md
+++ b/source/languages/en/riak/dev/advanced/2i.md
@@ -13,7 +13,7 @@ moved: {
 
 ## How It Works
 
-Secondary indexes use **document-based partitioning**, a system wherey
+Secondary indexes use **document-based partitioning**, a system where
 indexes reside with each document, local to the vnode. This system is
 also a local index. Secondary indexes are a list of key/value pairs that
 are similar to HTTP headers. At write time, objects are tagged with


### PR DESCRIPTION
change "wherey" to "where"
