### PR TITLE
Product Advisory RSS feed

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -75,8 +75,10 @@ end
 
 ########
 # Build
-desc      "Compile Compressed JS, Compile Compressed CSS, Build Hugo"
+desc      "Compile & Compress JS, Compile & Compress CSS"
 task      :build => ['clean', 'build:js', 'build:css']
+desc      "Compile Markdown content to #{$hugo_dest}"
+task      :hugo  => ['clean:hugo', 'build:hugo']
 namespace :build do
   task :js => "#{$js_dest}" do compile_js(debug: false); end
   task :css => "#{$css_dest}" do compile_css(debug: false); end

--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,11 @@ title: "Basho Documentation"
 baseURL: "https://docs.basho.com/"
 languageCode: "en-us"
 
+copyright: "This work is licensed under a Creative Commons Attribution 4.0 International Public License -- © 2011-2016 Basho Technologies, Inc."
+
+taxonomies:
+  announcement: "announcements"
+
 # Use YAML for front matter, rather than TOML
 metaDataFormat: "yaml"
 

--- a/config.yaml
+++ b/config.yaml
@@ -32,9 +32,10 @@ params:
   #       releases:        // List (release series) of lists (versions in that series).
   #         - ["<<version>>", "<<version>>", ...],
   #         - ["<<version>>", "<<version>>", ...],
-  #       latest:       "<<version>>" // Current development version
-  #       lts:          "<<version>>" // *Optional*: Current LTS version
-  #       archived_url: "<<URI>>"     // *Optional*: URL directing to un-maintained content
+  #       latest:        "<<version>>" // Current development version
+  #       lts:           "<<version>>" // *Optional*: Current LTS version
+  #       archived_url:  "<<URI>>"     // *Optional*: URL directing to un-maintained content
+  #       archived_path: "<<path>>"    // Previous path to project content; used for redirects
   project_descriptions:
     riak_kv:
       path: "riak/kv"

--- a/content/community/index.md
+++ b/content/community/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Community Overview"
 description: "Lorem ipsum quia dolor sit amet"
+date: "2015-10-15"
 menu:
   community:
     name: "Community"

--- a/content/community/productadvisories.md
+++ b/content/community/productadvisories.md
@@ -1,6 +1,7 @@
 ---
 title: "Product Advisories"
 description: "Product Advisories for Basho products"
+date: "2016-04-08"
 menu:
   community:
     name: "Product Advisories"

--- a/content/community/productadvisories/210-dataloss.md
+++ b/content/community/productadvisories/210-dataloss.md
@@ -1,6 +1,8 @@
 ---
 title: "Default Configuration For Handoff May Cause Data Loss"
 description: ""
+date: "2015-05-01"
+announcements: ["Product Advisories"]
 menu:
   community:
     name: "Data Loss KV 2.1.0"

--- a/content/community/productadvisories/appconfig-forward.md
+++ b/content/community/productadvisories/appconfig-forward.md
@@ -1,7 +1,9 @@
 ---
 title: Forward Incompatibility of app.config
 project: riak
-version: 1.0.0+ 
+date: "2015-04-15"
+announcements: ["Product Advisories"]
+version: 1.0.0+
 versions: false
 document: reference
 ---

--- a/content/community/productadvisories/codeinjectioninitfiles.md
+++ b/content/community/productadvisories/codeinjectioninitfiles.md
@@ -1,6 +1,8 @@
 ---
 title: "Possibility of Code Injection on Riak Init File"
 description: ""
+date: "2016-03-01"
+announcements: ["Product Advisories"]
 menu:
   community:
     name: "Possibility of Code Injection on Riak Init File"

--- a/content/community/productadvisories/dvvlastwritewins.md
+++ b/content/community/productadvisories/dvvlastwritewins.md
@@ -1,6 +1,8 @@
 ---
 title: "Incompatibility between Dotted Version Vectors and Last-Write Wins"
 description: ""
+date: "2015-07-06"
+announcements: ["Product Advisories"]
 menu:
   community:
     name: "Incompatiblility with DVV and Last-Write Wins"

--- a/content/community/productadvisories/golang151socket.md
+++ b/content/community/productadvisories/golang151socket.md
@@ -1,6 +1,8 @@
 ---
 title: "Socket reuse issue with Riak Golang client 1.5.1"
 description: ""
+date: "2016-03-01"
+announcements: ["Product Advisories"]
 menu:
   community:
     name: "Socket Reuse in Riak Golang 1.5.1"

--- a/content/community/productadvisories/leveldbrestart.md
+++ b/content/community/productadvisories/leveldbrestart.md
@@ -1,6 +1,8 @@
 ---
 title: "Potential data loss on restart with LevelDB tiered storage"
 description: ""
+date: "2016-03-02"
+announcements: ["Product Advisories"]
 menu:
   community:
     name: "Potential Data Loss with LevelDB Tiered Storage"

--- a/content/community/productadvisories/leveldbsegfault.md
+++ b/content/community/productadvisories/leveldbsegfault.md
@@ -1,6 +1,8 @@
 ---
 title: "LevelDB SEGV in Riak KV 2.1.3"
 description: ""
+date: "2016-04-08"
+announcements: ["Product Advisories"]
 menu:
   community:
     name: "LeveDB Segfault"

--- a/content/community/productadvisories/maps-204.md
+++ b/content/community/productadvisories/maps-204.md
@@ -1,7 +1,8 @@
-
 ---
 title: "Map Data Type Disk Incompatibility"
 description: ""
+date: "2015-01-21"
+announcements: ["Product Advisories"]
 menu:
   community:
     name: "Map Data Type Disk Incompatibility"

--- a/content/community/productadvisories/sslpoodle.md
+++ b/content/community/productadvisories/sslpoodle.md
@@ -1,7 +1,8 @@
-
 ---
 title: "SSL 3.0 Vulnerability and POODLE Attack"
 description: ""
+date: "2015-01-27"
+announcements: ["Product Advisories"]
 menu:
   community:
     name: "SSL 3.0 Vulnerability and POODLE Attack"

--- a/content/community/productadvisories/template.md
+++ b/content/community/productadvisories/template.md
@@ -2,6 +2,8 @@
 draft: true
 #title:
 #project: riak
+#date: "yyy-mm-dd"
+#announcements: ["Product Advisories"]
 #version: 1.0.0+
 #versions: false
 #document: reference

--- a/content/community/projects.md
+++ b/content/community/projects.md
@@ -1,6 +1,7 @@
 ---
 title: "Community Projects"
 description: ""
+date: "2016-03-07"
 menu:
   community:
     name: "Community Projects"

--- a/content/community/release-and-maintenance.md
+++ b/content/community/release-and-maintenance.md
@@ -1,6 +1,7 @@
 ---
 title: "Basho Software Release and Maintenance Policy"
 description: ""
+date: "2016-04-14"
 menu:
   community:
     name: "Release & Maintenance"

--- a/content/community/reporting-bugs.md
+++ b/content/community/reporting-bugs.md
@@ -1,6 +1,7 @@
 ---
 title: "Reporting Bugs"
 description: ""
+date: "2016-03-15"
 menu:
   community:
     name: "Reporting Bugs"

--- a/content/community/taishi.md
+++ b/content/community/taishi.md
@@ -1,6 +1,7 @@
 ---
 title: "Taishi Program"
 description: ""
+date: "2016-03-07"
 menu:
   community:
     name: "Taishi Program"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,12 +6,20 @@
   <meta name="version" content="{{ .Params.project_version }}">
   <meta name="base-url" content="/{{ .Scratch.Get "site_relative_url" }}">
   <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
-  <link rel="canonical" href="{{ .Params.canonical_link }}" />
+  {{ with .Params.canonical_link }}<link rel="canonical" href="{{ . }}" />{{ end }}
 
   <title>{{ .Title }}</title>
 
   <link href="/css/all.css" media="screen" rel="stylesheet" type="text/css">
   <link href="/css/print.css" media="print" rel="stylesheet" type="text/css">
+
+  {{ if .RSSlink }}
+    <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+    <link href="{{ .RSSlink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+  {{ else if in .Params.announcements "Product Advisories" }}
+    <link href="/announcements/product-advisories/index.xml" rel="alternate" type="application/rss+xml" title="Product Advisories" />
+    <link href="/announcements/product-advisories/index.xml" rel="feed" type="application/rss+xml" title="Product Advisories" />
+  {{ end }}
 
   <!--
     Iff JavaScript is enabled, we want to hide all pre>code blocks so we can


### PR DESCRIPTION
Some additional details;
- A `copyright:` string was added to config.yaml that's included as part of the rss feed.
- All of the Community pages were given a `date:` entry in their front matter to allow for a valid `<pubDate>` in the RSS feeds. We should consider including a `date:` on all pages, really.
- All product advisory pages were given an entry in the new `"announcements"` taxonomy to all for easy aggregation. (See below,)
  
  ```
  ---
  title: "Socket reuse issue with Riak Golang client 1.5.1"
  description: ""
  date: "2016-03-01"
  announcements: ["Product Advisories"]
  . . .
  ```
