### PR TITLE
Using Search: Add a closing quotation mark to an example

### DIFF
--- a/source/languages/en/riak/dev/using/search.md
+++ b/source/languages/en/riak/dev/using/search.md
@@ -163,7 +163,7 @@ riakc_pb_socket:create_search_index(Pid, <<"famous">>).
 ```
 
 ```curl
-export RIAK_HOST="http://localhost:8098
+export RIAK_HOST="http://localhost:8098"
 
 curl -XPUT $RIAK_HOST/search/index/famous
 ```


### PR DESCRIPTION
The example that shows how to export the $RIAK_HOST environment variable lacked a closing quotation mark.
