### PR TITLE
Fix formatting errors on Data Platform pages

### DIFF
--- a/source/languages/en/dataplatform/learn-about-dataplatform/leader-election-service.md
+++ b/source/languages/en/dataplatform/learn-about-dataplatform/leader-election-service.md
@@ -12,9 +12,7 @@ audience: beginner
 [riak_ensemble]: https://github.com/basho/riak_ensemble
 
 
-<div class="note">
-Leader Election Service is available to [Enterprise users only][ee].
-</div>
+>Leader Election Service is available to [Enterprise users only][ee].
 
 ##Overview
 

--- a/source/languages/en/dataplatform/learn-about-dataplatform/spark-cluster-manager-features.md
+++ b/source/languages/en/dataplatform/learn-about-dataplatform/spark-cluster-manager-features.md
@@ -10,15 +10,12 @@ audience: beginner
 [bdp cluster manager]: http://docs.basho.com/dataplatform/1.0.0/using-dataplatform/configuration/replace-spark-cluster-manager/
 [ee]: http://info.basho.com/Wiki_Riak_Enterprise_Request.html
 
-<div class="note">
-The Spark cluster manager is available to [Enterprise users only][ee].
-</div>
+>The Spark cluster manager is available to [Enterprise users only][ee].
 
 The Spark cluster manager provides all the functionality required for Spark Master high availability without the need to manage yet another software system (Zookeeper). This reduces operational complexity of Basho Data Platform (BDP).
 
-<div class="note">
-Please note that the Spark cluster manager depends on the [Riak Leader Election Service][bdp leader election]. Check out [Replace Your Previous Spark Cluster Manager with the Basho Data Platform Cluster Manager][bdp cluster manager] for instructions on setting up the Spark cluster manager.
-</div>
+
+>Please note that the Spark cluster manager depends on the [Riak Leader Election Service][bdp leader election]. Check out [Replace Your Previous Spark Cluster Manager with the Basho Data Platform Cluster Manager][bdp cluster manager] for instructions on setting up the Spark cluster manager.
 
 
 ##Zookeeper Replacement

--- a/source/languages/en/dataplatform/using-dataplatform/dataplatform-commands.md
+++ b/source/languages/en/dataplatform/using-dataplatform/dataplatform-commands.md
@@ -22,7 +22,7 @@ Usage: data-platform-admin { join | add-service-config | remove-service | start-
 
 Use `--help` after a sub-command for more details. For example:
 
-```
+```bash
 data-platform-admin join --help
 ```
 
@@ -31,7 +31,7 @@ data-platform-admin join --help
 
 Join a node to the Basho Data Platform cluster.
 
-```
+```bash
 data-platform-admin join »node«
 ```
 
@@ -46,7 +46,7 @@ data-platform-admin join »node«
 
 Remove a node from the Basho Data Platform cluster.
 
-```
+```bash
 data-platform-admin leave
 ```
 
@@ -55,7 +55,7 @@ data-platform-admin leave
 
 Display a summary of the status of nodes in the cluster.
 
-```
+```bash
 data-platform-admin cluster-status
 ```
 
@@ -64,7 +64,7 @@ data-platform-admin cluster-status
 
 Add a new service configuration to cluster.
 
-```
+```bash
 data-platform-admin add-service-config »service-name« »service« [»service-configuration«]
 ```
 
@@ -87,7 +87,7 @@ data-platform-admin add-service-config »service-name« »service« [»service-c
 
 Remove an existing service configuration from the cluster.
 
-```
+```bash
 data-platform-admin remove-service »service«
 ```
 
@@ -102,7 +102,7 @@ data-platform-admin remove-service »service«
 
 Start a service on the designated platform instance. The `-i/--output-ip` flag will cause the IP address of node to be printed back out on the console instead of the normal output.
 
-```
+```bash
 data-platform-admin start-service »node« »group« »service« [-i | --output-ip]
 ```
 
@@ -125,7 +125,7 @@ data-platform-admin start-service »node« »group« »service« [-i | --output-
 
 Stop a service on the designated instance.
 
-```
+```bash
 data-platform-admin stop-service »node« »group« »service«
 ```
 
@@ -142,7 +142,7 @@ data-platform-admin stop-service »node« »group« »service«
 
 Display available services on the cluster.
 
-```
+```bash
 data-platform-admin services
 ```
 
@@ -151,7 +151,7 @@ data-platform-admin services
 
 Display all running services for the given node.
 
-```
+```bash
 data-platform-admin node-services »node«
 ```
 
@@ -166,7 +166,7 @@ data-platform-admin node-services »node«
 
 Display all nodes running the designated service.
 
-```
+```bash
 data-platform-admin service-nodes »service«
 ```
 


### PR DESCRIPTION
- Fix link in note formatting on leader election service page.
- Fix link in note formatting on spark cluster manager features page.
- Add `bash` to Data Platform command/CLI examples for correct syntax highlighting.