### PR TITLE
Added item to link to PHP taste-of-riak tutorial

### DIFF
--- a/source/languages/en/riak/dev/taste-of-riak/index.md
+++ b/source/languages/en/riak/dev/taste-of-riak/index.md
@@ -30,6 +30,7 @@ language with which you'd like to proceed:
 <li><a href="/dev/taste-of-riak/csharp/"><img src="/images/plangs/csharp.png" alt="CSharp"></a></li>
 <li><a href="/dev/taste-of-riak/nodejs/"><img src="/images/plangs/nodejs.png" alt="Node.js"></a></li>
 <li><a href="/dev/taste-of-riak/erlang/"><img src="/images/plangs/erlang.jpg" alt="Erlang"></a></li>
+<li><a href="/dev/taste-of-riak/php/"><img src="/images/plangs/php.png" alt="PHP"></a></li>
 </ul>
 
 ### Community-supported Client Libraries

--- a/source/languages/en/riak/dev/taste-of-riak/php.md
+++ b/source/languages/en/riak/dev/taste-of-riak/php.md
@@ -149,7 +149,7 @@ print($riakObject->data);
  "copiesOwned":3}
 ```
 
-JSON!  The library encodes POPO’s as JSON strings.  If instead we wanted to get a data record back we could use `$mobyDick = $booksBucket->get(book.ISBN)->data`, and then use an array accessor like `$mobyDick[‘isbn’]` to grab the info we want.  
+JSON!  The library encodes POPO’s as JSON strings.  If instead we wanted to get a data record back we could use `$mobyDick = $booksBucket->get($book->ISBN)->data`, and then use an array accessor like `$mobyDick[‘isbn’]` to grab the info we want.  
 
 Now that we’ve ruined the magic of object encoding, let’s clean up our mess:
 


### PR DESCRIPTION
To be able to access the Taste of Riak PHP tutorial, to be consistent with https://github.com/basho/basho_docs/blob/master/source/languages/en/riak/dev/taste-of-riak/querying.md

Also fixed typo in the actual doc page itself