### PR TITLE
Fix missing `

### DIFF
--- a/source/languages/en/riak/dev/using/data-types.md
+++ b/source/languages/en/riak/dev/using/data-types.md
@@ -1374,7 +1374,7 @@ map.maps['annika_info'].registers.remove('phone_number')
 ```python
 del map.maps['annika_info'].registers['phone_number']
 map.store()
-``
+```
 
 ```erlang
 Map15 = riakc_map:update({<<"annika_info">>, map},


### PR DESCRIPTION
Fixed the following formatting problem:

![screen shot 2015-01-07 at 11 29 29 am](https://cloud.githubusercontent.com/assets/1332954/5640433/7dd0b86c-9660-11e4-843e-d87e84107544.png)
