### PR TITLE
Minor fix in Taste of Riak - Erlang

### DIFF
--- a/source/languages/en/riak/dev/taste-of-riak/erlang.md
+++ b/source/languages/en/riak/dev/taste-of-riak/erlang.md
@@ -87,7 +87,7 @@ they contain the values we expect.
 {ok, Fetched3} = riakc_pb_socket:get(Pid, MyBucket, <<"three">>).
 
 Val1 =:= binary_to_term(riakc_obj:get_value(Fetched1)). %% true
-Val2 =:= binary_to_term(riakc_obj:get_value(Fetched2)). %% true
+Val2 =:= riakc_obj:get_value(Fetched2).                 %% true
 Val3 =:= binary_to_term(riakc_obj:get_value(Fetched3)). %% true
 ```
 


### PR DESCRIPTION
In Reading Objects From Riak, this fails:

```
Val2 =:= binary_to_term(riakc_obj:get_value(Fetched2)).
```

because the fetched object is a bit string, which causes a bad argument exception to binary_to_term.
