### PR TITLE
Fix canonical_link's location into header on Security page

### DIFF
--- a/content/riak/kv/2.0.0/using/security.md
+++ b/content/riak/kv/2.0.0/using/security.md
@@ -13,6 +13,7 @@ toc: true
 aliases:
   - /riak/2.0.0/ops/advanced/security
   - /riak/kv/2.0.0/ops/advanced/security
+canonical_link: "docs.basho.com/riak/kv/latest/using/security"
 ---
 
 > **Internal security**
@@ -110,9 +111,6 @@ node's [Search configuration](/riak/kv/2.0.0/configuring/reference/#search). The
 In addition to JMX ports, Solr also binds to a well-known port of its
 own, as determined by each node's `search.solr.port` setting, which is
 also located in each node's Search configuration. The default is 8093.
-
-canonical_link: "docs.basho.com/riak/kv/latest/using/security"
----
 
 # Riak Security Community
 

--- a/content/riak/kv/2.0.1/using/security.md
+++ b/content/riak/kv/2.0.1/using/security.md
@@ -13,6 +13,7 @@ toc: true
 aliases:
   - /riak/2.0.1/ops/advanced/security
   - /riak/kv/2.0.1/ops/advanced/security
+canonical_link: "docs.basho.com/riak/kv/latest/using/security"
 ---
 
 > **Internal security**
@@ -110,9 +111,6 @@ node's [Search configuration](/riak/kv/2.0.1/configuring/reference/#search). The
 In addition to JMX ports, Solr also binds to a well-known port of its
 own, as determined by each node's `search.solr.port` setting, which is
 also located in each node's Search configuration. The default is 8093.
-
-canonical_link: "docs.basho.com/riak/kv/latest/using/security"
----
 
 # Riak Security Community
 

--- a/content/riak/kv/2.0.2/using/security.md
+++ b/content/riak/kv/2.0.2/using/security.md
@@ -12,6 +12,7 @@ menu:
 toc: true
 aliases:
   - /riak/2.0.2/ops/advanced/security
+canonical_link: "docs.basho.com/riak/kv/latest/using/security"
 ---
 
 > **Internal security**
@@ -109,9 +110,6 @@ node's [Search configuration](/riak/kv/2.0.2/configuring/reference/#search). The
 In addition to JMX ports, Solr also binds to a well-known port of its
 own, as determined by each node's `search.solr.port` setting, which is
 also located in each node's Search configuration. The default is 8093.
-
-canonical_link: "docs.basho.com/riak/kv/latest/using/security"
----
 
 # Riak Security Community
 

--- a/content/riak/kv/2.0.4/using/security.md
+++ b/content/riak/kv/2.0.4/using/security.md
@@ -13,6 +13,7 @@ toc: true
 aliases:
   - /riak/2.0.4/ops/advanced/security
   - /riak/kv/2.0.4/ops/advanced/security
+canonical_link: "docs.basho.com/riak/kv/latest/using/security"
 ---
 
 > **Internal security**
@@ -110,9 +111,6 @@ node's [Search configuration](/riak/kv/2.0.4/configuring/reference/#search). The
 In addition to JMX ports, Solr also binds to a well-known port of its
 own, as determined by each node's `search.solr.port` setting, which is
 also located in each node's Search configuration. The default is 8093.
-
-canonical_link: "docs.basho.com/riak/kv/latest/using/security"
----
 
 # Riak Security Community
 

--- a/content/riak/kv/2.0.5/using/security.md
+++ b/content/riak/kv/2.0.5/using/security.md
@@ -13,6 +13,7 @@ toc: true
 aliases:
   - /riak/2.0.5/ops/advanced/security
   - /riak/kv/2.0.5/ops/advanced/security
+canonical_link: "docs.basho.com/riak/kv/latest/using/security"
 ---
 
 > **Internal security**
@@ -110,9 +111,6 @@ node's [Search configuration](/riak/kv/2.0.5/configuring/reference/#search). The
 In addition to JMX ports, Solr also binds to a well-known port of its
 own, as determined by each node's `search.solr.port` setting, which is
 also located in each node's Search configuration. The default is 8093.
-
-canonical_link: "docs.basho.com/riak/kv/latest/using/security"
----
 
 # Riak Security Community
 

--- a/content/riak/kv/2.0.6/using/security.md
+++ b/content/riak/kv/2.0.6/using/security.md
@@ -13,6 +13,7 @@ toc: true
 aliases:
   - /riak/2.0.6/ops/advanced/security
   - /riak/kv/2.0.6/ops/advanced/security
+canonical_link: "docs.basho.com/riak/kv/latest/using/security"
 ---
 
 > **Internal security**
@@ -110,9 +111,6 @@ node's [Search configuration](/riak/kv/2.0.6/configuring/reference/#search). The
 In addition to JMX ports, Solr also binds to a well-known port of its
 own, as determined by each node's `search.solr.port` setting, which is
 also located in each node's Search configuration. The default is 8093.
-
-canonical_link: "docs.basho.com/riak/kv/latest/using/security"
----
 
 # Riak Security Community
 

--- a/content/riak/kv/2.1.1/using/security.md
+++ b/content/riak/kv/2.1.1/using/security.md
@@ -13,6 +13,7 @@ toc: true
 aliases:
   - /riak/2.1.1/ops/advanced/security
   - /riak/kv/2.1.1/ops/advanced/security
+canonical_link: "docs.basho.com/riak/kv/latest/using/security"
 ---
 
 > **Internal security**
@@ -110,9 +111,6 @@ node's [Search configuration](/riak/kv/2.1.1/configuring/reference/#search). The
 In addition to JMX ports, Solr also binds to a well-known port of its
 own, as determined by each node's `search.solr.port` setting, which is
 also located in each node's Search configuration. The default is 8093.
-
-canonical_link: "docs.basho.com/riak/kv/latest/using/security"
----
 
 # Riak Security Community
 

--- a/content/riak/kv/2.1.3/using/security.md
+++ b/content/riak/kv/2.1.3/using/security.md
@@ -13,6 +13,7 @@ toc: true
 aliases:
   - /riak/2.1.3/ops/advanced/security
   - /riak/kv/2.1.3/ops/advanced/security
+canonical_link: "docs.basho.com/riak/kv/latest/using/security"
 ---
 
 > **Internal security**
@@ -110,9 +111,6 @@ node's [Search configuration](/riak/kv/2.1.3/configuring/reference/#search). The
 In addition to JMX ports, Solr also binds to a well-known port of its
 own, as determined by each node's `search.solr.port` setting, which is
 also located in each node's Search configuration. The default is 8093.
-
-canonical_link: "docs.basho.com/riak/kv/latest/using/security"
----
 
 # Riak Security Community
 

--- a/content/riak/kv/2.1.4/using/security.md
+++ b/content/riak/kv/2.1.4/using/security.md
@@ -12,6 +12,7 @@ menu:
 toc: true
 aliases:
   - /riak/2.1.4/ops/advanced/security
+canonical_link: "docs.basho.com/riak/kv/latest/using/security"
 ---
 
 > **Internal security**
@@ -109,9 +110,6 @@ node's [Search configuration](/riak/kv/2.1.4/configuring/reference/#search). The
 In addition to JMX ports, Solr also binds to a well-known port of its
 own, as determined by each node's `search.solr.port` setting, which is
 also located in each node's Search configuration. The default is 8093.
-
-canonical_link: "docs.basho.com/riak/kv/latest/using/security"
----
 
 # Riak Security Community
 


### PR DESCRIPTION
See: http://docs.basho.com/riak/kv/2.1.4/using/security/