### PR TITLE
fix incorrect name of loglevel in Benchmarking

### DIFF
--- a/source/languages/en/riak/ops/building/benchmarking.md
+++ b/source/languages/en/riak/ops/building/benchmarking.md
@@ -429,7 +429,7 @@ The default level is `debug`.
 |:------------
 | `debug`
 | `info`
-| `warn`
+| `warning`
 | `error`
 
 #### report_interval


### PR DESCRIPTION
The name of the `warn` loglevel was incorrect, it should be `warning`. Setting `warn` in the config leads to keeping the default `debug` level.