### PR TITLE
Markdown Fix

### DIFF
--- a/content/riak/ts/1.3.0/using/querying.md
+++ b/content/riak/ts/1.3.0/using/querying.md
@@ -281,9 +281,9 @@ When querying with user-supplied data, it is essential that you protect against 
 
 A small subset of SQL is supported. All columns are of the format:
 
-```
+```sql
 Field    Operator   Constant
-````
+```
 
 The following operators are supported for each data type:
 


### PR DESCRIPTION
- Fixes incorrect markdown formatting for [this page](http://docs.basho.com/riak/ts/1.3.0/using/querying/) that was causing too large of code block to be rendered, with markdown inside that code block (see screenshot).

*** I do not have the whole build process installed on my machine, so probably worth pulling down and doing a build to make sure it is rendering correctly before accepting this PR.

<img width="595" alt="screenshot 2016-05-10 14 33 14" src="https://cloud.githubusercontent.com/assets/220885/15163293/754421b0-16bc-11e6-842e-fca98e66fc6a.png">
