### PR TITLE
Clean up redirects, content/ directories

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -46,7 +46,7 @@ end;
 ########
 # Clean
 desc      "Clean previous builds"
-task      :clean => ['clean:js', 'clean:css', 'clean:hugo']
+task      :clean => ['clean:js', 'clean:css']
 namespace :clean do
   #TODO<drew.pirrone.brusse@gmail>: These `rm -rf`s are maybe a bit much? Should
   # we be more precise with what we delete (and, if so, how)?
@@ -81,7 +81,8 @@ namespace :build do
   task :js => "#{$js_dest}" do compile_js(debug: false); end
   task :css => "#{$css_dest}" do compile_css(debug: false); end
 
-  task :hugo do sh "hugo -d #{$hugo_dest}"; end
+  desc "Build all statically-generated Hugo content"
+  task :hugo => ['clean:hugo'] do sh "hugo -d #{$hugo_dest}"; end
 
   desc "Shorthand for `rake build; rake watch:hugo` (Note: exits w/ an error)"
   task :watch => ['build:js', 'build:css', 'watch:hugo']

--- a/content/dataplatform/index.md
+++ b/content/dataplatform/index.md
@@ -4,3 +4,5 @@ target: "dataplatform/latest/"
 ---
 
 This page exists solely to redirect from the generated URL to the above `target`
+
+We prefer to store these redirects as .html files in static/ but -- for reasons yet divined -- Hugo replaces public/datapltform/index.html with an empty file some time after is sync'd from static/ but before the dynamic/ content is done being compiled.

--- a/content/riak/cs/index.md
+++ b/content/riak/cs/index.md
@@ -1,6 +1,0 @@
----
-layout: redirect
-target: "riak/cs/latest/"
----
-
-This page exists solely to redirect from the generated URL to the above `target`

--- a/content/riak/index.md
+++ b/content/riak/index.md
@@ -4,3 +4,6 @@ target: "riak/kv/latest/"
 ---
 
 This page exists solely to redirect from the generated URL to the above `target`
+
+
+We prefer to store these redirects as .html files in static/ but -- for reasons yet divined -- Hugo replaces public/riak/index.html with an empty file some time after it is sync'd from static/ but before the dynamic/ content is done being compiled.

--- a/content/riak/kv/index.md
+++ b/content/riak/kv/index.md
@@ -1,6 +1,0 @@
----
-layout: redirect
-target: "riak/kv/latest/"
----
-
-This page exists solely to redirect from the generated URL to the above `target`

--- a/content/riak/ts/index.md
+++ b/content/riak/ts/index.md
@@ -1,6 +1,0 @@
----
-layout: redirect
-target: "riak/ts/latest/"
----
-
-This page exists solely to redirect from the generated URL to the above `target`

--- a/content/riakcs/index.md
+++ b/content/riakcs/index.md
@@ -1,6 +1,0 @@
----
-layout: redirect
-target: "riak/cs/latest/"
----
-
-This page exists solely to redirect from the generated URL to the above `target`

--- a/content/riakts/index.md
+++ b/content/riakts/index.md
@@ -1,6 +1,0 @@
----
-layout: redirect
-target: "riak/ts/latest/"
----
-
-This page exists solely to redirect from the generated URL to the above `target`

--- a/static/riak/cs/index.html
+++ b/static/riak/cs/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="canonical" href="/riak/cs/latest/"/>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta http-equiv="refresh" content="0;url=/riak/cs/latest/" />
+  </head>
+</html>

--- a/static/riak/kv/index.html
+++ b/static/riak/kv/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="canonical" href="/riak/kv/latest/"/>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta http-equiv="refresh" content="0;url=/riak/kv/latest/" />
+  </head>
+</html>

--- a/static/riak/ts/index.html
+++ b/static/riak/ts/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="canonical" href="/riak/ts/latest/"/>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta http-equiv="refresh" content="0;url=/riak/ts/latest/" />
+  </head>
+</html>

--- a/static/riakcs/index.html
+++ b/static/riakcs/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="canonical" href="/riak/cs/latest/"/>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta http-equiv="refresh" content="0;url=/riak/cs/latest/" />
+  </head>
+</html>

--- a/static/riakts/index.html
+++ b/static/riakts/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="canonical" href="/riak/ts/latest/"/>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta http-equiv="refresh" content="0;url=/riak/ts/latest/" />
+  </head>
+</html>


### PR DESCRIPTION
content/riakcs/ and content/riakts/ were bad directories, and I felt bad for adding them.
This PR removes them, and replaces the redirects those directories were created for with static/riakcs/index/html and static/riakts/index/html .