### PR TITLE
READY: Quckstart for Node.js

### DIFF
--- a/source/languages/en/riak/community/lectures/developing.md
+++ b/source/languages/en/riak/community/lectures/developing.md
@@ -23,7 +23,7 @@ _If you have a video to add, please fork the [Riak Docs Repo on GitHub](https://
 	    	<a href="http://player.vimeo.com/video/21099379" target="_blank" title="Riak with node.js Webinar"><img class="vid_img"src="http://b.vimeocdn.com/ts/135/477/135477978_200.jpg"/></a>
 	    </td>
 	    <td class="vid_td">
-	    	<a href="http://player.vimeo.com/video/21099379" target="_blank" title="Riak with node.js Webinar">Riak with node.js Webinar</a><br />Learn how to use Riak from NodeJS applications.
+	    	<a href="http://player.vimeo.com/video/21099379" target="_blank" title="Riak with node.js Webinar">Riak with Node.js Webinar</a><br />Learn how to use Riak from Node.js applications.
 		</td>	    
 	</tr>
 	<tr>

--- a/source/languages/en/riak/dev/taste-of-riak/index.md
+++ b/source/languages/en/riak/dev/taste-of-riak/index.md
@@ -28,7 +28,7 @@ language with which you'd like to proceed:
 <li><a href="/dev/taste-of-riak/ruby/"><img src="/images/plangs/ruby.jpg" alt="Ruby"></a></li>
 <li><a href="/dev/taste-of-riak/python/"><img src="/images/plangs/python.png" alt="Python"></a></li>
 <li><a href="/dev/taste-of-riak/csharp/"><img src="/images/plangs/csharp.png" alt="CSharp"></a></li>
-<li><a href="/dev/taste-of-riak/nodejs/"><img src="/images/plangs/nodejs.png" alt="NodeJS"></a></li>
+<li><a href="/dev/taste-of-riak/nodejs/"><img src="/images/plangs/nodejs.png" alt="Node.js"></a></li>
 <li><a href="/dev/taste-of-riak/erlang/"><img src="/images/plangs/erlang.jpg" alt="Erlang"></a></li>
 </ul>
 

--- a/source/languages/en/riak/dev/taste-of-riak/nodejs.md
+++ b/source/languages/en/riak/dev/taste-of-riak/nodejs.md
@@ -11,7 +11,7 @@ keywords: [developers, client, javascript, nodejs]
 If you haven't set up a Riak Node and started it, please visit the
 [[Prerequisites|Taste of Riak: Prerequisites]] first.
 
-To try this flavor of Riak, a working installation of NodeJS 0.12 or later is
+To try this flavor of Riak, a working installation of Node.js 0.12 or later is
 required.
 
 Code for these examples is available [here][introduction.js]. To run, follow
@@ -26,11 +26,11 @@ node ./app.js
 
 ### Client Setup
 
-Install [the Riak NodeJS Client][node_js_installation] through [NPM][npm].
+Install [the Riak Node.js Client][node_js_installation] through [NPM][npm].
 
 ### Connecting to Riak
 
-Connecting to Riak with the Riak NodeJS Client requires creating a new client object.
+Connecting to Riak with the Riak Node.js Client requires creating a new client object.
 
 ```javascript
 var Riak = require('basho-riak-client');
@@ -46,7 +46,7 @@ This creates a new `Riak.Client` object which handles all the details of
 tracking active nodes and also provides load balancing. The `Riak.Client` object
 is used to send commands to Riak. When your application is completely done with
 Riak communications, the following method can be used to gracefully shut the
-client down and exit NodeJS:
+client down and exit Node.js:
 
 ```javascript
 function client_shutdown() {
@@ -74,7 +74,7 @@ client.ping(function (err, rslt) {
 ```
 
 This is some simple code to test that a node in a Riak cluster is online - we
-send a simple ping message. Even if the cluster isn't present, the Riak NodeJS
+send a simple ping message. Even if the cluster isn't present, the Riak Node.js
 Client will return a response message. In the callback it is important to check
 that your activity was successful by checking the `err` variable.
 
@@ -83,7 +83,7 @@ that your activity was successful by checking the `err` variable.
 Pinging a Riak cluster sounds like a lot of fun, but eventually someone is going
 to want us to do productive work. Let's create some data to save in Riak.
 
-The Riak NodeJS Client makes use of a `RiakObject` class to encapsulate Riak
+The Riak Node.js Client makes use of a `RiakObject` class to encapsulate Riak
 key/value objects. At the most basic, a `RiakObject` is responsible for
 identifying your object and for translating it into a format that can be easily
 saved to Riak.
@@ -191,9 +191,9 @@ Just like other operations, we check the results that have come back from Riak
 to make sure the object was successfully deleted. Of course, if you don't care
 about that, you can just ignore the result.
 
-The Riak NodeJS Client has a lot of additional functionality that makes it easy
+The Riak Node.js Client has a lot of additional functionality that makes it easy
 to build rich, complex applications with Riak. Check out the
-[documentation][dotnet_wiki] to learn more about working with the Riak NodeJS
+[documentation][dotnet_wiki] to learn more about working with the Riak Node.js
 Client and Riak.
 
 ## Next Steps

--- a/source/languages/en/riak/dev/taste-of-riak/querying-nodejs.md
+++ b/source/languages/en/riak/dev/taste-of-riak/querying-nodejs.md
@@ -8,9 +8,9 @@ audience: beginner
 keywords: [developers, client, 2i, search, nodejs]
 ---
 
-## NodeJS Version Setup
+## Node.js Version Setup
 
-For the NodeJS version, please download the source from GitHub by either
+For the Node.js version, please download the source from GitHub by either
 [cloning](https://github.com/basho/taste-of-riak) the source code
 repository or downloading the [current zip of the master
 branch](https://github.com/basho/taste-of-riak/archive/master.zip).

--- a/source/languages/en/riak/dev/taste-of-riak/querying.md
+++ b/source/languages/en/riak/dev/taste-of-riak/querying.md
@@ -47,7 +47,7 @@ Please select the language with which you'd like to proceed:
 <li><a href="/dev/taste-of-riak/querying-ruby/"><img src="/images/plangs/ruby.jpg" alt="Ruby"></a></li>
 <li><a href="/dev/taste-of-riak/querying-python/"><img src="/images/plangs/python.png" alt="Python"></a></li>
 <li><a href="/dev/taste-of-riak/querying-csharp/"><img src="/images/plangs/csharp.png" alt="CSharp"></a></li>
-<li><a href="/dev/taste-of-riak/querying-nodejs/"><img src="/images/plangs/nodejs.png" alt="NodeJS"></a></li>
+<li><a href="/dev/taste-of-riak/querying-nodejs/"><img src="/images/plangs/nodejs.png" alt="Node.js"></a></li>
 <li><a href="/dev/taste-of-riak/querying-erlang/"><img src="/images/plangs/erlang.jpg" alt="Erlang"></a></li>
 <li><a href="/dev/taste-of-riak/querying-php/"><img src="/images/plangs/php.png" alt="PHP"></a></li>
 </ul>

--- a/source/languages/en/riak/dev/using/basics.md
+++ b/source/languages/en/riak/dev/using/basics.md
@@ -261,7 +261,7 @@ ArgumentError: content_type is not defined!
 ```
 
 ```javascript
-// In the NodeJS client, the default content type is "application/json".
+// In the Node.js client, the default content type is "application/json".
 // Because of this, you should always make sure to specify the content
 // type when storing other types of data.
 ```
@@ -923,7 +923,7 @@ client.storeValue(options, function (err, rslt) {
     logger.info("Generated key: %s", generatedKey);
 });
 
-// The NodeJS client will output a random key similar to this:
+// The Node.js client will output a random key similar to this:
 // info: Generated key: VBAMoX0OOucymVCxeQEYzLzzAh2
 ```
 

--- a/source/languages/en/riak/dev/using/conflict-resolution/index.md
+++ b/source/languages/en/riak/dev/using/conflict-resolution/index.md
@@ -148,7 +148,7 @@ client-library-specific docs:
 * [[Ruby|Conflict Resolution: Ruby]]
 * [[Python|Conflict Resolution: Python]]
 * [[C#|Conflict Resolution: CSharp]]
-* [[NodeJS|Conflict Resolution: NodeJS]]
+* [[Node.js|Conflict Resolution: NodeJS]]
 
 In Riak versions 2.0 and later, `allow_mult` is set to `true` by default
 for any [[bucket types|Using Bucket Types]] that you create. This means
@@ -492,7 +492,7 @@ client-library-specific documentation for the following languages:
 * [[Ruby|Conflict Resolution: Ruby]]
 * [[Python|Conflict Resolution: Python]]
 * [[C#|Conflict Resolution: CSharp]]
-* [[NodeJS|Conflict Resolution: NodeJS]]
+* [[Node.js|Conflict Resolution: NodeJS]]
 
 We won't deal with conflict resolution in this section. Instead, we'll
 focus on how to use causal context.

--- a/source/languages/en/riak/dev/using/conflict-resolution/nodejs.md
+++ b/source/languages/en/riak/dev/using/conflict-resolution/nodejs.md
@@ -11,11 +11,11 @@ For reasons explained in the [[introduction to conflict resolution|Conflict
 Resolution]], we strongly recommend adopting a conflict resolution strategy that
 requires applications to resolve siblings according to use-case-specific
 criteria. Here, we'll provide a brief guide to conflict resolution using the
-official [Riak NodeJS client][riak_dotnet_client].
+official [Riak Node.js client][riak_dotnet_client].
 
-## How the NodeJS Client Handles Conflict Resolution
+## How the Node.js Client Handles Conflict Resolution
 
-In the Riak NodeJS client, the result of a fetch can possibly return an array
+In the Riak Node.js client, the result of a fetch can possibly return an array
 of sibling objects.  If there are no siblings, that property will return an
 array with one value in it.
 

--- a/source/languages/en/riak/dev/using/libraries.md
+++ b/source/languages/en/riak/dev/using/libraries.md
@@ -23,7 +23,7 @@ Java | [riak-java-client](https://github.com/basho/riak-java-client) | [javadoc]
 Ruby | [riak-ruby-client](https://github.com/basho/riak-ruby-client) | [GitHub Pages](http://basho.github.io/riak-ruby-client/) | [RubyGems](https://rubygems.org/gems/riak-client)
 Python | [riak-python-client](https://github.com/basho/riak-python-client) | [sphinx](http://basho.github.com/riak-python-client) | [PyPI](http://pypi.python.org/pypi?:action=display&name=riak#downloads)
 C# | [riak-dotnet-client](https://github.com/basho/riak-dotnet-client) | [api docs](http://basho.github.io/riak-dotnet-client-api/), [wiki](https://github.com/basho/riak-dotnet-client/wiki) | [NuGet package](http://www.nuget.org/List/Packages/RiakClient), [GitHub Releases](https://github.com/basho/riak-dotnet-client/releases)
-NodeJS | [riak-nodejs-client](https://github.com/basho/riak-nodejs-client) | [api docs](http://basho.github.com/riak-nodejs-client/), [wiki](https://github.com/basho/riak-nodejs-client/wiki) | [NPM](https://www.npmjs.com/package/basho-riak-client), [GitHub Releases](https://github.com/basho/riak-nodejs-client/releases)
+Node.js | [riak-nodejs-client](https://github.com/basho/riak-nodejs-client) | [api docs](http://basho.github.com/riak-nodejs-client/), [wiki](https://github.com/basho/riak-nodejs-client/wiki) | [NPM](https://www.npmjs.com/package/basho-riak-client), [GitHub Releases](https://github.com/basho/riak-nodejs-client/releases)
 Erlang | [riak-erlang-client (riakc)](https://github.com/basho/riak-erlang-client) | [edoc](http://basho.github.com/riak-erlang-client/) | [GitHub](https://github.com/basho/riak-erlang-client)
 
 **Note**: All official clients use the integrated issue tracker on

--- a/source/languages/en/riak/dev/using/updates.md
+++ b/source/languages/en/riak/dev/using/updates.md
@@ -101,7 +101,7 @@ obj = bucket.get('banana', deletedvclock: true)
 ## Example Update
 
 In this section, we'll provide an update example for Basho's official Ruby,
-Python, .NET, NodeJS and Erlang clients. Because updates with the official Java client
+Python, .NET, Node.js and Erlang clients. Because updates with the official Java client
 functions somewhat differently, those examples can be found in the [[section
 below|Object Updates#Java-Client-Example]].
 

--- a/source/languages/en/riak/quickstart.md
+++ b/source/languages/en/riak/quickstart.md
@@ -406,6 +406,7 @@ language:
 * [Ruby](https://github.com/basho/riak-ruby-client)
 * [Python](https://github.com/basho/riak-python-client)
 * [.NET](https://github.com/basho/riak-dotnet-client)
+* [Node.js](https://github.com/basho/riak-nodejs-client)
 * [Erlang](https://github.com/basho/riak-erlang-client)
 
 In each of the above docs, you'll find detailed client installation and
@@ -631,6 +632,44 @@ object that is used to execute all operations with Riak:
 ```csharp
 var client = cluster.CreateClient();
 ```
+
+### Node.js
+
+There are a variety of ways to set up cluster interaction with the Node.js
+client. The following is the simplest way, which is to pass an array of
+`host:port` information to the `Riak.Client` constructor.
+
+```javascript
+var Riak = require('basho-riak-client');
+
+var riakNodes = [
+    'riak-test:10017',
+    'riak-test:10027',
+    'riak-test:10037',
+    'riak-test:10047'
+];
+
+// Note: no need to call start() since the new Riak.Client object
+// will start the cluster connection
+var client  new Riak.Client(riakNodes);
+```
+
+There is also a method to shut the cluster down:
+
+```javascript
+client.shutdown(function (state) {
+    if (state === Riak.Cluster.State.SHUTDOWN) {
+        // Do whatever steps are necessary now that client is shut down
+        // like process.exit()
+    }
+});
+```
+
+For some Node.js code samples to get you started, see our tutorials on
+[[the basics of Riak|The Basics]], [[Riak Data Types|Using Data Types]],
+and [[Riak Search 2.0|Using Search]], as well as a variety of other
+pages in the **Riak for Developers** section of the documentation (in
+the navbar on the left).
 
 ### Erlang
 


### PR DESCRIPTION
* Complete quickstart examples for Node.js
* Ensure that, where possible, Node.js is used instead of NodeJS, since the former is the official trademark.