### PR TITLE
Fix network tuning settings being in the wrong section

### DIFF
--- a/source/languages/en/riak/ops/tuning/linux.md
+++ b/source/languages/en/riak/ops/tuning/linux.md
@@ -42,16 +42,6 @@ as possible:
 
 ```config
 vm.swappiness = 0
-net.ipv4.tcp_max_syn_backlog = 40000
-net.core.somaxconn = 40000
-net.core.wmem_default = 8388608
-net.core.rmem_default = 8388608
-net.ipv4.tcp_sack = 1
-net.ipv4.tcp_window_scaling = 1
-net.ipv4.tcp_fin_timeout = 15
-net.ipv4.tcp_keepalive_intvl = 30
-net.ipv4.tcp_tw_reuse = 1
-net.ipv4.tcp_moderate_rcvbuf = 1
 ```
 
 Ideally, you should disable swap to ensure that Riak's process pages are
@@ -167,7 +157,9 @@ of Riak usage on Linux, and should be added or updated in
 
 ```config
 net.ipv4.tcp_max_syn_backlog = 40000
-net.core.somaxconn=40000
+net.core.somaxconn = 40000
+net.core.wmem_default = 8388608
+net.core.rmem_default = 8388608
 net.ipv4.tcp_sack = 1
 net.ipv4.tcp_window_scaling = 1
 net.ipv4.tcp_fin_timeout = 15


### PR DESCRIPTION
Addresses https://github.com/basho/basho_docs/issues/1584

Additional network tuning sysctl settings were originally introduced in
6f5f31242b9ba02e16395f554ee47cf45af8610c, but seem to have
ended up in the wrong section due to a merge gone wrong.