### PR TITLE
add signature_v2 on s3cmd's config

### DIFF
--- a/source/languages/en/riakcs/cookbooks/configuration/Configuring-an-S3-Client.md
+++ b/source/languages/en/riakcs/cookbooks/configuration/Configuring-an-S3-Client.md
@@ -78,6 +78,7 @@ socket_timeout = 300
 urlencoding_mode = normal
 use_https = False
 verbosity = WARNING
+signature_v2 = True
 ```
 
 ## Sample s3cmd Configuration File for Production Use
@@ -125,6 +126,7 @@ socket_timeout = 300
 urlencoding_mode = normal
 use_https = True
 verbosity = WARNING
+signature_v2 = True
 ```
 
 To configure the s3cmd client for the user, you must change the


### PR DESCRIPTION
s3cmd was changed to use AWS Authentication v4 on default, but current RIak CS release doesn't support v4 yet. So, `signature_v2 = True` is require to connect to Riak CS via s3cmd.