### PR TITLE
Add a context to all http examples for data types that should have one

### DIFF
--- a/source/languages/en/riak/dev/using/data-types.md
+++ b/source/languages/en/riak/dev/using/data-types.md
@@ -656,7 +656,7 @@ CitiesSet5 = riakc_set:add_element(<<"Ottawa">>, CitiesSet4).
 ```curl
 curl -XPOST http://localhost:8098/types/sets/buckets/travel/datatypes/cities \
   -H "Content-Type: application/json" \
-  -d '{"remove": "Montreal"}'
+  -d '{"remove": "Montreal", "context" : "g2wAAAABaAJtAAAACCMJ/vkCeL5aYQlq"}'
 ```
 
 Now, we can check on which cities are currently in our set:
@@ -718,7 +718,7 @@ curl http://localhost:8098/types/sets/buckets/travel/datatypes/cities
 
 # Response
 
-{"type":"set","value":["Toronto"],"context":"SwGDUAAAAER4ActgymFgYGDMYMoFUhxHgzZyBzMfsU9kykISZg/JL8rPK8lHEkKoZMzKAgDwJA+e"}
+{"type":"set","value":["Toronto"],"context":"g2wAAAABaAJtAAAACCMJ/vkCeL5aYQhq"}
 
 # You can also fetch the value of the set without the context included:
 curl http://localhost:8098/types/sets/buckets/travel/datatypes/cities?include_context=false

--- a/source/languages/en/riak/dev/using/data-types.md
+++ b/source/languages/en/riak/dev/using/data-types.md
@@ -718,7 +718,7 @@ curl http://localhost:8098/types/sets/buckets/travel/datatypes/cities
 
 # Response
 
-{"type":"set","value":["Toronto"],"context":"g2wAAAABaAJtAAAACCMJ/vkCeL5aYQhq"}
+{"type":"set","value":["Toronto"],"context": "g2wAAAABaAJtAAAACCMJ/vkCeL5aYQhq"}
 
 # You can also fetch the value of the set without the context included:
 curl http://localhost:8098/types/sets/buckets/travel/datatypes/cities?include_context=false
@@ -1004,7 +1004,7 @@ curl -XPOST http://localhost:8098/types/maps/buckets/customers/datatypes/ahmed_i
     "update": {
       "enterprise_customer_flag": "disable"
     },
-    "context" : "g2wAAAABaAJtAAAACCMJ/vkCeL5aYQlq"
+    "context": "g2wAAAABaAJtAAAACCMJ/vkCeL5aYQlq"
   }'
 ```
 
@@ -1243,7 +1243,7 @@ curl -XPOST http://localhost:8098/types/maps/buckets/customers/datatypes/ahmed_i
         "add": "indie pop"
       }
     },
-    "context" : "g2wAAAABaAJtAAAACCMJ/vkCeL5aYQlq"
+    "context": "g2wAAAABaAJtAAAACCMJ/vkCeL5aYQlq"
   }
   '
 ```
@@ -1415,7 +1415,7 @@ curl -XPOST http://localhost:8098/types/maps/buckets/customers/datatypes/ahmed_i
         "remove": "phone_number_register"
       }
     },
-    "context" : "g2wAAAABaAJtAAAACCMJ/vkCeL5aYQlq"
+    "context": "g2wAAAABaAJtAAAACCMJ/vkCeL5aYQlq"
   }
   '
 ```
@@ -1494,7 +1494,7 @@ curl -XPOST http://localhost:8098/types/maps/buckets/customers/datatypes/ahmed_i
         }
       }
     },
-    "context" : "g2wAAAABaAJtAAAACCMJ/vkCeL5aYQlq"
+    "context": "g2wAAAABaAJtAAAACCMJ/vkCeL5aYQlq"
   }
   '
 ```
@@ -1680,7 +1680,7 @@ curl -XPOST http://localhost:8098/types/maps/buckets/customers/datatypes/ahmed_i
         }
       }
     },
-    "context" : "g2wAAAABaAJtAAAACCMJ/vkCeL5aYQlq"
+    "context": "g2wAAAABaAJtAAAACCMJ/vkCeL5aYQlq"
   }
   '
 ```

--- a/source/languages/en/riak/dev/using/data-types.md
+++ b/source/languages/en/riak/dev/using/data-types.md
@@ -1003,7 +1003,8 @@ curl -XPOST http://localhost:8098/types/maps/buckets/customers/datatypes/ahmed_i
   {
     "update": {
       "enterprise_customer_flag": "disable"
-    }
+    },
+    "context" : "g2wAAAABaAJtAAAACCMJ/vkCeL5aYQlq"
   }'
 ```
 
@@ -1241,7 +1242,8 @@ curl -XPOST http://localhost:8098/types/maps/buckets/customers/datatypes/ahmed_i
         "remove": "opera",
         "add": "indie pop"
       }
-    }
+    },
+    "context" : "g2wAAAABaAJtAAAACCMJ/vkCeL5aYQlq"
   }
   '
 ```
@@ -1412,7 +1414,8 @@ curl -XPOST http://localhost:8098/types/maps/buckets/customers/datatypes/ahmed_i
       "annika_info_map": {
         "remove": "phone_number_register"
       }
-    }
+    },
+    "context" : "g2wAAAABaAJtAAAACCMJ/vkCeL5aYQlq"
   }
   '
 ```
@@ -1490,7 +1493,8 @@ curl -XPOST http://localhost:8098/types/maps/buckets/customers/datatypes/ahmed_i
           "free_plan_flag": "enable"
         }
       }
-    }
+    },
+    "context" : "g2wAAAABaAJtAAAACCMJ/vkCeL5aYQlq"
   }
   '
 ```
@@ -1675,7 +1679,8 @@ curl -XPOST http://localhost:8098/types/maps/buckets/customers/datatypes/ahmed_i
           "remove": "tango dancing"
         }
       }
-    }
+    },
+    "context" : "g2wAAAABaAJtAAAACCMJ/vkCeL5aYQlq"
   }
   '
 ```


### PR DESCRIPTION
Since people tend to cut and paste examples, I think it better to have the recommended `context` field for all operations that should use one (removes, flag disables.) I also shortened the context to resemble one more typically seen in normal operation.