### PR TITLE
Typo in app.config parameter for setting the maximum Erlang VM port

### DIFF
--- a/source/languages/en/riak/ops/tuning/erlang.md
+++ b/source/languages/en/riak/ops/tuning/erlang.md
@@ -209,7 +209,7 @@ erlang.distribution.port_range.maximum = 5000
 {kernel, [
           % ...
           {inet_dist_listen_min, 3000},
-          {inet_dist_listen_min, 5000}
+          {inet_dist_listen_max, 5000}
           % ...
          ]}
 ```


### PR DESCRIPTION
In the Port Range section of the Erlang VM Tuning chapter, changed the second parameter in the first app.config tab to inet_dist_listen_max.