### PR TITLE
fix %w array on using/2i page

### DIFF
--- a/source/languages/en/riak/dev/using/2i.md
+++ b/source/languages/en/riak/dev/using/2i.md
@@ -436,7 +436,7 @@ obj3.store
 obj4 = Riak::RObject.new(bucket, 'veronica')
 obj4.content_type = 'text/plain'
 obj4.raw_data = 'My name is Veronica'
-obj4.indexes['field1_bin'] = %w{ val4, val4, val4a, val4b }
+obj4.indexes['field1_bin'] = %w{ val4 val4 val4a val4b }
 obj4.indexes['field2_int'] = [1004, 1004, 1005, 1006]
 obj4.indexes['field2_int'] = [1004]
 obj4.indexes['field2_int'] = [1004]


### PR DESCRIPTION
Ruby %w arrays don't use commas for element delimiting, just whitespace:

```ruby
# commas appear in array elements
%w{ val4, val4, val4a, val4b }
#=> ["val4,", "val4,", "val4a,", "val4b"]

# no commas in array elements
%w{ val4 val4 val4a val4b }
#=> ["val4", "val4", "val4a", "val4b"]
```