### PR TITLE
Update warning for Strong Consistency

### DIFF
--- a/source/languages/en/riak/dev/advanced/strong-consistency.md
+++ b/source/languages/en/riak/dev/advanced/strong-consistency.md
@@ -8,11 +8,7 @@ audience: advanced
 keywords: [developers, strong-consistency]
 ---
 
-<div class="note">
-<div class="title">Note on commercial support</div>
-Riak's strong consistency feature is currently an open-source-only
-feature and is not yet commercially supported.
-</div>
+>**Note:** Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
 
 In versions 2.0 and later, Riak allows you to create buckets that
 provide [[strong consistency]] guarantees for the data stored within

--- a/source/languages/en/riak/ops/advanced/strong-consistency.md
+++ b/source/languages/en/riak/ops/advanced/strong-consistency.md
@@ -7,11 +7,7 @@ audience: advanced
 keywords: [operators, strong-consistency]
 ---
 
-<div class="note">
-<div class="title">Note on commercial support</div>
-Riak's strong consistency feature is currently an open-source-only
-feature and is not yet commercially supported.
-</div>
+>**Note:** Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
 
 This document provides information on configuring and monitoring a Riak
 cluster's optional [[strong consistency]] subsystem. Documentation for

--- a/source/languages/en/riak/theory/concepts/strong-consistency.md
+++ b/source/languages/en/riak/theory/concepts/strong-consistency.md
@@ -7,11 +7,7 @@ audience: intermediate
 keyword: [appendix, concepts]
 ---
 
-<div class="note">
-<div class="title">Note on commercial support</div>
-Riak's strong consistency feature is currently an open-source-only
-feature and is not yet commercially supported.
-</div>
+>**Note:** Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
 
 Riak was originally designed as an [[eventually consistent|Eventual
 Consistency]] system, fundamentally geared toward providing partition

--- a/source/languages/en/riak/theory/why-riak.md
+++ b/source/languages/en/riak/theory/why-riak.md
@@ -60,8 +60,7 @@ Riak's focus on availability makes it a good fit whenever downtime is
 unacceptable. No one can promise 100% uptime, but Riak is designed to
 survive network partitions and hardware failures that would
 significantly disrupt most databases. An exception to Riak's high
-availability approach is the optional [[strong consistency|Using Strong
-Consistency]] feature, which can be applied on a selective basis.
+availability approach is the experimental strong consistency feature, which can be applied on a selective basis.
 
 A less-heralded feature of Riak is its predictable latency. Because its
 fundamental operations---read, write, and delete---do not involve


### PR DESCRIPTION
Replace old note for new note stressing experimental nature of SC. Remove link to SC page from Why Riak.