### PR TITLE
Don't use "Ctrl-C" to disconnect from "riak attach" console

### DIFF
--- a/source/languages/en/riak/community/product-advisories/ssl-poodle.md
+++ b/source/languages/en/riak/community/product-advisories/ssl-poodle.md
@@ -76,7 +76,7 @@ Once you have entered the Erlang shell, run `m(ssl_record).` (be sure
 to include the trailing period).
 
 In the resulting output, the `compiled: Date:` text should read
-`January 15 2015`. You can exit the shell using **Ctrl-C a**.
+`January 15 2015`. You can exit the shell using **Ctrl-G q**.
 
 ## Backout Plan
 

--- a/source/languages/en/riak/ops/running/backups.md
+++ b/source/languages/en/riak/ops/running/backups.md
@@ -283,7 +283,7 @@ configuration file. Then, once the node is started, run `riak attach` to
 connect to the node. It may be necessary to enter an Erlang atom and
 press enter to obtain a prompt, by typing `x.` and pressing enter. The
 prompt obtained should contain the correct node name. Disconnect from
-the attached session with `^d` (**Ctrl-d**). Finally, run `riak-admin
+the attached session with **Ctrl-G q**. Finally, run `riak-admin
 member_status` to list all of the nodes and verify that all nodes listed
 have the correct names.
 

--- a/source/languages/en/riak/ops/running/recovery/repairing-indexes.md
+++ b/source/languages/en/riak/ops/running/recovery/repairing-indexes.md
@@ -89,7 +89,7 @@ This code will force all keys in each partition on a node to be reread, thus reb
     [riak_search_vnode:repair(P) || P <- Partitions].
     ```
 
-5. When you're done, press `Ctrl-D` to disconnect the console. DO NOT RUN q() which will cause the running Riak node to quit. Note that `Ctrl-D` merely disconnects the console from the service, it does not stop the code from running.
+5. When you're done, press **Ctrl-G q** to disconnect the console. Note that **Ctrl-G q** merely disconnects the console from the service, it does not stop the code from running.
 
 
 ### Monitoring a Repair
@@ -100,7 +100,7 @@ The above Repair command can be slow, so if you reattach to the console, you can
 [{P, riak_search_vnode:repair_status(P)} || P <- Partitions].
 ```
 
-When you're done, press `Ctrl-D` to disconnect the console.
+When you're done, press **Ctrl-G q** to disconnect the console.
 
 ### Killing a Repair
 
@@ -128,7 +128,7 @@ Here is an example of executing the call remotely.
 rpc:call('dev1@127.0.0.1', riak_core_vnode_manager, kill_repairs, [killed_by_user]).
 ```
 
-When you're done, press `Ctrl-D` to disconnect the console.
+When you're done, press **Ctrl-G q** to disconnect the console.
 
 Repairs are not allowed to occur during ownership changes.  Since
 ownership entails the moving of partition data it is safest to make

--- a/source/languages/en/riak/ops/running/tools/riak.md
+++ b/source/languages/en/riak/ops/running/tools/riak.md
@@ -65,7 +65,8 @@ riak ping
 
 Starts the Riak node in the foreground, giving access to the Erlang shell and
 runtime messages. Prints `Node is already running - use 'riak attach' instead`
-when the node is running in the background. You can exit the shell by pressing **Ctrl-C** twice.
+when the node is running in the background. You can exit the shell by pressing
+**Ctrl-G q**.
 
 ```bash
 riak console
@@ -73,7 +74,9 @@ riak console
 
 ## attach
 
-Attaches to the console of a Riak node running in the background, giving access to the Erlang shell and runtime messages. Prints `Node is not running!` when the node cannot be reached.
+Attaches to the console of a Riak node running in the background, giving access
+to the Erlang shell and runtime messages. Prints `Node is not running!` when
+the node cannot be reached. You can exit the shell by pressing **Ctrl-G q**.
 
 ```bash
 riak attach

--- a/source/languages/en/riakcs/cookbooks/command-line-tools.md
+++ b/source/languages/en/riakcs/cookbooks/command-line-tools.md
@@ -107,13 +107,13 @@ riak-cs console
 
 If the node is already running in the background, you will see the
 output `Node is already running - use 'riak-cs attach' instead`. If the
-command is successful, you can exit the shell by pressing **Ctrl-C**
-twice.
+command is successful, you can exit the shell by pressing **Ctrl-G q**.
 
 #### attach
 
 Attaches to the console of a Riak CS node running in the background,
-providing access to the Erlang shell and to runtime messages.
+providing access to the Erlang shell and to runtime messages. You can
+exit the shell by pressing **Ctrl-G q**.
 
 ```bash
 riak-cs attach


### PR DESCRIPTION
On RHEL/CentOS the default shell is configured in such a way that
pressing "Ctrl-C" in a "riak attach" console immediately destroys
the controlling process, rather than letting Erlang catch the signal.

EShell prefers to be interrupted with "Ctrl-G" and on all tested
platforms "Ctrl-G q" cleanly detaches the Erlang console from the
running Riak node.

A related issue has been raised as basho/node_package#197

Fixes #1954 (DOC-251) for the 2.0.6 branch and can be forward-ported to
the 2.1.3 branch.