### PR TITLE
Add riak-cs.conf as an autogenerated codeblock.

### DIFF
--- a/lib/sitemap_render_override.rb
+++ b/lib/sitemap_render_override.rb
@@ -296,6 +296,8 @@ module SitemapRenderOverride
           "riak.conf"
         when "riakcsconf"
           "riak-cs.conf"
+        when "stanchionconf"
+          "stanchion.conf"
         when "advancedconfig"
           "advanced.config"
         else
@@ -312,6 +314,8 @@ module SitemapRenderOverride
           code = code.gsub(/(<code(?:\s.*?)?class\s*\=\s*["'])riakconf(["']\>)/, '\\1matlab\\2')
         when "riakcsconf"
           code = code.gsub(/(<code(?:\s.*?)?class\s*\=\s*["'])riakcsconf(["']\>)/, '\\1matlab\\2')
+        when "stanchionconf"
+          code = code.gsub(/(<code(?:\s.*?)?class\s*\=\s*["'])stanchionconf(["']\>)/, '\\1matlab\\2')
         when "vmargs"
           code = code.gsub(/(<code(?:\s.*?)?class\s*\=\s*["'])vmargs(["']\>)/, '\\1ini\\2')
         when "protobuf"

--- a/lib/sitemap_render_override.rb
+++ b/lib/sitemap_render_override.rb
@@ -294,6 +294,8 @@ module SitemapRenderOverride
           "vm.args"
         when "riakconf"
           "riak.conf"
+        when "riakcsconf"
+          "riak-cs.conf"
         when "advancedconfig"
           "advanced.config"
         else
@@ -308,6 +310,8 @@ module SitemapRenderOverride
           code = code.gsub(/(<code(?:\s.*?)?class\s*\=\s*["'])advancedconfig(["']\>)/, '\\1erlang\\2')
         when "riakconf"
           code = code.gsub(/(<code(?:\s.*?)?class\s*\=\s*["'])riakconf(["']\>)/, '\\1matlab\\2')
+        when "riakcsconf"
+          code = code.gsub(/(<code(?:\s.*?)?class\s*\=\s*["'])riakcsconf(["']\>)/, '\\1matlab\\2')
         when "vmargs"
           code = code.gsub(/(<code(?:\s.*?)?class\s*\=\s*["'])vmargs(["']\>)/, '\\1ini\\2')
         when "protobuf"


### PR DESCRIPTION
Codeblocks such as
\`\`\`riakcsconf
rewrite_module = riak_cs_s3_rewrite
\`\`\`
now render correctly with the title showing `riak-cs.conf`.