### PR TITLE
[Issue 1567] Adds Cloudsoft links

### DIFF
--- a/source/languages/en/riak/dev/advanced/community-projects.md
+++ b/source/languages/en/riak/dev/advanced/community-projects.md
@@ -56,12 +56,13 @@ moved: {
 * [Lager AMQP Backend](https://github.com/jbrisbin/lager_amqp_backend) --- AMQP RabbitMQ Lager backend
 
 
-## Recipes, Cookbooks, and Configurations
+## Install and Configure
 
 * [Scalarium-Riak](https://github.com/roidrage/scalarium-riak) --- Riak Cookbooks for Scalarium Platform
 * [Riak Chef Recipe](https://github.com/basho/riak-chef-cookbook) --- Vanilla Chef Recipe for installing and configuring Riak
 * [Custom Chef Recipe for running Riak on the Engine Yard AppCloud](https://github.com/engineyard/ey-cloud-recipes/tree/master/cookbooks/riak)
 * [RiakAWS](http://github.com/roder/riakaws) --- A simple way to deploy a Riak cluster in the Amazon Cloud
+* [Cloudsoft-Riak](https://github.com/cloudsoft/amp-basho) --- Tested and optimized Riak blueprints for developing and deploying applications faster.
 * [Using Nginx as a front-end for Riak](http://rigelgroupllc.com/wp/blog/using-nginx-as-a-front-end-for-riak)
 * [Sample HA Proxy Configuration for Protocol Buffers Interface](http://lists.basho.com/pipermail/riak-users_lists.basho.com/2011-May/004387.html) (courtesy of Scott M. Likens)
 * [Sample HA Proxy Configuration for Protocol Buffers Interface](http://lists.basho.com/pipermail/riak-users_lists.basho.com/2011-May/004388.html) (courtesy of Bob Feldbauer)

--- a/source/languages/en/riak/dev/advanced/community-projects.md
+++ b/source/languages/en/riak/dev/advanced/community-projects.md
@@ -42,7 +42,6 @@ moved: {
 * [riak_zab](https://github.com/jtuple/riak_zab) --- An extension for `riak_core` that provides totally ordered atomic broadcast capabilities
 * [riak_zab_example](https://github.com/jtuple/riak_zab_example) --- An example application that allows you to build a multi-node cluster using `riak_zab`
 
-
 ## Riak and RabbitMQ
 
 * [Riak/RabbitMQ Commit Hook](https://github.com/jbrisbin/riak-rabbitmq-commit-hooks) --- A post-commit hook that sends entries into a RabbitMQ broker using the Erlang AMQP client
@@ -54,7 +53,6 @@ moved: {
 ## lager
 
 * [Lager AMQP Backend](https://github.com/jbrisbin/lager_amqp_backend) --- AMQP RabbitMQ Lager backend
-
 
 ## Install and Configure
 

--- a/source/languages/en/riak/ops/building/installing/index.md
+++ b/source/languages/en/riak/ops/building/installing/index.md
@@ -35,8 +35,8 @@ detailed Riak installation instructions.
 
 Cloudsoft provides tested, optimized Riak blueprints to help develop and deploy applications faster and easier on a wide range of environments. The AMP-Basho software will automatically deploy and manage Basho Riak and Riak Enterprise clusters using Apache Brooklyn's easy-to-use YAML blueprinting approach, combined with Cloudsoft's enterprise-supported Application Management Platform (AMP).
 
-  * [Install Riak with Cloudsoft](https://github.com/cloudsoft/amp-basho) 
-  
+  * [Install Riak with Cloudsoft](https://github.com/cloudsoft/amp-basho)
+
 ### Upgrading
 
   * [[Rolling Upgrades]]

--- a/source/languages/en/riak/ops/building/installing/index.md
+++ b/source/languages/en/riak/ops/building/installing/index.md
@@ -31,6 +31,12 @@ detailed Riak installation instructions.
 
   * [[Installing Riak With Chef]]
 
+### Cloudsoft
+
+Cloudsoft provides tested, optimized Riak blueprints to help develop and deploy applications faster and easier on a wide range of environments. The AMP-Basho software will automatically deploy and manage Basho Riak and Riak Enterprise clusters using Apache Brooklyn's easy-to-use YAML blueprinting approach, combined with Cloudsoft's enterprise-supported Application Management Platform (AMP).
+
+  * [Install Riak with Cloudsoft](https://github.com/cloudsoft/amp-basho) 
+  
 ### Upgrading
 
   * [[Rolling Upgrades]]


### PR DESCRIPTION
Links to Cloudsoft Riak integration tool were added in Community Projects in Advanced/Dev and on the Installation page of the Building/Ops page. The Building Ops page includes a description of the integration from the tool's README.

I have no idea why this works here and not to my fork. Whatever.