### PR TITLE
Clarify SSL setting documentation [RIAK-1613]

### DIFF
--- a/source/languages/en/riak/ops/mdc/v2/configuration.md
+++ b/source/languages/en/riak/ops/mdc/v2/configuration.md
@@ -81,16 +81,16 @@ Setting | Options | Default | Description
 :-------|:--------|:--------|:-----------
 `ssl_enabled` | `true`, `false` | `false` | Enable SSL communications
 `keyfile` | `path` (string) | `undefined` | Fully qualified path to an SSL `.pem` key file
-`data_root` | `path` (string) | `data/riak_repl` | Path (relative or absolute) to the working directory for the replication process
 `cacertdir` | `path` (string) | `undefined` | The `cacertdir` is a fully-qualified directory containing all the CA certificates needed to verify the CA chain back to the root
 `certfile` | `path` (string) | `undefined` | Fully qualified path to a `.pem` cert file
-`ssl_depth` | `depth` (integer) | `1` | Set the depth to check for SSL CA certs. See <a href="/ops/mdc/v2/configuration/#f1">1</a>.
-`peer_common_name_acl` | `cert` (string) | `"*"` | Verify an SSL peer’s certificate common name. You can provide multiple ACLs as a list of strings, and you can wildcard the leftmost part of the common name, so `*.basho.com` would match `site3.basho.com` but not `foo.bar.basho.com` or `basho.com`. See <a href="/ops/mdc/v2/configuration/#f4">4</a>.
+`ssl_depth` | `depth` (integer) | `1` | Set the depth to check for SSL CA certs. See [1](/ops/mdc/v2/configuration/#f1).
+`peer_common_name_acl` | `cert` (string) | `"*"` | Verify an SSL peer’s certificate common name. You can provide an ACL as a list of common name *patterns*, and you can wildcard the leftmost part of any of the patterns, so `*.basho.com` would match `site3.basho.com` but not `foo.bar.basho.com` or `basho.com`. See [4](/ops/mdc/v2/configuration/#f4).
 
 ## Queue, Object, and Batch Settings
 
 Setting | Options | Default | Description
 :-------|:--------|:--------|:-----------
+`data_root` | `path` (string) | `data/riak_repl` | Path (relative or absolute) to the working directory for the replication process
 `queue_size` | `bytes` (integer) | `104857600` (100 MiB) | The size of the replication queue in bytes before the replication leader will drop requests. If requests are dropped, a fullsync will be required. Information about dropped requests is available using the `riak-repl status` command
 `server_max_pending` | `max` (integer) | `5` | The maximum number of objects the leader will wait to get an acknowledgment from, from the remote location, before queuing the request
 `vnode_gets` | `true`, `false` | `true` | If `true`, repl will do a direct get against the vnode, rather than use a `GET` finite state machine
@@ -116,20 +116,31 @@ Setting | Options | Default | Description
 
 Setting | Options | Default | Description
 :-------|:--------|:--------|:-----------
-`max_get_workers` | `max` (integer) | `100` | The maximum number of get workers spawned for fullsync. Every time a replication difference is found, a `GET` will be performed to get the actual object to send. See <a href="/ops/mdc/v2/configuration/#f2">2</a>.
-`max_put_workers` | `max` (integer) | `100` | The maximum number of put workers spawned for fullsync. Every time a replication difference is found, a `GET` will be performed to get the actual object to send. See <a href="/ops/mdc/v2/configuration/#f3">3</a>.
-`min_get_workers` | `min` (integer) | `5` | The minimum number of get workers spawned for fullsync. Every time a replication difference is found, a `GET` will be performed to get the actual object to send. See <a href="/ops/mdc/v2/configuration/#f2">2</a>.
-`min_put_workers` | `min` (integer) | `5` | The minimum number of put workers spawned for fullsync. Every time a replication difference is found, a `GET` will be performed to get the actual object to send. See <a href="/ops/mdc/v2/configuration/#f3">3</a>.
+`max_get_workers` | `max` (integer) | `100` | The maximum number of get workers spawned for fullsync. Every time a replication difference is found, a `GET` will be performed to get the actual object to send. See [2](/ops/mdc/v2/configuration/#f2).
+`max_put_workers` | `max` (integer) | `100` | The maximum number of put workers spawned for fullsync. Every time a replication difference is found, a `GET` will be performed to get the actual object to send. See [3](/ops/mdc/v2/configuration/#f3).
+`min_get_workers` | `min` (integer) | `5` | The minimum number of get workers spawned for fullsync. Every time a replication difference is found, a `GET` will be performed to get the actual object to send. See [2](/ops/mdc/v2/configuration/#f2).
+`min_put_workers` | `min` (integer) | `5` | The minimum number of put workers spawned for fullsync. Every time a replication difference is found, a `GET` will be performed to get the actual object to send. See [3](/ops/mdc/v2/configuration/#f3).
 
 
-1. <a name="f1"></a>SSL depth is the maximum number of non-self-issued intermediate certificates that may follow the peer certificate in a valid certification path. If depth is `0`, the PEER must be signed by the trusted ROOT-CA directly; if `1` the path can be PEER, CA, ROOT-CA; if depth is `2` then PEER, CA, CA, ROOT-CA and so on.
+1. <a name="f1"></a>SSL depth is the maximum number of non-self-issued
+ intermediate certificates that may follow the peer certificate in a valid
+ certificate chain. If depth is `0`, the PEER must be signed by the trusted
+ ROOT-CA directly; if `1` the path can be PEER, CA, ROOT-CA; if depth is `2`
+ then PEER, CA, CA, ROOT-CA and so on.
 
-2. <a name="f2"></a>Each get worker spawns 2 processes, one for the work and one for the get FSM (an Erlang finite state machine implementation for `GET` requests). Be sure that you don't run over the maximum number of allowed processes in an Erlang VM (check `vm.args` for a `+P` property).
+2. <a name="f2"></a>Each get worker spawns 2 processes, one for the work and
+ one for the get FSM (an Erlang finite state machine implementation for `GET`
+ requests). Be sure that you don't run over the maximum number of allowed
+ processes in an Erlang VM (check `vm.args` for a `+P` property).
 
 3. <a name="f3"></a>Each put worker spawns 2 processes, one for the work, and
-  one for the put FSM (an Erlang finite state machine implementation for `PUT` requests). Be sure that you don't run over the maximum number of allowed
+  one for the put FSM (an Erlang finite state machine implementation for `PUT`
+  requests). Be sure that you don't run over the maximum number of allowed
   processes in an Erlang VM (check `vm.args` for a `+P` property).
 
 4. <a name="f4"></a>If the ACL is specified and not the special value `*`,
-  certificates not matching any of the rules will not be allowed to connect.
-  If no ACLs are configured, no checks on the common name are done.
+ peers presenting certificates not matching any of the patterns will not be
+ allowed to connect.
+ If no ACLs are configured, no checks on the common name are done, except
+ as described for [[Identical Local and Peer Common Names
+ |Multi Data Center Replication: SSL#Verifying-Peer-Certificates]].

--- a/source/languages/en/riak/ops/mdc/v2/ssl.md
+++ b/source/languages/en/riak/ops/mdc/v2/ssl.md
@@ -42,17 +42,33 @@ needed to verify the CA chain back to the root.
 
 ## Verifying Peer Certificates
 
-Verification of a peer's certificate common name is enabled by using the 
-`peer_common_name_acl` property in the `riak_repl` section of your
-`app.config`.
+Verification of a peer's certificate common name *(CN)* is enabled by using
+the `peer_common_name_acl` property in the `riak_repl` section of your
+`app.config` to specify an Access Control List *(ACL)*.
 
-You can provide multiple ACLs, separated by commas, and you can wildcard
-the leftmost part of the common name. For example, `*.corp.com` would
-match `site3.corp.com` but not `foo.bar.corp.com` or `corp.com`. If the
-ACL is specified and not the special value `"*"`, certificates not
-matching any of the rules will not be allowed to connect.
+The ACL is a list of one or more *patterns*, separated by commas. Each
+pattern may be either the exact CN of a certificate to allow, or a
+wildcard in the form `*.some.domain.name`. Pattern comparison is
+case-insensitive, and a CN matching any of the patterns is allowed to connect.
 
-If no ACLs are configured, no checks on the common name are done.
+For example, `["*.corp.com"]` would match `site3.corp.com` but not
+`foo.bar.corp.com` or `corp.com`. If the ACL were
+`["*.corp.com", "foo.bar.corp.com"]`, `site3.corp.com` and `foo.bar.corp.com`
+would be allowed to connect, but `corp.com` still would not.
+
+If no ACL (or only the special value `"*"`) is specified, no CN filtering
+is performed, except as described below.
+
+<div class="info">
+<div class="title">Identical Local and Peer Common Names</div>
+As a special case supporting the view that a host's CN is a fully-qualified
+domain name that uniquely identifies a single network device, if the CNs of
+the local and peer certificates are the same, the nodes will *NOT* be allowed
+to connect.
+
+This evaluation supercedes ACL checks, so it cannot be overridden with any
+setting of the `peer_common_name_acl` property.
+</div>
 
 ### Examples
 
@@ -106,8 +122,10 @@ following to the `riak_repl` section of your `app.config`:
 **Note**: `ssl_depth` takes an integer parameter.
 
 The depth specifies the maximum number of intermediate certificates that
-may follow the peer certificate in a valid certification path. The
-intermediate certificates must not be self signed.
+may follow the peer certificate in a valid certification path. By default,
+no more than one (1) intermediate certificate is allowed between the peer
+certificate and root CA. By definition, intermediate certificates cannot
+be self signed.
 
 For example:
 

--- a/source/languages/en/riak/ops/mdc/v3/configuration.md
+++ b/source/languages/en/riak/ops/mdc/v3/configuration.md
@@ -79,8 +79,9 @@ Setting | Options | Default | Description
 `rtq_overload_recover` | `length` (integer) | `1000` | The length to which the realtime replication queue, in an overload mode, must shrink before new objects are replicated again.
 `rtq_max_bytes` | `bytes` (integer) | `104857600` | The maximum size to which the realtime replication queue can grow before new objects are dropped. Defaults to 100MB. Dropped objects will need to be replicated with a fullsync.
 `proxy_get` | `enabled`, `disabled` | `disabled` | Enable Riak CS `proxy_get` and block filter.
-`rt_heartbeat_interval` | `seconds` (integer) | `15` | A full explanation can be found [[below|Multi Data Center Replication v3 Configuration#Heartbeat-Settings]].
-`rt_heartbeat_timeout` | `seconds` (integer) | `15` | A full explanation can be found [[below|Multi Data Center Replication v3 Configuration#Heartbeat-Settings]].
+`rt_heartbeat_interval` | `seconds` (integer) | `15` | A full explanation can be found [below](/ops/mdc/v3/configuration/#Heartbeat-Settings).
+`rt_heartbeat_timeout` | `seconds` (integer) | `15` | A full explanation can be found [below](/ops/mdc/v3/configuration/#Heartbeat-Settings).
+
 
 ## riak_core Settings
 
@@ -89,9 +90,10 @@ Setting | Options | Default | Description
 `keyfile` | `path` (string) | `undefined` | Fully qualified path to an ssl `.pem` key file
 `cacertdir` | `path` (string) | `undefined` | The `cacertdir` is a fully-qualified directory containing all the CA certificates needed to verify the CA chain back to the root
 `certfile` | `path` (string) | `undefined` | Fully qualified path to a `.pem` cert file
-`ssl_depth` | `depth` (integer) | `1` | Set the depth to check for SSL CA certs. See <a href="/ops/mdc/v2/configuration/#f1">1</a>.
+`ssl_depth` | `depth` (integer) | `1` | Set the depth to check for SSL CA certs. See [1](/ops/mdc/v3/configuration/#f1).
 `ssl_enabled` | `true`, `false` | `false` | Enable SSL communications
-`peer_common_name_acl` | `cert` (string) | `"*"` | Verify an SSL peer’s certificate common name. You can provide multiple ACLs as a list of strings, and you can wildcard the leftmost part of the common name, so `*.basho.com` would match `site3.basho.com` but not `foo.bar.basho.com` or `basho.com`. See <a href="/ops/mdc/v2/configuration/#f4">2</a>.
+`peer_common_name_acl` | `cert` (string) | `"*"` | Verify an SSL peer’s certificate common name. You can provide an ACL as a list of common name *patterns*, and you can wildcard the leftmost part of any of the patterns, so `*.basho.com` would match `site3.basho.com` but not `foo.bar.basho.com` or `basho.com`. See [2](/ops/mdc/v3/configuration/#f2).
+
 
 ## Heartbeat Settings
 
@@ -113,12 +115,14 @@ lengthening the timeout will make Riak less sensitive to cases in which
 the connection really has been compromised.
 
 1. <a name="f1"></a>SSL depth is the maximum number of non-self-issued
-intermediate certificates that may follow the peer certificate in a
-valid certification path. If depth is `0` the PEER must be signed by the
-trusted ROOT-CA directly; if `1` the path can be PEER, CA, ROOT-CA; if
-depth is `2` then PEER, CA, CA, ROOT-CA and so on.
+ intermediate certificates that may follow the peer certificate in a valid
+ certificate chain. If depth is `0`, the PEER must be signed by the trusted
+ ROOT-CA directly; if `1` the path can be PEER, CA, ROOT-CA; if depth is `2`
+ then PEER, CA, CA, ROOT-CA and so on.
 
-2. <a name="f4"></a>If the ACL is specified and not the special value
-`*`, certificates not matching any of the rules will not be allowed to
-connect. If no ACLs are configured, no checks on the common name are
-done.
+2. <a name="f2"></a>If the ACL is specified and not the special value `*`,
+  peers presenting certificates not matching any of the patterns will not be
+  allowed to connect.
+  If no ACLs are configured, no checks on the common name are done, except
+  as described for [[Identical Local and Peer Common Names
+  |Multi Data Center Replication v3 SSL#Verifying-Peer-Certificates]].

--- a/source/languages/en/riak/ops/mdc/v3/ssl.md
+++ b/source/languages/en/riak/ops/mdc/v3/ssl.md
@@ -57,19 +57,40 @@ In Version 3 replication, the SSL settings need to be placed in the
 the <code>riak-repl</code> section used by Version 2 replication.
 </div>
 
-## Verifying peer certificates
+## Verifying Peer Certificates
 
-Verification of a peer's certificate common name is enabled using the
-`peer_common_name_acl` property in the `riak_repl` section of
-`app.config`.
+Verification of a peer's certificate common name *(CN)* is enabled by using
+the `peer_common_name_acl` property in the `riak_core` section of your
+`app.config` to specify an Access Control List *(ACL)*.
 
-You can provide multiple ACLs, separated by commas, and you can wildcard
-the leftmost part of the common name. For example, `*.corp.com` would
-match `site3.corp.com` but not `foo.bar.corp.com` or `corp.com`. If the
-ACL is specified and not the special value `"*"`, certificates not
-matching any of the rules will not be allowed to connect.
+The ACL is a list of one or more *patterns*, separated by commas. Each
+pattern may be either the exact CN of a certificate to allow, or a
+wildcard in the form `*.some.domain.name`. Pattern comparison is
+case-insensitive, and a CN matching any of the patterns is allowed to connect.
 
-If no ACLs are configured, no checks on the common name are done.
+For example, `["*.corp.com"]` would match `site3.corp.com` but not
+`foo.bar.corp.com` or `corp.com`. If the ACL were
+`["*.corp.com", "foo.bar.corp.com"]`, `site3.corp.com` and `foo.bar.corp.com`
+would be allowed to connect, but `corp.com` still would not.
+
+If no ACL (or only the special value `"*"`) is specified, no CN filtering
+is performed, except as described below.
+
+<div class="info">
+<div class="title">Identical Local and Peer Common Names</div>
+As a special case supporting the view that a host's CN is a fully-qualified
+domain name that uniquely identifies a single network device, if the CNs of
+the local and peer certificates are the same, the nodes will *NOT* be allowed
+to connect.
+
+{{#2.1.0+}}An exception is made when the CN begins with `*`, on the assumption
+that a pool of nodes might all legitimately use a certificate with a CN
+like `*.dc5.example.com`. In this specific case, peers with matching CNs are
+allowed to connect, so long as an explicit or implicit ACL allows it.{{/2.1.0+}}
+
+This evaluation supercedes ACL checks, so it cannot be overridden with any
+setting of the `peer_common_name_acl` property.
+</div>
 
 ### Examples
 


### PR DESCRIPTION
Document default for ssl_depth on SSL-specific pages.
Improve documentation for peer_common_name_acl.
Add a note about the handling of identical certificate CNs.