### PR TITLE
Update content under /riak/ops/building, small updates across /riak

### DIFF
--- a/source/languages/en/riak/community/faqs/operations.html.fml
+++ b/source/languages/en/riak/community/faqs/operations.html.fml
@@ -214,7 +214,7 @@ Q: How can I back up my Riak data?
 A:
   **Note**: The `backup` command provided in `riak-admin` will only backup Riak KV data. The `backup` command has not been updated to work with Riak Search indexes.
   
-  When using the Bitcask (default Riak KV backend) and Merge Index (Riak Search backend) backends, it is recommended that you use standard filesystem backup utilities (`tar`) to back up Riak nodes. Both Bitcask and Merge Index are append-only data structures that perform incremental merge operations. This allows backups to be made while the system is running. Restoring backups involves moving the backups into the Riak `data` directory and starting the Riak node.
+  When using the Bitcask (default Riak KV backend) and Merge Index (Riak Search backend) backends, we recommend using standard filesystem backup utilities (`tar`) to back up Riak nodes. Both Bitcask and Merge Index are append-only data structures that perform incremental merge operations. This allows backups to be made while the system is running. Restoring backups involves moving the backups into the Riak `data` directory and starting the Riak node.
   
   The directories that need to be backed up are the following (the location of these will vary depending on how you installed and configured Riak or Riak Search):
   
@@ -339,7 +339,7 @@ A:
 
 Q: How many partitions should I assign to a new cluster?
 A:
-  You need to plan the number of partitions of your cluster ahead of time and set them in the `ring_creation_size` configuration parameter. A good rule of thumb is that `ring_creation_size` divided by `number_of_nodes` should be between 10 and 50. For 15 nodes, 256 is a good number; 512 or 1024 would be better if you intend to grow the cluster over time.
+  You need to plan the number of partitions of your cluster ahead of time and set them in the `ring_creation_size` configuration parameter. A good rule to follow is that `ring_creation_size` divided by `number_of_nodes` should be between 10 and 50. For 15 nodes, 256 is a good number; 512 or 1024 would be better if you intend to grow the cluster over time.
 
 Q: Is it possible to change the number of partitions in my Riak ring after it's already running?
 A:

--- a/source/languages/en/riak/community/product-advisories/210-dataloss.md
+++ b/source/languages/en/riak/community/product-advisories/210-dataloss.md
@@ -60,7 +60,7 @@ Then configure handoff.ip in riak.conf to an external IP address or 0.0.0.0 on a
 
 Perform a rolling restart of Riak across your cluster to activate the new setting.
 
-After correcting the configuration and restarting the nodes, you should run Riak KV repair on each cluster member as documented at [http://docs.basho.com/riak/latest/ops/running/recovery/repairing-partitions/](http://docs.basho.com/riak/latest/ops/running/recovery/repairing-partitions/) to recreate any missing replicas from available replicas elsewhere in the cluster.  It is recommended to perform the Riak KV repair in a round-robin fashion on each node of your cluster (node0, node1, node2, etc). Repeat this round-robin repair “n_val - 1” times. For example: the default configuration for n_val is 3, which means you would run Riak KV repair twice across the entire cluster. 
+After correcting the configuration and restarting the nodes, you should run Riak KV repair on each cluster member as documented at [http://docs.basho.com/riak/latest/ops/running/recovery/repairing-partitions/](http://docs.basho.com/riak/latest/ops/running/recovery/repairing-partitions/) to recreate any missing replicas from available replicas elsewhere in the cluster.  We recommend performing the Riak KV repair in a round-robin fashion on each node of your cluster (node0, node1, node2, etc). Repeat this round-robin repair “n_val - 1” times. For example: the default configuration for n_val is 3, which means you would run Riak KV repair twice across the entire cluster. 
 
 > NOTE: It is important to ensure that you execute in a round-robin fashion: node0, node1, node2 and then repeat.
 A forthcoming 2.1.1 release will provide an updated default configuration.

--- a/source/languages/en/riak/dev/advanced/bucket-types.md
+++ b/source/languages/en/riak/dev/advanced/bucket-types.md
@@ -261,7 +261,7 @@ to `true`), is set up as a `map`, `set`, or `counter`, or is defined as a write-
 bucket (requiring `write_once` be set to `true`), then this will be true of
 the bucket types.
 
-If you need to change one of these properties, it is recommended that
+If you need to change one of these properties, we recommend that
 you simply create and activate a new bucket type.
 </div>
 

--- a/source/languages/en/riak/dev/advanced/replication-properties.md
+++ b/source/languages/en/riak/dev/advanced/replication-properties.md
@@ -580,7 +580,7 @@ A vector clock is not included with the write request and an object already exis
 ## Screencast
 
 Here is a brief screencast that shows just how the N, R, and W values
-function in our running three-node Riak cluster:
+function in our running 3-node Riak cluster:
 
 <div style="display:none" class="iframe-video"
 id="http://player.vimeo.com/video/11172656"></div>

--- a/source/languages/en/riak/dev/references/backend-api.md
+++ b/source/languages/en/riak/dev/references/backend-api.md
@@ -17,7 +17,7 @@ the storage backend API in the form of
 (specs).
 
 Specs are used by [dialyzer](http://www.erlang.org/doc/man/dialyzer.html),
-an Erlang static analysis tool. It is recommended to copy these specs into any
+an Erlang static analysis tool. We recommend copying these specs into any
 custom backend modules and use them as a guide for development to
 avoid errors and ensure full compatibility with Riak.
 

--- a/source/languages/en/riak/dev/taste-of-riak/java.md
+++ b/source/languages/en/riak/dev/taste-of-riak/java.md
@@ -35,7 +35,7 @@ source code for this tutorial, and save it to your working directory.
 <div class="note">
 <div class="title">Configuring for a local cluster</div>
 The `TasteOfRiak.java` file that you downloaded is set up to communicate
-with a one-node Riak cluster listening on `localhost` port 10017. We
+with a 1-node Riak cluster listening on `localhost` port 10017. We
 recommend modifying the connection info directly within the
 `setUpCluster()` method.
 </div>

--- a/source/languages/en/riak/dev/using/application-guide.md
+++ b/source/languages/en/riak/dev/using/application-guide.md
@@ -363,7 +363,7 @@ If you have a good sense of how you will be using Riak for your
 application (or if you just want to experiment), the following guides
 will help you get up and running:
 
-* [[Five-Minute Install]] --- Install Riak and start up a five-node Riak
+* [[Five-Minute Install]] --- Install Riak and start up a 5-node Riak
   cluster
 * [[Client Libraries]] --- A listing of official and non-official client
   libraries for building applications with Riak

--- a/source/languages/en/riak/ops/advanced/deletion.md
+++ b/source/languages/en/riak/ops/advanced/deletion.md
@@ -105,8 +105,8 @@ before a node is stopped will remain in the backend.
 
 ## Client Library Examples
 
-If you are updating an object that has been deleted---or if you suspect
-that an update might target a deleted object---it is recommended that
+If you are updating an object that has been deleted---or if an update 
+might target a deleted object---we recommend that
 you first fetch the [[causal context]] of the object prior to updating.
 This can be done by setting the `deletedvclock` parameter to `true` as
 part of the [[fetch operation|PBC Fetch Object]]. This can also be done

--- a/source/languages/en/riak/ops/building/installing/azure.md
+++ b/source/languages/en/riak/ops/building/installing/azure.md
@@ -13,8 +13,6 @@ moved: {
 }
 ---
 
-Steps to install Riak on CentOS VMs using the Windows Azure platform.
-
 ## Creating CentOS VMs
 
 You will need to sign up for the Windows Azure Virtual Machines preview feature in order to create a virtual machine. You can also sign up for a free trial account if you do not have a Windows Azure account.

--- a/source/languages/en/riak/ops/building/planning/best-practices.md
+++ b/source/languages/en/riak/ops/building/planning/best-practices.md
@@ -11,10 +11,7 @@ moved: {
 }
 ---
 
-Riak is a database that's designed to be as easily operable and
-painlessly scalable as possible. But as with all databases, there are
-some best practices that will enable you to improve performance and
-reliability at all stages in the like of your Riak cluster.
+Riak is a database that's designed for easy operation and scaling. Below are some best practices that will enable you to improve performance and reliability at all stages in the life of your Riak cluster.
 
 ## Disk Capacity
 

--- a/source/languages/en/riak/ops/building/planning/cluster.md
+++ b/source/languages/en/riak/ops/building/planning/cluster.md
@@ -10,23 +10,15 @@ moved: {
 }
 ---
 
-This document outlines the various elements and variables that should be
-considered when planning your Riak cluster. Your use case and
-environment variables will be specific to what you're building, but this
-document should set you on the right path when planning and launching a
-Riak cluster.
+This document outlines the various elements and variables to keep in mind when planning your Riak cluster. Your use case and environment variables will be specific to what you're building, but this document should set you on the right path when planning and launching a Riak cluster.
 
 ## RAM
 
-[RAM](http://en.wikipedia.org/wiki/Random-access_memory) should be
-viewed as the most important resource when sizing your Riak cluster.
-Aside from helping you keep more data closer to your users, memory will
-also be required when running complex MapReduce queries and for caching
-data to provide low-latency request times.
+[RAM](http://en.wikipedia.org/wiki/Random-access_memory) is the most important resource when sizing your Riak cluster. Memory keeps data closer to your users. Memory is essential for running complex MapReduce queries or caching data to provide low-latency request times.
 
 ### Bitcask and Memory Requirements
 
-Your choice of local storage backend for Riak directly impacts your RAM
+Your choice of local storage backend for Riak impacts your RAM
 needs. Though Riak has pluggable backend storage, Bitcask is the
 default.  Why? Because it's built for:
 
@@ -41,45 +33,34 @@ each file contained within each Bitcask backend) to a fixed-size
 structure giving the file, offset, and size of the most recently written
 entry for that bucket + key on disk.
 
-If you want to read more about what the keydir is and what it entails,
-as well as more about Bitcask in general, see the [Hello
-Bitcask](http://basho.com/hello-bitcask/) article from
-the Basho blog as well as Basho's [Introduction to
-Bitcask](http://basho.com/assets/bitcask-intro.pdf) paper.
+To learn about Bitcask see [Hello Bitcask](http://basho.com/hello-bitcask/) on the Basho blog as well as the [Introduction to Bitcask](http://basho.com/assets/bitcask-intro.pdf) paper.
 
-
-When you calculate that your RAM needs will exceed your hardware
-resources--in other words, if you can't afford the RAM to enable you to
-use Bitcask---we recommend that you use LevelDB.
+If your calculated RAM needs will exceed your hardware resources--in other words, if you can't afford the RAM to use Bitcask---we recommend that you use LevelDB.
 
 Check out [[Bitcask Capacity Planning]] for more details on designing a
 Bitcask-backed cluster.
 
 ### LevelDB
 
-If RAM requirements for Bitcask are prohibitive, Basho recommends use of
+If RAM requirements for Bitcask are prohibitive, we recommend use of
 the LevelDB backend. While LevelDB doesn't require a large amount of RAM
-to operate, supplying it with the maximum amount of memory available
-will lead to higher performance.
+to operate, supplying it with the maximum amount of memory available leads to higher performance.
 
 For more information see [[LevelDB]].
 
 ## Disk
 
-Now that you have an idea of how much RAM you'll need, it's time to
-think about disk space. Disk space needs are much easier to calculate
-and essentially boil down to this simple equation:
+Now that you have an idea of how much RAM you'll need, it's time to think about disk space. Disk space needs are much easier to calculate. Below is an equation to help you calculate disk space needs:
 
 #### Estimated Total Objects * Average Object Size * n_val
 
-For example, with
+For example:
 
 * 50,000,000 objects
 * an average object size of two kilobytes (2,048 bytes)
 * the default `n_val` of 3
 
-then you would need just over approximately **286 GB** of disk space in
-the entire cluster to accommodate your data.
+Then you would need just over approximately **286 GB** of disk space in the entire cluster to accommodate your data.
 
 We believe that databases should be durable out of the box. When we
 built Riak, we did so in a way that you could write to disk while
@@ -87,24 +68,18 @@ keeping response times below your users' expectations. So this
 calculation assumes that you'll be keeping the entire data set on disk.
 
 Many of the considerations taken when configuring a machine to serve a
-database can be applied to configuring a node for Riak as well. Mounting
+database apply to configuring a node for Riak as well. Mounting
 disks with noatime and having separate disks for your OS and Riak data
 lead to much better performance. See [[System Planning|Planning for a
 Riak System]] for more information.
 
 ### Disk Space Planning and Ownership Handoff
 
-When Riak nodes fail or leave the cluster for some other reason, other
-nodes in the cluster begin engaging in the process of **ownership
-handoff**, whereby the remaining nodes assume ownership of the data
-partitions handled by the node that has left. While this is an expected
-state of affairs in Riak, one side effect is that this requires more
-intensive disk space usage from the other nodes, in rare cases to the
-point of filling the disk of one or more of those nodes.
+When Riak nodes fail or leave the cluster, other nodes in the cluster start the **ownership handoff** process. Ownership handoff is when remaining nodes take ownership of the data partitions handled by an absent node. One side effect of this process is that the other nodes require more intensive disk space usage; in rare cases filling the disk of one or more of those nodes.
 
 When making disk space planning decisions, we recommend that you:
 
-* assume that one or more nodes may be down at any time, and
+* assume that one or more nodes may be down at any time
 * monitor your disk space usage and add additional space when usage
   exceeds 50-60% of available space.
 
@@ -128,8 +103,8 @@ won't need as much RAM available to cache those keys' values.
 The number of nodes (i.e. physical servers) in your Riak Cluster depends
 on the number of times data is [[replicated|Replication]] across the
 cluster.  To ensure that the cluster is always available to respond to
-read and write requests, Basho recommends a "sane default" of N=3
-replicas.  This requirement can be met with a three- or four-node
+read and write requests, we recommend a "sane default" of N=3
+replicas.  This requirement can be met with a 3 or 4-node
 cluster (you can tweak nodes installed through the [[Five Minute
 Install]]).
 
@@ -148,7 +123,7 @@ Riak can be scaled in two ways: vertically, via improved hardware, and
 horizontally, by adding more nodes. Both ways can provide performance
 and capacity benefits, but should be used in different circumstances.
 The [[riak-admin cluster command|riak-admin Command Line#cluster]] can
-assist in scaling in both directions.
+assist scaling in both directions.
 
 #### Vertical Scaling
 
@@ -181,32 +156,20 @@ between nodes in the cluster.
 
 #### Reducing Horizontal Scale
 
-In the case in which a Riak cluster is over provisioned, or in response
-to seasonal usage decreases, the horizontal scale of a Riak cluster can
-be decreased using the `riak-admin cluster leave` command.
+If a Riak cluster is over provisioned, or in response to seasonal usage decreases, the horizontal scale of a Riak cluster can be decreased using the `riak-admin cluster leave` command.
 
 ## Ring Size/Number of Partitions
 
-Ring size is the number of partitions that make up your Riak cluster.
-This is a number that is configured before you cluster is started, and
+Ring size is the number of partitions that make up your Riak cluster. Ring sizes must be a power of 2. Ring size is configured before your cluster is started, and
 is set in your [[configuration files]].
 
-The default number of partitions in a Riak cluster is 64. This works for
-smaller clusters, but if you plan to grow your cluster past 5 nodes it
-is recommended that you consider a larger ring size. Ring sizes must be
-a power of 2. The minimum number of partitions recommended per node is
-10, and you can determine the number of partitions that will be
-allocated per node by dividing the number of partitions by the number of
-nodes.
+The default number of partitions in a Riak cluster is 64. This works for smaller clusters, but if you plan to grow your cluster past 5 nodes we recommend a larger ring size.
 
-Because Riak clusters vary so greatly in terms of the features that are
-used, the use cases that are served, and so on, there are no
-hard-and-fast rules regarding the ideal partitions-per-node ratio. A
-good rule of thumb, however, is that you should have between 10 and 50
-data partitions per node. So if you're running a 3-node development
-cluster, a ring size of 64 or 128 should work just fine, while a 10-node
-cluster should work well with a ring size of 128 or 256 (64 is too small
-while 512 is likely too large).
+The minimum number of partitions recommended per node is 10. You can determine the number of partitions allocated per node by dividing the number of partitions by the number of nodes.
+
+There are no absolute rules for the ideal partitions-per-node ratio. This depends on your particular use case and what features the Riak cluster uses. We recommend between 10 and 50 data partitions per node. 
+
+So if you're running a 3-node development cluster, a ring size of 64 or 128 should work just fine. While a 10-node cluster should work well with a ring size of 128 or 256 (64 is too small while 512 is likely too large).
 
 The table below provides some suggested combinations:
 
@@ -238,18 +201,18 @@ your cluster performs under load for an extended period of time. Doing
 so will help you size your cluster for future growth and lead to optimal
 performance.
 
-Basho recommends using [[Basho Bench]] for benchmarking the performance
+We recommend using [[Basho Bench]] for benchmarking the performance
 of your cluster.
 
 ### Bandwidth
 
 Riak uses Erlang's built-in distribution capabilities to provide
 reliable access to data. A Riak cluster can be deployed in many
-different network topologies, but it is recommended that you produce as
+different network environments. We recommend that you produce as
 little latency between nodes as possible, as high latency leads to
-sub-optimal performance. It is not recommended that you deploy a single
-Riak cluster across two datacenters. If your use case requires this
-capability, Basho offers a [[Multi Data Center Replication:
+sub-optimal performance. 
+
+Deploying a single Riak cluster across two datacenters is not recommended. If your use case requires this capability, Basho offers a [[Multi Data Center Replication:
 Architecture]] option that is built to keep multiple Riak clusters in
 sync across several geographically diverse deployments.
 

--- a/source/languages/en/riak/ops/mdc/v2/quick-start.md
+++ b/source/languages/en/riak/ops/mdc/v2/quick-start.md
@@ -31,7 +31,7 @@ This Guide assumes that you have completed the following steps:
 ## Scenario
 
 Configure Riak MDC to perform replication, given the following
-three-node Riak Enterprise clusters: 
+3-node Riak Enterprise clusters: 
 
 #### Cluster 1
 

--- a/source/languages/en/riak/ops/mdc/v3/aae.md
+++ b/source/languages/en/riak/ops/mdc/v3/aae.md
@@ -88,7 +88,7 @@ Changing the rate of tree building can speed up this process, with the
 caveat that rebuilding a tree takes processing time from the cluster,
 and this should not be done without assessing the possible impact on
 get/put latencies for normal cluster operations. For a production
-cluster, it is recommended that you leave the default in place.
+cluster, we recommend leaving the default in place.
 
 For a test cluster, the build rate can be changed with
 `anti_entropy_build_limit` and `anti_entropy_concurrency`. If a

--- a/source/languages/en/riak/ops/mdc/v3/operations.md
+++ b/source/languages/en/riak/ops/mdc/v3/operations.md
@@ -352,7 +352,7 @@ file or command line.
 
 Riak Version 2 Replication and Version 3 Replication can be safely used
 at the same time. If you choose to move to Version 3 Replication
-completely, it is recommended that you disable Version 2 realtime
+completely, we recommend disabling Version 2 realtime
 replication bucket hooks with the `riak-repl modes` command.
 
 #### `riak-repl modes`

--- a/source/languages/en/riak/ops/running/cluster-admin.md
+++ b/source/languages/en/riak/ops/running/cluster-admin.md
@@ -51,7 +51,7 @@ Displays a variety of information about the cluster.
 riak-admin cluster status
 ```
 
-This will return output like the following in a three-node cluster:
+This will return output like the following in a 3-node cluster:
 
 ```
 ---- Cluster Status ----
@@ -210,7 +210,7 @@ If there is no current cluster plan, the output will be `There are no
 staged changes`. If there is a staged change (or changes), however, you
 will see a detailed listing of what will take place upon commit, what
 the cluster will look like afterward, etc. If a `cluster leave`
-operation is staged in a three-node cluster, for example, the output
+operation is staged in a 3-node cluster, for example, the output
 will look something like this:
 
 ```

--- a/source/languages/en/riak/ops/running/handoff.md
+++ b/source/languages/en/riak/ops/running/handoff.md
@@ -27,7 +27,7 @@ handoff** and **ownership transfer**.
 
 Hinted handoff occurs when a [[vnode|Vnodes]] temporarily takes over
 responsibility for some data and then returns that data to its original
-"owner." Imagine a three-node cluster with nodes A, B, and C. If node C
+"owner." Imagine a 3-node cluster with nodes A, B, and C. If node C
 goes offline, e.g. during a network partition, nodes A and B will pick
 up the slack, so to speak, assuming responsibility for node C's
 operations. When node C comes back online, responsibility will be handed

--- a/source/languages/en/riak/ops/running/recovery/repairing-indexes.md
+++ b/source/languages/en/riak/ops/running/recovery/repairing-indexes.md
@@ -13,7 +13,7 @@ moved: {
 
 ## Repairing Secondary Indexes
 
-The `riak-admin repair-2i` command can be used to repair any stale or missing secondary indexes.  This command scans and repairs any mismatches between the secondary index data used for querying and the secondary index data stored in the Riak objects. It can be run on all partitions of a node or on a subset of them.  It is recommended that these repairs are only scheduled outside of peak load time.
+The `riak-admin repair-2i` command can be used to repair any stale or missing secondary indexes.  This command scans and repairs any mismatches between the secondary index data used for querying and the secondary index data stored in the Riak objects. It can be run on all partitions of a node or on a subset of them.  We recommend scheduling these repairs outside of peak load time.
 
 ### Running a Repair
 

--- a/source/languages/en/riak/ops/tuning/latency-reduction.md
+++ b/source/languages/en/riak/ops/tuning/latency-reduction.md
@@ -262,7 +262,7 @@ these settings.
 
 ### Object Size
 
-As stated above, Basho recommends _always_ keeping objects below 1-2 MB
+As stated above, we recommend _always_ keeping objects below 1-2 MB
 and preferably below 100 KB if possible. If you want to ensure that
 objects above a certain size do not get stored in Riak, you can do so by
 setting the `object.size.maximum` parameter lower than the default of

--- a/source/languages/en/riak/quickstart.md
+++ b/source/languages/en/riak/quickstart.md
@@ -13,7 +13,7 @@ moved: {
 
 In this tutorial, we'll share some quick start installers for OSX, as 
 well as provide instructions for building a
-[five-node](http://basho.com/why-your-riak-cluster-should-have-at-least-five-nodes/)
+[5-node](http://basho.com/why-your-riak-cluster-should-have-at-least-five-nodes/)
 Riak cluster running on your local machine.
 
 ## DMG Installer for OSX
@@ -27,7 +27,7 @@ application should not be used in a production deployment.
 
 ## Riak Dev Cluster for OSX
 
-To quickly create a five-node local devrel cluster on OSX, you may use the
+To quickly create a 5-node local devrel cluster on OSX, you may use the
 [[Riak Dev Cluster|https://github.com/basho-labs/riak-dev-cluster/]] project.
 This application will easily install and join a cluster of local nodes on OSX
 for testing and administration.  Note that this sample application should not 
@@ -294,7 +294,7 @@ the [[riak-admin command line]] documentation.
 
 ## Test the Cluster
 
-Now that we have a running five-node Riak cluster, let's make sure that
+Now that we have a running 5-node Riak cluster, let's make sure that
 it's working properly. For this we have a couple of options. The
 simplest is to run the `member-status` command on one of our nodes:
 
@@ -384,7 +384,7 @@ This will save the image to the current directory. You can open it with
 an image editor to verify that the image has been stored and retrieved
 correctly.
 
-Congratulations! You should now have a five-node Riak cluster up and
+Congratulations! You should now have a 5-node Riak cluster up and
 running.
 
 <div class="note">
@@ -508,13 +508,13 @@ the navbar on the left).
 ### Ruby
 
 How you connect to Riak with the Ruby client depends on whether you're
-using Riak in a development environment with a one-node
+using Riak in a development environment with a 1-node
 [[cluster|Clusters]] or if you're using multiple nodes, as you would in
 any production environment.
 
 If you're developing using a single-node cluster, you can create a
 `client` object and specify the host and [[Protocol Buffers|PBC API]]
-port. The example below connects the Ruby client to a one-node cluster
+port. The example below connects the Ruby client to a 1-node cluster
 running on the host 101.0.0.1 and the port 8087:
 
 ```ruby
@@ -549,13 +549,13 @@ Developers** section of the documentation (in the navbar on the left).
 ### Python
 
 How you connect to Riak with the Python client depends on whether you're
-using Riak in a development environment with a one-node
+using Riak in a development environment with a 1-node
 [[cluster|Clusters]] or if you're using multiple nodes, as you would in
 any production environment.
 
 If you're developing using a single-node cluster, you can create a
 `client` object and specify the host and [[Protocol Buffers|PBC API]]
-port. The example below connects the Python client to a one-node cluster
+port. The example below connects the Python client to a 1-node cluster
 running on host 101.0.0.1 and port 8087:
 
 ```python
@@ -675,7 +675,7 @@ the navbar on the left).
 ### Erlang
 
 How you connect to Riak with the Erlang client depends on whether you're
-using Riak in a development environment with a one-node
+using Riak in a development environment with a 1-node
 [[cluster|Clusters]] or if you're using multiple nodes, as you would in
 any production environment.
 
@@ -684,7 +684,7 @@ single process identifier (i.e.
 [pid](http://www.erlang.org/doc/reference_manual/data_types.html#id66818))
 to which your client will connect on the basis of the host and Protocol
 Buffers port you provide. The example below connects the Erlang client
-to a one-node cluster running on the host 101.0.0.1 and the port 8087:
+to a 1-node cluster running on the host 101.0.0.1 and the port 8087:
 
 ```erlang
 {ok, Pid} = riakc_pb_socket:start_link("101.0.0.1", 8087).
@@ -712,13 +712,13 @@ the navbar on the left).
 ### PHP
 
 How you connect to Riak with the PHP client depends on whether you're
-using Riak in a development environment with a one-node
+using Riak in a development environment with a 1-node
 [[cluster|Clusters]] or if you're using multiple nodes, as you would in
 any production environment.
 
 If you're developing using a single-node cluster, you can create a
 `client` object and specify the host and [[HTTP|HTTP API]]
-port. The example below connects the PHP client to a one-node cluster
+port. The example below connects the PHP client to a 1-node cluster
 running on host 101.0.0.1 and port 8098:
 
 ```PHP

--- a/source/languages/en/riak/theory/why-riak.md
+++ b/source/languages/en/riak/theory/why-riak.md
@@ -78,7 +78,7 @@ high availability approach while simplifying application development.
 
 ### When Riak is Less of a Good Fit
 
-Basho recommends that you run no fewer than 5 data servers in a cluster.
+We recommend running no fewer than 5 data servers in a cluster.
 This means that Riak can be overkill for small databases. If you're not
 already sure that you will need a distributed database, there's a good
 chance that you won't need Riak.


### PR DESCRIPTION
Feedback / comments on these changes would be much appreciated :smile: 

* Changed instances of **it is recommended** and **Basho recommends** to **we recommend**.
* Changed instances of **number-node** to **#-node** for consistency across docs.
  - For example, *three-node* = *3-node*.
* Edited pages under Building a Cluster (`/riak/ops/building`) section.
  - Changed/removed some idioms or informal language (ex: *rule of thumb*).
  - Added whitespace to break up dense paragraphs.