### PR TITLE
Fix wrong time format description of storage calculation in Riak CS.

### DIFF
--- a/source/languages/en/riakcs/cookbooks/Usage-and-Billing-Data.md
+++ b/source/languages/en/riakcs/cookbooks/Usage-and-Billing-Data.md
@@ -218,7 +218,7 @@ In the `riak_cs` section of the file, add an entry for
 `storage_schedule` like this:
 
 ```riakcsconf
-stats.storage.schedule.1 = "06:00"
+stats.storage.schedule.1 = 0600
 ```
 
 ```advancedconfig
@@ -229,8 +229,7 @@ stats.storage.schedule.1 = "06:00"
 {storage_schedule, "0600"}
 ```
 
-The time is given as a string of the form `HH:MM` (omit the `:` in the old-style
-`advanced.config`/`app.config` files, so it's simply `HHMM`), representing the
+The time is given as a string of the form `HHMM`, representing the
 hour and minute GMT to start the calculation process. In this example, the node
 would start the storage calculation at 6am GMT every day.
 
@@ -238,8 +237,8 @@ To set up multiple times, simply specify multiple times. For example,
 to schedule the calculation to happen at both 6am and 6pm, use:
 
 ```riakcsconf
-stats.storage.schedule.1 = "06:00"
-stats.storage.schedule.2 = "18:00"
+stats.storage.schedule.1 = 0600
+stats.storage.schedule.2 = 1800
 ```
 
 ```advancedconfig

--- a/source/languages/en/riakcs/cookbooks/configuration/configuration-reference.md
+++ b/source/languages/en/riakcs/cookbooks/configuration/configuration-reference.md
@@ -431,11 +431,11 @@ independently to access/usage and billing/storage. Expressed as a time-value</td
 <tr>
 <td><code>stats.storage.schedule.<em>$time</em></code></td>
 <td>When to automatically start storage calculation batches. Expressed as an
-<code>HH:MM</code> UTC time. For example, <code>"06:00"</code> would calculate
+<code>HHMM</code> UTC time. For example, <code>0600</code> would calculate
 at 6 am UTC every day. If you would like to schedule multiple batches, changing
 <em>$time</em> for each entry. For example <code>stats.storage.schedule.2 =
-"18:00"</code> could be the second entry, scheduled for 6:00pm UTC.</td>
-<td><code>"06:00"</code></td>
+1800</code> could be the second entry, scheduled for 6:00pm UTC.</td>
+<td><code>0600</code></td>
 </tr>
 <tr>
 <td><code>stats.storage.archive_period</code></td>


### PR DESCRIPTION
Even though using riak-cs.schema, the time format of storage schedule is not `"HH:MM"`, but `HHMM`. This is a documentation bug in source code of riak_cs and here. It's my fault :(

The description which `riak-cs config describe 'stats.storage.schedule.$time'` shows will be also fixed by https://github.com/basho/riak_cs/pull/1153