### PR TITLE
Added missing brace to fix download link

### DIFF
--- a/source/languages/en/riak/ops/building/installing/from-source.md
+++ b/source/languages/en/riak/ops/building/installing/from-source.md
@@ -52,7 +52,7 @@ Download the Riak source package from the [[Download
 Center|http://basho.com/resources/downloads/]] and build:
 
 ```bash
-curl -O http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{VERSION}}/riak-{{VERSION}.tar.gz
+curl -O http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{VERSION}}/riak-{{VERSION}}.tar.gz
 tar zxvf riak-{{VERSION}}.tar.gz
 cd riak-{{VERSION}}
 make rel


### PR DESCRIPTION
This should fix the broken link in the "Installing from source package" section of the docs.

http://docs.basho.com/riak/2.0.5/ops/building/installing/from-source/