### PR TITLE
Add a description of minus in version range.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ version). The ranges are specified using either greater/less than or
 plus/minus signs or a version range.
 
 * **{{1.0.0+}}** _(greater than 1.0.0, inclusive)_
+* **{{1.0.0-}}** _(less than 1.0.0, exclusive)_
 * **{{>=1.0.0}}** _(greater than 1.0.0, inclusive)_
 * **{{<1.0.0}}** _(less than 1.0.0, exclusive)_
 * **{{1.0.0-1.2.0}}** _(between 1.0 and 1.2, inclusive)_


### PR DESCRIPTION
This behaviour is defined [here](https://github.com/basho/basho_docs/blob/0e834b7ab8ae9ef1c0dd937b7ec2320d62f2afdb/lib/tools.rb#L20-L29).