### PR TITLE
Fix malformed tag in cassandra comparison

### DIFF
--- a/source/languages/en/riak/theory/comparisons/cassandra.md
+++ b/source/languages/en/riak/theory/comparisons/cassandra.md
@@ -179,7 +179,7 @@ and Cassandra online documentation.
     <tr>
         <td><strong>Multi-Datacenter Replication</strong></td>
 
-        td>Riak features two distinct types of [[replication]]. Users can replicate to any number of nodes in one cluster (which is usually contained within one datacenter over a LAN) using the Apache 2.0-licensed database. Riak Enterprise, Basho's commercial extension to Riak, is required for Multi-Datacenter deployments (meaning the ability to run active Riak clusters in N datacenters).
+        <td>Riak features two distinct types of [[replication]]. Users can replicate to any number of nodes in one cluster (which is usually contained within one datacenter over a LAN) using the Apache 2.0-licensed database. Riak Enterprise, Basho's commercial extension to Riak, is required for Multi-Datacenter deployments (meaning the ability to run active Riak clusters in N datacenters).
 
         <ul>
             <li><a href="http://basho.com/products/riak-enterprise/">Riak Enterprise</a></li>


### PR DESCRIPTION
Looks like the `<td>` was missing an opening angle bracket.