### PR TITLE
Update multi.md

### DIFF
--- a/source/languages/en/riak/ops/advanced/backends/multi.md
+++ b/source/languages/en/riak/ops/advanced/backends/multi.md
@@ -190,10 +190,10 @@ the default.
 storage_backend = multi
 
 multi_backend.bitcask_mult.storage_backend = bitcask
-multi_backend.bitcask_mult.bitcask.data_root = "/var/lib/riak/bitcask"
+multi_backend.bitcask_mult.bitcask.data_root = /var/lib/riak/bitcask_mult
 
 multi_backend.leveldb_mult.storage_backend = leveldb
-multi_backend.leveldb_mult.bitcask.data_root = "/var/lib/riak/leveldb"
+multi_backend.leveldb_mult.leveldb.data_root = /var/lib/riak/leveldb_mult
 
 multi_backend.default = bitcask_mult
 ```


### PR DESCRIPTION
Removed quotes around the directory names, riak creates directories with quotes if you do so, and in a really wierd way, perhaps it should be reported as a bug to cuttlefish or riak kv ?

Having followed the instructions, with a data directory - `"/var/lib/riak/bitcask"`.

Also renamed the data storage directories to reflect their connection with the name, as discussed, might do some more work on this page.

I found it necessary to remove the created directory, which was under a directory relative to Riak.

```
rm -rf \"*
```

Corrected typo bitcask -> leveldb
