### PR TITLE
[upgrade-v20] clarify 'allow_mult' setting

### DIFF
--- a/source/languages/en/riak/upgrade-v20.md
+++ b/source/languages/en/riak/upgrade-v20.md
@@ -179,16 +179,16 @@ however, that some settings must be set in an `advanced.config` file.
 For a listing of those parameters, see our documentation on [[advanced
 configuration|Configuration Files#advanced-configuration]].
 
-If you chose to keep the existing `app.config` files, you _must_ add the
+If you choose to keep the existing `app.config` files, you _must_ add the
 following additional settings in the `riak_core` section:
 
-```app.config
+```appconfig
 {riak_core,
      [{default_bucket_props,
-          [{allow_mult,false},
+          [{allow_mult,false}, %% or the same as an existing setting
            {dvv_enabled,false}]},
-	 %% other settings
-	 ]
+          %% other settings
+     ]
 },
 ```
 This is to ensure backwards compatibility with 1.4 for these bucket properties.


### PR DESCRIPTION
710a32be8b11502c404e3d08167875d0a9cafef1 added advice to
add additional settings for the default bucket type to
app.config. If the user had previously set 'allow_mult=true'
they should keep that setting.

Fixed the markup of the app.config fragment and a typo.