### PR TITLE
Fixes to HTTP code on "Using Data Types" page

### DIFF
--- a/source/languages/en/riak/dev/using/data-types.md
+++ b/source/languages/en/riak/dev/using/data-types.md
@@ -292,7 +292,7 @@ Counter2 = riakc_counter:increment(5, Counter1).
 ```
 
 ```curl
-curl -XPUT http://localhost:8098/types/counters/buckets/counters/datatypes/traffic_tickets \
+curl -XPOST http://localhost:8098/types/counters/buckets/counters/datatypes/traffic_tickets \
   -H "Content-Type: application/json" \
   -d 5
 ```


### PR DESCRIPTION
Using -XPUT in the curl request examples for counters returned `405 Method Not Allowed`. Changing the three examples using -XPUT to use -XPOST instead allows the curl commands to function properly.

There are also two other curl examples that failed:
  • The example demonstrating that registers can also be removed contained an extra "update" bracket resulting in the error: `Invalid map field name 'remove'`.
  • The example demonstrating a map within a map within a map was missing a necessary "update" bracket resulting in the error: `Invalid operation on datatype 'map': "first_purchase_flag"`.
