### PR TITLE
Feature/doc fixes: Avoid wrong version for ubuntu downloads

### DIFF
--- a/source/languages/en/riak/ops/building/installing/debian-ubuntu.md
+++ b/source/languages/en/riak/ops/building/installing/debian-ubuntu.md
@@ -34,11 +34,11 @@ installation, Chef, and Puppet can be found in packagecloud's
 
 Platform-specific pages are linked below:
 
-* [Lucid](https://packagecloud.io/basho/riak/riak_2.0.4-1_amd64.deb?distro=lucid)
-* [Precise](https://packagecloud.io/basho/riak/riak_2.0.4-1_amd64.deb?distro=precise)
-* [Squeeze](https://packagecloud.io/basho/riak/riak_2.0.4-1_amd64.deb?distro=squeeze)
-* [Trusty](https://packagecloud.io/basho/riak/riak_2.0.4-1_amd64.deb?distro=trusty)
-* [Wheezy](https://packagecloud.io/basho/riak/riak_2.0.4-1_amd64.deb?distro=wheezy)
+* [Lucid](https://packagecloud.io/basho/riak/riak_{{VERSION}}-1_amd64.deb?distro=lucid)
+* [Precise](https://packagecloud.io/basho/riak/riak_{{VERSION}}-1_amd64.deb?distro=precise)
+* [Squeeze](https://packagecloud.io/basho/riak/riak_{{VERSION}}-1_amd64.deb?distro=squeeze)
+* [Trusty](https://packagecloud.io/basho/riak/riak_{{VERSION}}-1_amd64.deb?distro=trusty)
+* [Wheezy](https://packagecloud.io/basho/riak/riak_{{VERSION}}-1_amd64.deb?distro=wheezy)
 
 Our documentation also includes instructions regarding signing keys and
 sources lists, which can be found in the [[Advanced apt

--- a/source/languages/en/riak/ops/upgrading/production-checklist.md
+++ b/source/languages/en/riak/ops/upgrading/production-checklist.md
@@ -28,7 +28,7 @@ to ask while making this transition.
 
 * Are all systems using the same [NTP servers](http://www.ntp.org/) to
   synchronize clocks?
-* Are your sure that your NTP clients' configuration is monotonic (i.e.
+* Are you sure that your NTP clients' configuration is monotonic (i.e.
   that your clocks will not roll back)?
 * Is DNS correctly configured for all systems' production deployments?
 * Are connections correctly routed between all Riak nodes?


### PR DESCRIPTION
We still have the wrong version on the Ubuntu download page