### PR TITLE
Update note div html to markdown

### DIFF
--- a/source/languages/en/dataplatform/learn-about-dataplatform/cache-proxy-features.md
+++ b/source/languages/en/dataplatform/learn-about-dataplatform/cache-proxy-features.md
@@ -11,9 +11,7 @@ audience: beginner
 [readthrough-strategy]: /readthrough-strategy.png
 [writethrough-sequence]: /writethrough-sequence.png
 
-<div class="note">
-Cache proxy is available to [Enterprise users only][ee].
-</div>
+>Cache proxy is available to [Enterprise users only][ee].
 
 ##Overview
 


### PR DESCRIPTION
Turns out, reference style links don't render in html style notes. WEIRD. Also, probably something we should fix.