### PR TITLE
update post 2.0.0 build instructions

### DIFF
--- a/source/languages/en/riak/ops/building/installing/from-source.md
+++ b/source/languages/en/riak/ops/building/installing/from-source.md
@@ -51,12 +51,23 @@ or cloned source.
 Download the Riak source package from the [[Download
 Center|http://basho.com/resources/downloads/]] and build:
 
+{{#2.0.0+}}
+```bash
+curl -O http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{VERSION}}/riak-{{VERSION}.tar.gz
+tar zxvf riak-{{VERSION}}.tar.gz
+cd riak-{{VERSION}}
+make locked-deps
+make rel
+```
+{{/#2.0.0+}}
+{{#2.0.0-}}
 ```bash
 curl -O http://s3.amazonaws.com/downloads.basho.com/riak/{{V.V}}/{{VERSION}}/riak-{{VERSION}.tar.gz
 tar zxvf riak-{{VERSION}}.tar.gz
 cd riak-{{VERSION}}
 make rel
 ```
+{{/2.0.0-}}
 
 ### Installing from GitHub
 
@@ -65,12 +76,21 @@ more information on building and installing Riak from source. To clone
 and build Riak from source, follow the steps below.
 
 Clone the repository using [Git](http://git-scm.com) and build:
-
+{{#2.0.0+}}
+```bash
+git clone git://github.com/basho/riak.git
+cd riak
+make locked-deps
+make rel
+```
+{{/2.0.0+}}
+{{#2.0.0-}}
 ```bash
 git clone git://github.com/basho/riak.git
 cd riak
 make rel
 ```
+{{/2.0.0-}}
 
 ## Platform-Specific Instructions
 


### PR DESCRIPTION
If `make locked-deps` is not run before `make rel` or `make devrel` warnings such as those below will be output, and the build will crash.
```
./rebar clean
WARN:  Directory expected to be an app dir, but no app file found
in ebin/ or src/:
/basho/riak/deps/cluster_info
WARN:  Missing plugins: [rebar_lock_deps_plugin]
WARN:  Missing plugins: [rebar_lock_deps_plugin]
WARN:  Missing plugins: [rebar_lock_deps_plugin]
WARN:  Missing plugins: [rebar_lock_deps_plugin]
WARN:  Missing plugins: [rebar_lock_deps_plugin]
WARN:  Missing plugins: [rebar_lock_deps_plugin]
WARN:  Missing plugins: [rebar_lock_deps_plugin]
WARN:  Missing plugins: [cuttlefish_rebar_plugin,rebar_lock_deps_plugin]
```