### PR TITLE
Correct links and remove in-page header links

### DIFF
--- a/source/languages/en/dataplatform/dataplatform-index.md
+++ b/source/languages/en/dataplatform/dataplatform-index.md
@@ -13,8 +13,8 @@ versions: true
 ---
 
 
-[bdp install]: ./installing
-[bdp reference]: ./learnaboutdataplatform.html
+[bdp install]: http://docs.basho.com/dataplatform/1.0.0/installing/
+[bdp reference]: http://docs.basho.com/dataplatform/1.0.0/learn-about-dataplatform/service-manager-features/
 [ee]: http://info.basho.com/Wiki_Riak_Enterprise_Request.html
 
 #Basho Data Platform

--- a/source/languages/en/dataplatform/installing.md
+++ b/source/languages/en/dataplatform/installing.md
@@ -8,9 +8,9 @@ index: true
 audience: beginner
 ---
 
-[bdp compatibility]: http://docs.basho.com/dataplatform/latest/#supported-operating-systems
-[bdp configure]: LINK
-[bdp download]: http://docs.basho.com/dataplatform/latest/dataplatform-downloads/
+[bdp compatibility]: http://docs.basho.com/dataplatform/1.0.0/#supported-operating-systems
+[bdp configure]: http://docs.basho.com/dataplatform/1.0.0/using-dataplatform/configuration/setup-a-cluster/
+[bdp download]: http://docs.basho.com/dataplatform/1.0.0/downloads/
 
 
 Basho Data Platform (BDP) enables you to extend Riak with Spark and Redis. This page will guide you through the process of installing BDP on most supported operating systems.
@@ -24,9 +24,9 @@ You need to have root or sudo access on the nodes you will be installing BDP on.
 
 ##Installing
 
-1. First, [change the open-files limit.](#increase-the-openfiles-limit).
-2. If you plan to use Spark, then [install Java 8](#java-8).
-3. Finally, [install the BDP package](#install-bdp).
+1. First, change the open-files limit.
+2. If you plan to use Spark, then install Java 8.
+3. Finally, install the BDP package.
 
 ###Increase The Open-Files Limit
 
@@ -86,26 +86,26 @@ grep JAVA_HOME /etc/environment >/dev/null 2>&1 || test $? -ne 0 && sudo bash -c
 export JAVA_HOME
 ```
 
-### Install BDP
+###Install BDP
 
-Now that you've increased your [open-files limit](#increase-the-openfiles-limit) and [installed Java 8](#java-8) where necessary, you're ready to install the BDP package.
+Now that you've increased your open-files limit and installed Java 8 where necessary, you're ready to install the BDP packages.
 
 >Enterprise Note:
->If you are an Enterprise customer, you will need to download the -extras package as well. The -extras package is available along with the regular packages in the usual Zendesk forums.
+>If you are an Enterprise customer, make sure to download the -extras package as well. The -extras package is available alongside the regular packages in the usual Zendesk forums.
 
 BDP open source packages for all supported operating systems are available for download on the [Download Basho Data Platform page][bdp download]. 
 
-Choose the installation instructions below that match your OS: [Ubuntu](#ubuntu) or [CentOS](#centos).
+Choose the installation instructions below that match your OS.
 
 ####Ubuntu
 
-1. Download the package from the [downloads][bdp download] page (or packages from Zendesk).
-2. Unpack the package using `sudo dpkg -i`.
+1. Download the packages from the [downloads][bdp download] page (or packages from Zendesk).
+2. Unpack the packages using `sudo dpkg -i` for each one.
 
 ####CentOS
 
-1. Download the package(s) from the [downloads][bdp download] page (or packages from Zendesk).
-2. Unpack the package using `sudo yum` and `sudo rpm`.
+1. Download the packages from the [downloads][bdp download] page (or packages from Zendesk).
+2. Unpack the packages using `sudo yum` and `sudo rpm`.
 
 ##Next Steps
 

--- a/source/languages/en/dataplatform/learn-about-dataplatform/cache-proxy-features.md
+++ b/source/languages/en/dataplatform/learn-about-dataplatform/cache-proxy-features.md
@@ -21,13 +21,13 @@ Basho Data Platform (BDP) cache proxy provides pre-sharding and connection aggre
 
 On this page, you will find detailed descriptions of cache proxy's components, including what each component does and how you implement it. Cache proxy has the following components:
  
-* [Pre-sharding](#presharding)
-* [Connection Aggregation](#connection-aggregation)
-* [Command Pipelining](#command-pipelining)
-* [Read-through Cache](#readthrough-cache)
-* [Write-through Cache](#writethrough-cache)
+* Pre-sharding
+* Connection Aggregation
+* Command Pipelining
+* Read-through Cache
+* Write-through Cache
 
-You will also find a list of [commands](#commands) you can use with cache proxy.
+You will also find a list of commands you can use with cache proxy.
 
 ##Pre-sharding
 
@@ -72,12 +72,12 @@ In addition to developer efficiency gains, the Cache Proxy write-through strateg
 
 ## Commands
 
-For command details, refer to the Redis [documentation - http://redis.io/commands ](LINK)
+For command details, refer to the Redis [documentation](http://redis.io/commands)
 
 The Cache Proxy supports the following augmented Redis commands fully:
 
 * GET - get the value of a key from Redis or Riak KV utilizing the read-through caching strategy with a TTL set at service configuration time.
 
-The Cache Proxy also supports the set of Redis commands supported by Twemproxy, but only to the point of presharding and command pipelining, refer to the Twemproxy [documentation - https://github.com/twitter/twemproxy/blob/master/notes/redis.md ](LINK)
+The Cache Proxy also supports the set of Redis commands supported by Twemproxy, but only to the point of presharding and command pipelining, refer to the Twemproxy [documentation](https://github.com/twitter/twemproxy/blob/master/notes/redis.md)
 
 *!IMPORTANT!* While the Cache Proxy does support issuing DEL commands, PEXPIRE with a small TTL is suggested instead when the semantic intent is to remove an item from cache.  With write-through, the DEL command will issue a delete to the Riak backend.

--- a/source/languages/en/dataplatform/learn-about-dataplatform/leader-election-service.md
+++ b/source/languages/en/dataplatform/learn-about-dataplatform/leader-election-service.md
@@ -9,7 +9,7 @@ audience: beginner
 ---
 
 [ee]: http://info.basho.com/Wiki_Riak_Enterprise_Request.html
-[riak_ensemble]:
+[riak_ensemble]: https://github.com/basho/riak_ensemble
 
 
 <div class="note">
@@ -20,7 +20,7 @@ Leader Election Service is available to [Enterprise users only][ee].
 
 The Basho Data Platform (BDP) Leader Election Service enables Spark clusters to run without a ZooKeeper instance. 
 
-The Leader Election Service uses a simple, line-based, ascii protocol to interact with Spark. This protocol is incompatible with the ZooKeeper protocol, and requires a BDP-specific patch to Spark for compatibility purposes. The [SECTION](#LINK) section of this page further details the Leader Election Service protocol.
+The Leader Election Service uses a simple, line-based, ascii protocol to interact with Spark. This protocol is incompatible with the ZooKeeper protocol, and requires a BDP-specific patch to Spark for compatibility purposes. The Protocol Details section of this page further details the Leader Election Service protocol.
 
 The service can be run on any or all nodes in a Riak cluster, so long as those nodes have [`riak_ensemble`][riak_ensemble]. Because it uses a strongly consistent backing store that is spread across the entire cluster, it does not normally matter which nodes are running the service. As long as there are no network partitions or outages interfering with normal operation, you should be able to point Spark to any Riak node that is running the election service, and everything will work the same way regardless.
 

--- a/source/languages/en/dataplatform/learn-about-dataplatform/learn-about-dataplatform.md
+++ b/source/languages/en/dataplatform/learn-about-dataplatform/learn-about-dataplatform.md
@@ -12,10 +12,10 @@ versions: true
 ---
 
 [using bdp index]: LINK
-[cache proxy features]: LINK
-[service manager features]: LINK
-[leader election features]: LINK
-[spark manager features]: LINK
+[cache proxy features]: http://docs.basho.com/dataplatform/1.0.0/learn-about-dataplatform/cache-proxy-features/
+[service manager features]: http://docs.basho.com/dataplatform/1.0.0/learn-about-dataplatform/service-manager-features/
+[leader election features]: http://docs.basho.com/dataplatform/1.0.0/learn-about-dataplatform/leader-election-service/
+[spark manager features]: http://docs.basho.com/dataplatform/1.0.0/learn-about-dataplatform/spark-cluster-manager-features/
 
 ##In This Section
 

--- a/source/languages/en/dataplatform/learn-about-dataplatform/service-manager-features.md
+++ b/source/languages/en/dataplatform/learn-about-dataplatform/service-manager-features.md
@@ -6,6 +6,8 @@ document: guide
 audience: beginner
 ---
 
+[bdp cli]: http://docs.basho.com/dataplatform/1.0.0/using-dataplatform/dataplatform-commands/
+
 ##Overview
 
 The service manager is the foundation of the Basho Data Platform (BDP). It provides a means for building a cluster of nodes that can deploy, run, and manage platform services. Note that Riak KV is included with BDP, and use of BDP assumes familiarity with Riak KV.

--- a/source/languages/en/dataplatform/learn-about-dataplatform/spark-cluster-manager-features.md
+++ b/source/languages/en/dataplatform/learn-about-dataplatform/spark-cluster-manager-features.md
@@ -6,6 +6,8 @@ document: guide
 audience: beginner
 ---
 
+[bdp leader election]: http://docs.basho.com/dataplatform/1.0.0/learn-about-dataplatform/leader-election-service/
+[bdp cluster manager]: http://docs.basho.com/dataplatform/1.0.0/using-dataplatform/configuration/replace-spark-cluster-manager/
 [ee]: http://info.basho.com/Wiki_Riak_Enterprise_Request.html
 
 <div class="note">
@@ -15,13 +17,13 @@ The Spark cluster manager is available to [Enterprise users only][ee].
 The Spark cluster manager provides all the functionality required for Spark Master high availability without the need to manage yet another software system (Zookeeper). This reduces operational complexity of Basho Data Platform (BDP).
 
 <div class="note">
-Please note that the Spark cluster manager depends on the [Riak Leader Election Service](LINK). Check out [Replace Your Previous Spark Cluster Manager with the Basho Data Platform Cluster Manager](LINK) for instructions on setting up the Spark cluster manager.
+Please note that the Spark cluster manager depends on the [Riak Leader Election Service][bdp leader election]. Check out [Replace Your Previous Spark Cluster Manager with the Basho Data Platform Cluster Manager][bdp cluster manager] for instructions on setting up the Spark cluster manager.
 </div>
 
 
 ##Zookeeper Replacement
 
-The Spark cluster manager forms a pair with the [leader election service (LES)](LINK). It enables Spark to use the LES rather than ZooKeeper. Spark cluster manager provides all the functionality required for Spark Master high availability without the need to manage yet another software system.
+The Spark cluster manager forms a pair with the [leader election service (LES)][bdp leader election]. It enables Spark to use the LES rather than ZooKeeper. Spark cluster manager provides all the functionality required for Spark Master high availability without the need to manage yet another software system.
 
 
 ##Store Spark Cluster Metadata in Riak KV

--- a/source/languages/en/dataplatform/release-notes.md
+++ b/source/languages/en/dataplatform/release-notes.md
@@ -8,7 +8,10 @@ toc: true
 keywords: [developers]
 ---
 
-Released August XY, 2015.
+[bdp downloads]: http://docs.basho.com/dataplatform/1.0.0/downloads/
+[bdp install]: http://docs.basho.com/dataplatform/1.0.0/installing/
+
+Released August 27, 2015.
 
 This release is the introductory release of Basho Data Platform (BDP), so everything is new!
 
@@ -54,7 +57,7 @@ BDP also supports the following operating systems for development:
 
 ##Installing
 
-You can find the install packages for BDP [here](LINK) and the instructions to walk you through the installation process [here](LINK).
+You can find the install packages for BDP [here][bdp downloads] and the instructions to walk you through the installation process [here][bdp install].
 
 ##Known Issues
 

--- a/source/languages/en/dataplatform/upgrading.md
+++ b/source/languages/en/dataplatform/upgrading.md
@@ -18,7 +18,7 @@ There were many changes between the Basho Data Platform (BDP) beta releases and 
 
 ##Uninstall Instructions
 
-Choose the installation instructions below that match your OS, [Ubuntu or Debian](#ubuntu-or-debian) or [CentOS or RHEL](#centos-or-rhel)
+Choose the installation instructions below that match your OS.
 
 >Important: 
 >

--- a/source/languages/en/dataplatform/using-dataplatform/configuration/getting-started-with-cache-proxy.md
+++ b/source/languages/en/dataplatform/using-dataplatform/configuration/getting-started-with-cache-proxy.md
@@ -8,9 +8,9 @@ index: true
 audience: beginner
 ---
 
-[bdp install]: LINK
-[bdp configure]: LINK
-[bdp configure add services]: LINK
+[bdp install]: http://docs.basho.com/dataplatform/1.0.0/installing/
+[bdp configure]: http://docs.basho.com/dataplatform/1.0.0/using-dataplatform/configuration/setup-a-cluster/
+[bdp configure add services]: http://docs.basho.com/dataplatform/1.0.0/using-dataplatform/configuration/setup-a-cluster/#add-services
 
 
 Now that you’ve [set up a Basho Data Platform cluster][bdp configure], which included [adding a service configuration for Redis and cache proxy][bdp configure add services], you’re ready to use cache proxy with any Redis client that supports the `GET` command.

--- a/source/languages/en/dataplatform/using-dataplatform/configuration/replace-spark-cluster-manager.md
+++ b/source/languages/en/dataplatform/using-dataplatform/configuration/replace-spark-cluster-manager.md
@@ -9,9 +9,9 @@ audience: beginner
 ---
 
 
-[bdp install]: LINK
-[bdp configure]: LINK
-[bdp configure spark master]: LINK
+[bdp install]: http://docs.basho.com/dataplatform/1.0.0/installing/
+[bdp configure]: http://docs.basho.com/dataplatform/1.0.0/using-dataplatform/configuration/setup-a-cluster/
+[bdp configure spark master]: http://docs.basho.com/dataplatform/1.0.0/using-dataplatform/configuration/setup-a-cluster/#set-up-spark-cluster-metadata
 [riak data types]: http://docs.basho.com/riak/2.1.1/dev/using/data-types/
 
 
@@ -38,9 +38,9 @@ Name of CRDT map for metadata storage (i.e. 'spark-cluster-map'). The CRDT map s
 
 To replace your Spark Cluster Manager with the BDP cluster manager, you will do the following:
 
-1. [Add BDP service configs for spark-master and spark-worker.](#add-bdp-service-configs)
-2. [Activate the services.](#activate-the-services)
-3. [Verify.](#verify-your-success)
+1. Add BDP service configs for spark-master and spark-worker.
+2. Activate the services.
+3. Verify
 
 ###Add BDP Service Configs
 

--- a/source/languages/en/dataplatform/using-dataplatform/configuration/setup-a-cluster.md
+++ b/source/languages/en/dataplatform/using-dataplatform/configuration/setup-a-cluster.md
@@ -8,7 +8,7 @@ index: true
 audience: beginner
 ---
 
-[bdp install]: LINK
+[bdp install]: http://docs.basho.com/dataplatform/1.0.0/installing/
 [riak cluster setup]: http://docs.basho.com/riak/2.1.1/ops/building/basic-cluster-setup/
 [riak configure]: http://docs.basho.com/riak/2.1.1/ops/building/basic-cluster-setup/
 [riak_ensemble]: https://github.com/basho/riak_ensemble
@@ -17,7 +17,7 @@ audience: beginner
 
 Now that you've [installed Basho Data Platform][bdp install], you're ready to set up a Basho Data Platform (BDP) cluster. This page will guide you through this process.
 
-This page also lists the [default port connections for BDP](#configuration-defaults).
+This page also lists the default port connections for BDP.
 
 ##Prerequisites
 
@@ -31,7 +31,7 @@ This page also lists the [default port connections for BDP](#configuration-defau
 
 <div class="note">
 <div class="title">Note on Amazon Web Services</div>
-AWS security profile must allow incoming and outgoing traffic from ip/ports used by Riak, Spark, and BDP.  A [list of default ports](LINK) is at the end of this document. 
+AWS security profile must allow incoming and outgoing traffic from ip/ports used by Riak, Spark, and BDP.  A list of default ports is at the end of this document. 
 </div>
 
 <div class="warning">
@@ -40,13 +40,13 @@ AWS security profile must allow incoming and outgoing traffic from ip/ports used
 
 ##Configure a BDP Cluster
 
-1. First, [start your BDP nodes](#start-your-bdp-nodes).
-2. Then, [join your BDP nodes together](#join-bdp-nodes).
-3. Next, [make sure riak_ensemble is running](#start-riakensemble).
-4. Then, [configure the leader election service](#configure-the-leader-election-service)
-5. Next, if you're running a Spark cluster, [set up your Spark cluster metadata](#set-up-spark-cluster-metadata).
-6. After that, you'll need to [confirm that Java is correctly configured](#confirm-javahome-is-set-correctly).
-7. Finally, [add services to the nodes](#add-services).
+1. First, start your BDP nodes.
+2. Then, join your BDP nodes together.
+3. Next, make sure riak_ensemble is running.
+4. Then, configure the leader election service.
+5. Next, if you're running a Spark cluster, set up your Spark cluster metadata.
+6. After that, you'll need to confirm that Java is correctly configured.
+7. Finally, add services to the nodes.
  
 ###Start Your BDP Nodes
 
@@ -107,11 +107,11 @@ For more information on why this is important, please see our [strong consistenc
 
 ###Configure The Leader Election Service
 
-Before enabling the leader election service, you must have enabled `riak_ensemble` (as directed in the [previous step](#start-riakensemble)). If you skipped the previous step for any reason, please go back and do it now.
+Before enabling the leader election service, you must have enabled `riak_ensemble` (as directed in the previous step). If you skipped the previous step for any reason, please go back and do it now.
 
 1. Locate and open `riak.conf`.
 2. Find the line `## listener.leader_latch.internal = 127.0.0.1:5323`.
-3. Uncomment the line and set to your node's IP and port. (**Note:** Any port will work as long as it matches what you set in the [Spark master step](#spark-master) below.)
+3. Uncomment the line and set to your node's IP and port. (**Note:** Any port will work as long as it matches what you set in the Spark master step below.)
 
 <div class="note">
 The leader election service provides no authentication mechanism. We strongly suggest that you use a network shielded from external connection attempts, otherwise you run the risk of an attacker performing a Denial of Service attack against your cluster.
@@ -133,7 +133,7 @@ Changes to the `listener.leader_latch` setting will not have an impact on a live
 ###Set Up Spark Cluster Metadata
 
 <div class="note">
-Follow these steps ONLY if you are running a Spark cluster. Otherwise, skip to [Add Services](#add-services).
+Follow these steps ONLY if you are running a Spark cluster. Otherwise, skip to Add Services.
 </div>
 
 If you are running a Spark cluster, you need to connect it with BDP.
@@ -205,10 +205,10 @@ $ sudo riak restart
 
 You are ready to add services to your started, joined BDP nodes. There are several different types of services you can add to your BDP nodes:
 
-* [Spark master](#spark-master)
-* [Spark worker](#spark-worker)
-* [Redis](#redis)
-* [Cache proxy](#cache-proxy)
+* Spark master
+* Spark worker
+* Redis
+* Cache proxy
 
 ####Spark Master
 
@@ -258,7 +258,7 @@ The IP addresses you provide should be the IP addresses of the 3 BDP nodes you s
 ##Configuration Defaults
 
 
-Each service has one or more default ports if a port has not been specified when [adding a service configuration](#add-services).
+Each service has one or more default ports if a port has not been specified when adding a service configuration.
 
 For example, you can add a service configuration from the command line for Redis using a specified port:
 

--- a/source/languages/en/dataplatform/using-dataplatform/dataplatform-commands.md
+++ b/source/languages/en/dataplatform/using-dataplatform/dataplatform-commands.md
@@ -8,10 +8,10 @@ audience: beginner
 ---
 
 
-[bdp configure]: LINK
-[bdp configure add services]: LINK
-[bdp install]: LINK
-[bdp reference]: LINK
+[bdp configure]: http://docs.basho.com/dataplatform/1.0.0/using-dataplatform/configuration/setup-a-cluster/
+[bdp configure add services]: http://docs.basho.com/dataplatform/1.0.0/using-dataplatform/configuration/setup-a-cluster/#add-services
+[bdp install]: http://docs.basho.com/dataplatform/1.0.0/installing/
+[bdp reference]: http://docs.basho.com/dataplatform/1.0.0/learn-about-dataplatform/service-manager-features/
 
 
 Basho Data Platform (BDP) comes with a command line tool (`data-platform-admin`) that allows you to perform various operations on your BDP cluster. The following reference outlines available commands and their uses.

--- a/source/languages/en/dataplatform/using-dataplatform/using-bdp.md
+++ b/source/languages/en/dataplatform/using-dataplatform/using-bdp.md
@@ -9,10 +9,10 @@ audience: beginner
 ---
 
 
-[bdp configure]: LINK 
-[bdp configure add services]: LINK
-[bdp install]: ./dataplatform/installing.html
-[bdp reference]: LINK
+[bdp configure]: http://docs.basho.com/dataplatform/1.0.0/using-dataplatform/configuration/setup-a-cluster/
+[bdp configure add services]: http://docs.basho.com/dataplatform/1.0.0/using-dataplatform/configuration/setup-a-cluster/#add-services
+[bdp install]: http://docs.basho.com/dataplatform/1.0.0/installing/
+[bdp reference]: http://docs.basho.com/dataplatform/1.0.0/learn-about-dataplatform/service-manager-features/
 
 
 You've [installed][bdp install] Basho Data Platform (BDP), [configured][bdp configure] your cluster, and [added services][bdp configure add services] to your nodes. The setup of your BDP cluster is complete! Now you can begin using your BDP cluster. 
@@ -22,10 +22,10 @@ You've [installed][bdp install] Basho Data Platform (BDP), [configured][bdp conf
 
 The very first thing you can do with your BDP cluster is start the services you added. In the last section of the [configuration instructions][bdp configure add services], you added the following services:
 
-* [Spark-master](#spark-master-service)
-* [Spark-worker](#spark-worker-service)
-* [Redis](#redis-service)
-* [Cache proxy](#cache-proxy-service)
+* Spark-master
+* Spark-worker
+* Redis
+* Cache proxy
 
 ###Spark-Master Service
 
@@ -91,7 +91,7 @@ $ data-platform-admin start-service »NODENAME«@»IPADDRESS« my-cache-proxy-gr
 
 ###Redis and Cache Proxy
 
-Do you use [CentOS](#centos) or [Ubuntu](#ubuntu)?
+Do you use CentOS or Ubuntu?
 
 ####CentOS
 

--- a/source/languages/en/dataplatform/using-dataplatform/using-dataplatform.md
+++ b/source/languages/en/dataplatform/using-dataplatform/using-dataplatform.md
@@ -11,13 +11,13 @@ simple: true
 versions: true
 ---
 
-[bdp install]: LINK
-[bdp config]: LINK
-[bdp cluster manager]: LINK
-[cache proxy config]: LINK
-[using bdp]: LINK
-[bdp cli]: LINK
-[learn bdp index]: LINK
+[bdp install]: http://docs.basho.com/dataplatform/1.0.0/installing/
+[bdp config]: http://docs.basho.com/dataplatform/1.0.0/using-dataplatform/configuration/setup-a-cluster/
+[bdp cluster manager]: http://docs.basho.com/dataplatform/1.0.0/using-dataplatform/configuration/replace-spark-cluster-manager/
+[cache proxy config]: http://docs.basho.com/dataplatform/1.0.0/using-dataplatform/configuration/getting-started-with-cache-proxy/
+[using bdp]: http://docs.basho.com/dataplatform/1.0.0/using-dataplatform/using-bdp/
+[bdp cli]: http://docs.basho.com/dataplatform/1.0.0/using-dataplatform/dataplatform-commands/
+[learn bdp index]: http://docs.basho.com/dataplatform/1.0.0/learn-about-dataplatform/service-manager-features/
 
 ##In This Section
 


### PR DESCRIPTION
Many links were left unspecified before launch so that we could correctly link them once we knew which form of link worked. Of those that were specified, only those with full URLs worked. The ones relying on the directory and S3 bucket structure to fill in the URL failed. All have been updated and corrected with full URLs. 
Additionally, it was found that all links within a document to headers within that document (or to specific headers on other pages) failed, as linking to headers below h2 is currently unsupported. We are working to change that, but until then, all links have been removed.