### PR TITLE
Feature/doc fixes: Deprecation notice for link walking

### DIFF
--- a/source/languages/en/riak/dev/using/link-walking.md
+++ b/source/languages/en/riak/dev/using/link-walking.md
@@ -10,6 +10,11 @@ moved: {
 }
 ---
 
+<div class="info"><div class="title">Deprecation Notice</div>Link Walking is a deprecated feature of Riak and will eventually be removed. Please refrain from using it, and instead model your data where related data are multi-step lookups, or consider an alternative query option such as [[Riak Search|Using Search]] or [[MapReduce|Using MapReduce]].
+<br />
+Link walking <strong>will not work</strong> when [[security|Authentication and Authorization]] is enabled.
+</div>
+
 ## What are Links?
 
 One of the ways that we are able to extend the fairly-limited data model provided by a key/value store is with the notion "links" and a type of query known as "link walking."

--- a/source/languages/en/riak/dev/using/link-walking.md
+++ b/source/languages/en/riak/dev/using/link-walking.md
@@ -12,6 +12,8 @@ moved: {
 
 <div class="info"><div class="title">Deprecation Notice</div>Link Walking is a deprecated feature of Riak and will eventually be removed. Please refrain from using it, and instead model your data where related data are multi-step lookups, or consider an alternative query option such as [[Riak Search|Using Search]] or [[MapReduce|Using MapReduce]].
 <br />
+In Riak 2.0 link walking is only supported on the default bucket type.
+<br />
 Link walking <strong>will not work</strong> when [[security|Authentication and Authorization]] is enabled.
 </div>
 

--- a/source/languages/en/riak/dev/using/link-walking.md
+++ b/source/languages/en/riak/dev/using/link-walking.md
@@ -10,7 +10,7 @@ moved: {
 }
 ---
 
-<div class="info"><div class="title">Deprecation Notice</div>Link Walking is a deprecated feature of Riak and will eventually be removed. Please refrain from using it, and instead model your data where related data are multi-step lookups, or consider an alternative query option such as [[Riak Search|Using Search]] or [[MapReduce|Using MapReduce]].
+<div class="info"><div class="title">Deprecation Notice</div>Link walking is a deprecated feature of Riak and will eventually be removed. Please refrain from using it, and instead model your data where related data are multi-step lookups, or consider an alternative query option such as [[Riak Search|Using Search]] or [[MapReduce|Using MapReduce]].
 <br />
 In Riak 2.0 link walking is only supported on the default bucket type.
 <br />


### PR DESCRIPTION
Confusion about the status of link walking in Riak-2.0 has surfaced several times over the last week. I have resurrected the deprecation warning that was dropped without an explanation.

Please review and merge if appropriate