### PR TITLE
Obvious spelling error is obvious...length shortened

### DIFF
--- a/source/languages/en/en.yml
+++ b/source/languages/en/en.yml
@@ -20,7 +20,7 @@ en:
   footer: "This work is licensed under a <a href=\"http://creativecommons.org/licenses/by/3.0/\" target=\"_blank\">Creative Commons Attribution 3.0 Unported License</a>"
   banner_ad: "Riak 2.0.5 is now available. <a class=\"register\" href=\"http://docs.basho.com/riak/latest/downloads/\">Download Here</a>"
   banner_ad_mobile: "<a href=\"http://docs.basho.com/riak/latest/downloads/\">Download Riak 2.0</a>"
-  marketing_ad: "<strong>Register with Basho</strong> to be kept up-do-date on new Riak product releases, educational materials, and events"
+  marketing_ad: "<strong>Register with Basho</strong> to be kept up-to-date on Riak releases, education, and events"
   marketing_ad_mobile: "<a href=\"http://docs.basho.com/riak/latest/downloads/\">Download Riak 2.0.5</a>"
   alert_version_title_older: "This documentation is for an older version of Riak"
   alert_version_title_unreleased: "This documentation is for an unreleased version of Riak"


### PR DESCRIPTION
The promo banner has always had length issues...but the spelling error was egregious.

This attempts to rectify both (without actually making the banner fully responsive because...reasons).