### PR TITLE
Change description of ETS acronym

### DIFF
--- a/source/languages/en/riak/ops/tuning/erlang.md
+++ b/source/languages/en/riak/ops/tuning/erlang.md
@@ -323,7 +323,7 @@ setting.
 ## Erlang Built-in Storage
 
 Erlang uses a built-in database called
-[ets](http://www.erlang.org/doc/man/ets.html) \(Erlang Table Storage)
+[ets](http://www.erlang.org/doc/man/ets.html) \(Erlang Term Storage)
 for some processes that require fast access from memory in constant
 access time (rather than logarithmic access time).  The maximum number
 of tables can be set using the `erlang.max_ets_tables` setting. The


### PR DESCRIPTION
It had been referred to as "Erlang Table Storage". The following
resources describe it as "Erlang Term Storage":

http://docs.basho.com/riak/latest/ops/running/nodes/inspecting/
Descripion of "memory_ets", under "CPU and Memory"

http://docs.basho.com/riak/latest/ops/running/recovery/errors/
Descripion of "{system_limit, {ets, new}}", under "Lager Formats"

https://github.com/erlang/otp/blob/maint/lib/stdlib/src/ets.erl#L22
"Erlang Term Store"

https://www.safaribooksonline.com/library/view/programming-erlang-2nd/9781941222454/f_0155.html
Joe Armstrong's book "Programming Erlang"

http://learnyousomeerlang.com/ets