### PR TITLE
Fix URL for Azure install script

### DIFF
--- a/source/languages/en/riak/ops/building/installing/azure.md
+++ b/source/languages/en/riak/ops/building/installing/azure.md
@@ -111,7 +111,7 @@ If you are using a Windows computer, connect to the VM using PuTTY. PuTTY can be
 
 ```bash
 sudo su -
-curl -s https://raw.github.com/basho/riak_on_azure/1.0/azure_install_riak.sh | sh
+curl -s https://raw.githubusercontent.com/basho/riak_on_azure/1.0/azure_install_riak.sh | sh
 ```
 
 ## Configure Riak using Riak Control


### PR DESCRIPTION
The current URL returns a 301 redirect as GitHub sends the request on to raw.githubusercontent.com, breaking the install instructions.