### PR TITLE
Formatting fix + stats wording

### DIFF
--- a/source/languages/en/riak/ops/running/stats-and-monitoring.md
+++ b/source/languages/en/riak/ops/running/stats-and-monitoring.md
@@ -115,9 +115,10 @@ Metric | Also | Relevance | Latency (in microseconds)
 ```consistent_get_time_mean``` | ```_median```, ```_95```, ```_99```, ```_100``` | Strong Consistency | Strongly consistent read latency
 ```consistent_put_time_mean``` | ```_median```, ```_95```, ```_99```, ```_100``` | Strong Consistency | Strongly consistent write latency
 
-### Erlang Resource Usage Metrics These are system metrics from the
-perspective of the Erlang VM, measuring resources allocated and used
-by Erlang.
+### Erlang Resource Usage Metrics
+
+These are system metrics from the perspective of the Erlang VM,
+measuring resources allocated and used by Erlang.
 
 Metric | Notes
 :------|:-------------------------
@@ -201,7 +202,7 @@ Like all code under [Basho Labs](https://github.com/basho-labs/), the below
 tools are "best effort" and have no dedicated Basho support. We both appreciate
 and need your contribution to keep these tools stable and up to date. Please
 open up a GitHub issue on the repository if you'd like to be a maintainer.</br>
-Look for banners calling out the tools that do support the full set of Riak 2.x
+Look for banners calling out the tools we've verified that support the latest Riak 2.x
 statistics!
 </div>
 
@@ -251,7 +252,7 @@ the Riak HTTP `[[/stats|HTTP Status]]` endpoint is also available.
 #### Nagios
 
 <div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
+<strong>Tested and Verified Support for Riak 2.x.</strong>
 </div>
 
 [Nagios](http://www.nagios.org) is a monitoring and alerting solution


### PR DESCRIPTION
The header for 'Erlang Resource Usage Metrics' was showing up as  'Erlang Resource Usage Metrics These are system metrics from the'

Changed "Tested and Verified Support for Riak 2.x Stats." to "Tested and Verified Support for Riak 2.x.", on Nagios's banner, because Nagios doesn't support stats.

Changed some text in the "Note on Riak 2.x Statistics Support" banner. Reading "full set" would make me think the tools include *all* available stats. However, none of the tools include all the stats, on purpose ( it would be too much info for most tools ). Also, calling out the tools that "support Riak 2.0" would make me think the other tools do not, so I added "we've verified". The text was changed from:
"Look for banners calling out the tools that do support the full set of Riak 2.x statistics!"

to

"Look for banners calling out the tools we've verified that support the latest Riak 2.x statistics!"

This could probably be worded better.