### PR TITLE
Update packagecloud.io links

### DIFF
--- a/source/languages/en/riak/ops/building/installing/debian-ubuntu.md
+++ b/source/languages/en/riak/ops/building/installing/debian-ubuntu.md
@@ -34,11 +34,11 @@ installation, Chef, and Puppet can be found in packagecloud's
 
 Platform-specific pages are linked below:
 
-* [Lucid](https://packagecloud.io/basho/riak/riak_{{VERSION}}-1_amd64.deb?distro=lucid)
-* [Precise](https://packagecloud.io/basho/riak/riak_{{VERSION}}-1_amd64.deb?distro=precise)
-* [Squeeze](https://packagecloud.io/basho/riak/riak_{{VERSION}}-1_amd64.deb?distro=squeeze)
-* [Trusty](https://packagecloud.io/basho/riak/riak_{{VERSION}}-1_amd64.deb?distro=trusty)
-* [Wheezy](https://packagecloud.io/basho/riak/riak_{{VERSION}}-1_amd64.deb?distro=wheezy)
+* [Lucid](https://packagecloud.io/basho/riak/packages/ubuntu/lucid/riak_{{VERSION}}-1_amd64.deb)
+* [Precise](https://packagecloud.io/basho/riak/packages/ubuntu/precise/riak_{{VERSION}}-1_amd64.deb)
+* [Squeeze](https://packagecloud.io/basho/riak/packages/debian/squeeze/riak_{{VERSION}}-1_amd64.deb)
+* [Trusty](https://packagecloud.io/basho/riak/packages/ubuntu/trusty/riak_{{VERSION}}-1_amd64.deb)
+* [Wheezy](https://packagecloud.io/basho/riak/packages/debian/wheezy/riak_{{VERSION}}-1_amd64.deb)
 
 Our documentation also includes instructions regarding signing keys and
 sources lists, which can be found in the [[Advanced apt

--- a/source/languages/en/riak/ops/building/installing/rhel-centos.md
+++ b/source/languages/en/riak/ops/building/installing/rhel-centos.md
@@ -39,10 +39,10 @@ docs](https://packagecloud.io/basho/riak/install).
 
 Platform-specific pages are linked below:
 
-* [el5](https://packagecloud.io/basho/riak/riak-{{VERSION}}-1.x86_64.rpm?distro=5)
-* [el6](https://packagecloud.io/basho/riak/riak-{{VERSION}}-1.el6.x86_64.rpm?distro=6)
-* [el7](https://packagecloud.io/basho/riak/riak-{{VERSION}}-1.el7.centos.x86_64.rpm?distro=7)
-* [Fedora 19](https://packagecloud.io/basho/riak/riak-{{VERSION}}-1.fc19.x86_64.rpm?distro=19)
+* [el5](https://packagecloud.io/basho/riak/packages/el/5/riak-{{VERSION}}-1.x86_64.rpm)
+* [el6](https://packagecloud.io/basho/riak/packages/el/6/riak-{{VERSION}}-1.el6.x86_64.rpm)
+* [el7](https://packagecloud.io/basho/riak/packages/el/7/riak-{{VERSION}}-1.el7.centos.x86_64.rpm)
+* [Fedora 19](https://packagecloud.io/basho/riak/packages/fedora/19/riak-{{VERSION}}-1.fc19.x86_64.rpm)
 
 Our documentation also includes instructions regarding signing keys and
 sources lists, which can be found in the [[Advanced rpm

--- a/source/languages/en/riakcs/cookbooks/installing/Installing-Riak-CS.md
+++ b/source/languages/en/riakcs/cookbooks/installing/Installing-Riak-CS.md
@@ -142,11 +142,11 @@ docs](https://packagecloud.io/basho/riak/install).
 
 Platform-specific pages are linked below:
 
-* [Lucid](https://packagecloud.io/basho/riak-cs/riak-cs_{{VERSION}}-1_amd64.deb?distro=lucid)
-* [Precise](https://packagecloud.io/basho/riak-cs/riak-cs_{{VERSION}}-1_amd64.deb?distro=precise)
-* [Squeeze](https://packagecloud.io/basho/riak-cs/riak-cs_{{VERSION}}-1_amd64.deb?distro=squeeze)
-* [Trusty](https://packagecloud.io/basho/riak-cs/riak-cs_{{VERSION}}-1_amd64.deb?distro=trusty)
-* [Wheezy](https://packagecloud.io/basho/riak-cs/riak-cs_{{VERSION}}-1_amd64.deb?distro=wheezy)
+* [Lucid](https://packagecloud.io/basho/riak-cs/packages/ubuntu/lucid/riak-cs_{{VERSION}}-1_amd64.deb)
+* [Precise](https://packagecloud.io/basho/riak-cs/packages/ubuntu/precise/riak-cs_{{VERSION}}-1_amd64.deb)
+* [Squeeze](https://packagecloud.io/basho/riak-cs/packages/debian/squeeze/riak-cs_{{VERSION}}-1_amd64.deb)
+* [Trusty](https://packagecloud.io/basho/riak-cs/packages/ubuntu/trusty/riak-cs_{{VERSION}}-1_amd64.deb)
+* [Wheezy](https://packagecloud.io/basho/riak-cs/packages/debian/wheezy/riak-cs_{{VERSION}}-1_amd64.deb)
 
 #### Advanced apt Installation
 
@@ -221,10 +221,10 @@ docs](https://packagecloud.io/basho/riak-cs/install).
 
 Platform-specific pages are linked below:
 
-* [el5](https://packagecloud.io/basho/riak-cs/riak-cs-{{VERSION}}-1.x86_64.rpm?distro=5)
+* [el5](https://packagecloud.io/basho/riak-cs/packages/el/5/riak-cs-{{VERSION}}-1.x86_64.rpm)
 * [el6](https://packagecloud.io/basho/riak-cs/packages/el/6/riak-cs-{{VERSION}}-1.el6.x86_64.rpm)
-<!-- * [el7](https://packagecloud.io/basho/riak-cs/riak-cs-{{VERSION}}-1.x86_64.rpm?distro=7) -->
-* [Fedora 19](https://packagecloud.io/basho/riak-cs/riak-cs-{{VERSION}}-1.fc19.x86_64.rpm?distro=19)
+* [el7](https://packagecloud.io/basho/riak-cs/packages/el/7/riak-cs-{{VERSION}}-1.el7.centos.x86_64.rpm)
+* [Fedora 19](https://packagecloud.io/basho/riak-cs/packages/fedora/19/riak-cs-{{VERSION}}-1.fc19.x86_64.rpm)
 
 #### Advanced rpm Installation
 


### PR DESCRIPTION
This updates multiple links in the Basho docs that were pointing to deprecated [packagecloud](https://packagecloud.io) URLs. Also, a link to `el7` is broken / semi-commented out in the *Installing Riak CS on RHEL or CentOS* section of this page:

http://docs.basho.com/riakcs/latest/cookbooks/installing/Installing-Riak-CS/

This pull request fixes that link as well.

