### PR TITLE
totol_leveldb_mem_percent needs to be moved to eleveldb sections

### DIFF
--- a/content/riak/cs/2.0.0/cookbooks/configuration/riak-for-cs.md
+++ b/content/riak/cs/2.0.0/cookbooks/configuration/riak-for-cs.md
@@ -73,6 +73,9 @@ to use the custom backend provided by Riak CS. We need to use either the
 `advanced.config` or `app.config` file and insert the following options:
 
 ```advancedconfig
+{eleveldb, [
+    {total_leveldb_mem_percent, 30}
+    ]},
 {riak_kv, [
     %% Other configs
     {add_paths, ["/usr/lib/riak-cs/lib/riak_cs-{{VERSION}}/ebin"]},
@@ -81,7 +84,6 @@ to use the custom backend provided by Riak CS. We need to use either the
     {multi_backend_default, be_default},
     {multi_backend, [
         {be_default, riak_kv_eleveldb_backend, [
-            {total_leveldb_mem_percent, 30},
             {data_root, "/var/lib/riak/leveldb"}
         ]},
         {be_blocks, riak_kv_bitcask_backend, [
@@ -93,6 +95,9 @@ to use the custom backend provided by Riak CS. We need to use either the
 ```
 
 ```appconfig
+{eleveldb, [
+    {total_leveldb_mem_percent, 30}
+    ]},
 {riak_kv, [
     %% Other configs
     {add_paths, ["/usr/lib/riak-cs/lib/riak_cs-{{VERSION}}/ebin"]},
@@ -101,7 +106,6 @@ to use the custom backend provided by Riak CS. We need to use either the
     {multi_backend_default, be_default},
     {multi_backend, [
         {be_default, riak_kv_eleveldb_backend, [
-            {total_leveldb_mem_percent, 30},
             {data_root, "/var/lib/riak/leveldb"}
         ]},
         {be_blocks, riak_kv_bitcask_backend, [

--- a/content/riak/cs/2.0.1/cookbooks/configuration/riak-for-cs.md
+++ b/content/riak/cs/2.0.1/cookbooks/configuration/riak-for-cs.md
@@ -73,6 +73,9 @@ to use the custom backend provided by Riak CS. We need to use either the
 `advanced.config` or `app.config` file and insert the following options:
 
 ```advancedconfig
+{eleveldb, [
+    {total_leveldb_mem_percent, 30}
+    ]},
 {riak_kv, [
     %% Other configs
     {add_paths, ["/usr/lib/riak-cs/lib/riak_cs-{{VERSION}}/ebin"]},
@@ -81,7 +84,6 @@ to use the custom backend provided by Riak CS. We need to use either the
     {multi_backend_default, be_default},
     {multi_backend, [
         {be_default, riak_kv_eleveldb_backend, [
-            {total_leveldb_mem_percent, 30},
             {data_root, "/var/lib/riak/leveldb"}
         ]},
         {be_blocks, riak_kv_bitcask_backend, [
@@ -93,6 +95,9 @@ to use the custom backend provided by Riak CS. We need to use either the
 ```
 
 ```appconfig
+{eleveldb, [
+    {total_leveldb_mem_percent, 30}
+    ]},
 {riak_kv, [
     %% Other configs
     {add_paths, ["/usr/lib/riak-cs/lib/riak_cs-{{VERSION}}/ebin"]},
@@ -101,7 +106,6 @@ to use the custom backend provided by Riak CS. We need to use either the
     {multi_backend_default, be_default},
     {multi_backend, [
         {be_default, riak_kv_eleveldb_backend, [
-            {total_leveldb_mem_percent, 30},
             {data_root, "/var/lib/riak/leveldb"}
         ]},
         {be_blocks, riak_kv_bitcask_backend, [

--- a/content/riak/cs/2.1.0/cookbooks/configuration/riak-for-cs.md
+++ b/content/riak/cs/2.1.0/cookbooks/configuration/riak-for-cs.md
@@ -73,6 +73,9 @@ to use the custom backend provided by Riak CS. We need to use either the
 `advanced.config` or `app.config` file and insert the following options:
 
 ```advancedconfig
+{eleveldb, [
+    {total_leveldb_mem_percent, 30}
+    ]},
 {riak_kv, [
     %% Other configs
     {add_paths, ["/usr/lib/riak-cs/lib/riak_cs-{{VERSION}}/ebin"]},
@@ -81,7 +84,6 @@ to use the custom backend provided by Riak CS. We need to use either the
     {multi_backend_default, be_default},
     {multi_backend, [
         {be_default, riak_kv_eleveldb_backend, [
-            {total_leveldb_mem_percent, 30},
             {data_root, "/var/lib/riak/leveldb"}
         ]},
         {be_blocks, riak_kv_bitcask_backend, [
@@ -93,6 +95,9 @@ to use the custom backend provided by Riak CS. We need to use either the
 ```
 
 ```appconfig
+{eleveldb, [
+    {total_leveldb_mem_percent, 30}
+    ]},
 {riak_kv, [
     %% Other configs
     {add_paths, ["/usr/lib/riak-cs/lib/riak_cs-{{VERSION}}/ebin"]},
@@ -101,7 +106,6 @@ to use the custom backend provided by Riak CS. We need to use either the
     {multi_backend_default, be_default},
     {multi_backend, [
         {be_default, riak_kv_eleveldb_backend, [
-            {total_leveldb_mem_percent, 30},
             {data_root, "/var/lib/riak/leveldb"}
         ]},
         {be_blocks, riak_kv_bitcask_backend, [

--- a/content/riak/cs/2.1.1/cookbooks/configuration/riak-for-cs.md
+++ b/content/riak/cs/2.1.1/cookbooks/configuration/riak-for-cs.md
@@ -73,6 +73,9 @@ to use the custom backend provided by Riak CS. We need to use either the
 `advanced.config` or `app.config` file and insert the following options:
 
 ```advancedconfig
+{eleveldb, [
+    {total_leveldb_mem_percent, 30}
+    ]},
 {riak_kv, [
     %% Other configs
     {add_paths, ["/usr/lib/riak-cs/lib/riak_cs-{{VERSION}}/ebin"]},
@@ -81,7 +84,6 @@ to use the custom backend provided by Riak CS. We need to use either the
     {multi_backend_default, be_default},
     {multi_backend, [
         {be_default, riak_kv_eleveldb_backend, [
-            {total_leveldb_mem_percent, 30},
             {data_root, "/var/lib/riak/leveldb"}
         ]},
         {be_blocks, riak_kv_bitcask_backend, [
@@ -93,6 +95,9 @@ to use the custom backend provided by Riak CS. We need to use either the
 ```
 
 ```appconfig
+{eleveldb, [
+    {total_leveldb_mem_percent, 30}
+    ]},
 {riak_kv, [
     %% Other configs
     {add_paths, ["/usr/lib/riak-cs/lib/riak_cs-{{VERSION}}/ebin"]},
@@ -101,7 +106,6 @@ to use the custom backend provided by Riak CS. We need to use either the
     {multi_backend_default, be_default},
     {multi_backend, [
         {be_default, riak_kv_eleveldb_backend, [
-            {total_leveldb_mem_percent, 30},
             {data_root, "/var/lib/riak/leveldb"}
         ]},
         {be_blocks, riak_kv_bitcask_backend, [


### PR DESCRIPTION
this setting is ignored in a multi-backend config, it must be in the top level eleveldb section to be effective