### PR TITLE
'Part Upload - Copy' API have been supported since Riak CS 1.5.0.

### DIFF
--- a/source/languages/en/riakcs/references/apis/storage/s3/index.md
+++ b/source/languages/en/riakcs/references/apis/storage/s3/index.md
@@ -38,7 +38,7 @@ GET Bucket Info (HEAD) | <abbr title="Supported" class="supported">✓</abbr> | 
 Bucket Request Payment | <abbr title="Unsupported" class="unsupported">✗</abbr> | |
 PUT Object | <abbr title="Supported" class="supported">✓</abbr> | |
 Put Object (Copy) {{1.5.0+}} | <abbr title="Supported" class="supported">✓</abbr> | |
-PUT Object (Copy) {{1.3.0-1.5.0}} | <abbr title="Supported" class="supported">✓</abbr> | Support is limited to a 0 byte copy from an object to itself for the purpose of updating metadata. |
+PUT Object (Copy) {{1.3.0-1.4.5}} | <abbr title="Supported" class="supported">✓</abbr> | Support is limited to a 0 byte copy from an object to itself for the purpose of updating metadata. |
 PUT Object (Copy) {{1.3.0-}} | Coming Soon | Planned for future release |
 DELETE Object | <abbr title="Supported" class="supported">✓</abbr> | |
 DELETE Multiple Objects | <abbr title="Supported" class="supported">✓</abbr> | |
@@ -48,7 +48,8 @@ Object ACLs (GET, PUT) | <abbr title="Supported" class="supported">✓</abbr> | 
 HEAD Object | <abbr title="Supported" class="supported">✓</abbr> | |
 POST Object | <abbr title="Unsupported" class="unsupported">✗</abbr> | |
 Copy Object | <abbr title="Supported" class="supported">✓</abbr> | |
-Multipart Uploads {{1.3.0+}} | <abbr title="Supported" class="supported">✓</abbr> | UploadPartCopy unimplemented |
+Multipart Uploads {{1.5.0+}} | <abbr title="Supported" class="supported">✓</abbr> | |
+Multipart Uploads {{1.3.0-1.4.5}} | <abbr title="Supported" class="supported">✓</abbr> | UploadPartCopy unimplemented |
 Multipart Uploads {{1.3.0-}} | Coming Soon | Planned for future release |
 
 ## Service-level Operations


### PR DESCRIPTION
This PR depends on #1314.

The commits of Part upload - copy. https://github.com/basho/riak_cs/pull/868
