### PR TITLE
fix ports and URLs

### DIFF
--- a/content/riak/kv/2.0.0/configuring/mapreduce.md
+++ b/content/riak/kv/2.0.0/configuring/mapreduce.md
@@ -32,7 +32,7 @@ follows under `riak_kv`
 
 `mapred_name` is the URL directory used to submit M/R requests to Riak.
 By default `mapred`, making the command path, for example:
-`http://localhost:8091/mapred`
+`http://localhost:8098/mapred`
 
 ```erlang
     {mapred_name, "mapred"},

--- a/content/riak/kv/2.0.0/using/reference/multi-datacenter/per-bucket-replication.md
+++ b/content/riak/kv/2.0.0/using/reference/multi-datacenter/per-bucket-replication.md
@@ -37,7 +37,7 @@ and above:
 ### Example of Disabling
 
 ```curl
-curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
+curl -v -XPUT http://127.0.0.1:8098/buckets/my_bucket \
   -H "Content-Type: application/json" \
   -d '{"props":{"repl":false}}'
 ```
@@ -45,7 +45,7 @@ curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
 ### Example of Enabling
 
 ```curl
-curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
+curl -v -XPUT http://127.0.0.1:8098/buckets/my_bucket \
   -H "Content-Type: application/json" \
   -d '{"props":{"repl":true}}'
 ```

--- a/content/riak/kv/2.0.1/configuring/mapreduce.md
+++ b/content/riak/kv/2.0.1/configuring/mapreduce.md
@@ -32,7 +32,7 @@ follows under `riak_kv`
 
 `mapred_name` is the URL directory used to submit M/R requests to Riak.
 By default `mapred`, making the command path, for example:
-`http://localhost:8091/mapred`
+`http://localhost:8098/mapred`
 
 ```erlang
     {mapred_name, "mapred"},

--- a/content/riak/kv/2.0.1/using/reference/multi-datacenter/per-bucket-replication.md
+++ b/content/riak/kv/2.0.1/using/reference/multi-datacenter/per-bucket-replication.md
@@ -37,7 +37,7 @@ and above:
 ### Example of Disabling
 
 ```curl
-curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
+curl -v -XPUT http://127.0.0.1:8098/buckets/my_bucket \
   -H "Content-Type: application/json" \
   -d '{"props":{"repl":false}}'
 ```
@@ -45,7 +45,7 @@ curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
 ### Example of Enabling
 
 ```curl
-curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
+curl -v -XPUT http://127.0.0.1:8098/buckets/my_bucket \
   -H "Content-Type: application/json" \
   -d '{"props":{"repl":true}}'
 ```

--- a/content/riak/kv/2.0.2/configuring/mapreduce.md
+++ b/content/riak/kv/2.0.2/configuring/mapreduce.md
@@ -31,7 +31,7 @@ follows under `riak_kv`
 
 `mapred_name` is the URL directory used to submit M/R requests to Riak.
 By default `mapred`, making the command path, for example:
-`http://localhost:8091/mapred`
+`http://localhost:8098/mapred`
 
 ```erlang
     {mapred_name, "mapred"},

--- a/content/riak/kv/2.0.2/using/reference/multi-datacenter/per-bucket-replication.md
+++ b/content/riak/kv/2.0.2/using/reference/multi-datacenter/per-bucket-replication.md
@@ -36,7 +36,7 @@ and above:
 ### Example of Disabling
 
 ```curl
-curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
+curl -v -XPUT http://127.0.0.1:8098/buckets/my_bucket \
   -H "Content-Type: application/json" \
   -d '{"props":{"repl":false}}'
 ```
@@ -44,7 +44,7 @@ curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
 ### Example of Enabling
 
 ```curl
-curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
+curl -v -XPUT http://127.0.0.1:8098/buckets/my_bucket \
   -H "Content-Type: application/json" \
   -d '{"props":{"repl":true}}'
 ```

--- a/content/riak/kv/2.0.4/configuring/mapreduce.md
+++ b/content/riak/kv/2.0.4/configuring/mapreduce.md
@@ -32,7 +32,7 @@ follows under `riak_kv`
 
 `mapred_name` is the URL directory used to submit M/R requests to Riak.
 By default `mapred`, making the command path, for example:
-`http://localhost:8091/mapred`
+`http://localhost:8098/mapred`
 
 ```erlang
     {mapred_name, "mapred"},

--- a/content/riak/kv/2.0.4/using/reference/multi-datacenter/per-bucket-replication.md
+++ b/content/riak/kv/2.0.4/using/reference/multi-datacenter/per-bucket-replication.md
@@ -37,7 +37,7 @@ and above:
 ### Example of Disabling
 
 ```curl
-curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
+curl -v -XPUT http://127.0.0.1:8098/buckets/my_bucket \
   -H "Content-Type: application/json" \
   -d '{"props":{"repl":false}}'
 ```
@@ -45,7 +45,7 @@ curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
 ### Example of Enabling
 
 ```curl
-curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
+curl -v -XPUT http://127.0.0.1:8098/buckets/my_bucket \
   -H "Content-Type: application/json" \
   -d '{"props":{"repl":true}}'
 ```

--- a/content/riak/kv/2.0.5/configuring/mapreduce.md
+++ b/content/riak/kv/2.0.5/configuring/mapreduce.md
@@ -32,7 +32,7 @@ follows under `riak_kv`
 
 `mapred_name` is the URL directory used to submit M/R requests to Riak.
 By default `mapred`, making the command path, for example:
-`http://localhost:8091/mapred`
+`http://localhost:8098/mapred`
 
 ```erlang
     {mapred_name, "mapred"},

--- a/content/riak/kv/2.0.5/using/reference/multi-datacenter/per-bucket-replication.md
+++ b/content/riak/kv/2.0.5/using/reference/multi-datacenter/per-bucket-replication.md
@@ -37,7 +37,7 @@ and above:
 ### Example of Disabling
 
 ```curl
-curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
+curl -v -XPUT http://127.0.0.1:8098/buckets/my_bucket \
   -H "Content-Type: application/json" \
   -d '{"props":{"repl":false}}'
 ```
@@ -45,7 +45,7 @@ curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
 ### Example of Enabling
 
 ```curl
-curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
+curl -v -XPUT http://127.0.0.1:8098/buckets/my_bucket \
   -H "Content-Type: application/json" \
   -d '{"props":{"repl":true}}'
 ```

--- a/content/riak/kv/2.0.6/configuring/mapreduce.md
+++ b/content/riak/kv/2.0.6/configuring/mapreduce.md
@@ -32,7 +32,7 @@ follows under `riak_kv`
 
 `mapred_name` is the URL directory used to submit M/R requests to Riak.
 By default `mapred`, making the command path, for example:
-`http://localhost:8091/mapred`
+`http://localhost:8098/mapred`
 
 ```erlang
     {mapred_name, "mapred"},

--- a/content/riak/kv/2.0.6/using/reference/multi-datacenter/per-bucket-replication.md
+++ b/content/riak/kv/2.0.6/using/reference/multi-datacenter/per-bucket-replication.md
@@ -37,7 +37,7 @@ and above:
 ### Example of Disabling
 
 ```curl
-curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
+curl -v -XPUT http://127.0.0.1:8098/buckets/my_bucket \
   -H "Content-Type: application/json" \
   -d '{"props":{"repl":false}}'
 ```
@@ -45,7 +45,7 @@ curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
 ### Example of Enabling
 
 ```curl
-curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
+curl -v -XPUT http://127.0.0.1:8098/buckets/my_bucket \
   -H "Content-Type: application/json" \
   -d '{"props":{"repl":true}}'
 ```

--- a/content/riak/kv/2.1.1/configuring/mapreduce.md
+++ b/content/riak/kv/2.1.1/configuring/mapreduce.md
@@ -32,7 +32,7 @@ follows under `riak_kv`
 
 `mapred_name` is the URL directory used to submit M/R requests to Riak.
 By default `mapred`, making the command path, for example:
-`http://localhost:8091/mapred`
+`http://localhost:8098/mapred`
 
 ```erlang
     {mapred_name, "mapred"},

--- a/content/riak/kv/2.1.1/using/reference/multi-datacenter/per-bucket-replication.md
+++ b/content/riak/kv/2.1.1/using/reference/multi-datacenter/per-bucket-replication.md
@@ -37,7 +37,7 @@ and above:
 ### Example of Disabling
 
 ```curl
-curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
+curl -v -XPUT http://127.0.0.1:8098/buckets/my_bucket \
   -H "Content-Type: application/json" \
   -d '{"props":{"repl":false}}'
 ```
@@ -45,7 +45,7 @@ curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
 ### Example of Enabling
 
 ```curl
-curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
+curl -v -XPUT http://127.0.0.1:8098/buckets/my_bucket \
   -H "Content-Type: application/json" \
   -d '{"props":{"repl":true}}'
 ```

--- a/content/riak/kv/2.1.3/configuring/mapreduce.md
+++ b/content/riak/kv/2.1.3/configuring/mapreduce.md
@@ -32,7 +32,7 @@ follows under `riak_kv`
 
 `mapred_name` is the URL directory used to submit M/R requests to Riak.
 By default `mapred`, making the command path, for example:
-`http://localhost:8091/mapred`
+`http://localhost:8098/mapred`
 
 ```erlang
     {mapred_name, "mapred"},

--- a/content/riak/kv/2.1.3/using/reference/multi-datacenter/per-bucket-replication.md
+++ b/content/riak/kv/2.1.3/using/reference/multi-datacenter/per-bucket-replication.md
@@ -37,7 +37,7 @@ and above:
 ### Example of Disabling
 
 ```curl
-curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
+curl -v -XPUT http://127.0.0.1:8098/buckets/my_bucket \
   -H "Content-Type: application/json" \
   -d '{"props":{"repl":false}}'
 ```
@@ -45,7 +45,7 @@ curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
 ### Example of Enabling
 
 ```curl
-curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
+curl -v -XPUT http://127.0.0.1:8098/buckets/my_bucket \
   -H "Content-Type: application/json" \
   -d '{"props":{"repl":true}}'
 ```

--- a/content/riak/kv/2.1.4/configuring/mapreduce.md
+++ b/content/riak/kv/2.1.4/configuring/mapreduce.md
@@ -32,7 +32,7 @@ follows under `riak_kv`
 
 `mapred_name` is the URL directory used to submit M/R requests to Riak.
 By default `mapred`, making the command path, for example:
-`http://localhost:8091/mapred`
+`http://localhost:8098/mapred`
 
 ```erlang
     {mapred_name, "mapred"},

--- a/content/riak/kv/2.1.4/using/reference/multi-datacenter/per-bucket-replication.md
+++ b/content/riak/kv/2.1.4/using/reference/multi-datacenter/per-bucket-replication.md
@@ -37,7 +37,7 @@ and above:
 ### Example of Disabling
 
 ```curl
-curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
+curl -v -XPUT http://127.0.0.1:8098/buckets/my_bucket \
   -H "Content-Type: application/json" \
   -d '{"props":{"repl":false}}'
 ```
@@ -45,7 +45,7 @@ curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
 ### Example of Enabling
 
 ```curl
-curl -v -XPUT http://127.0.0.1:8091/riak/my_bucket \
+curl -v -XPUT http://127.0.0.1:8098/buckets/my_bucket \
   -H "Content-Type: application/json" \
   -d '{"props":{"repl":true}}'
 ```

--- a/extras/code-examples/load_data.erl
+++ b/extras/code-examples/load_data.erl
@@ -7,6 +7,6 @@ main([Filename]) ->
 
 format_and_insert(Line) ->
     JSON = io_lib:format("{\"Date\":\"~s\",\"Open\":~s,\"High\":~s,\"Low\":~s,\"Close\":~s,\"Volume\":~s,\"Adj. Close\":~s}", Line),
-    Command = io_lib:format("curl -X PUT http://127.0.0.1:8091/riak/goog/~s -d '~s' -H 'content-type: application/json'", [hd(Line),JSON]),
+    Command = io_lib:format("curl -X PUT http://127.0.0.1:8098/buckets/goog/~s -d '~s' -H 'content-type: application/json'", [hd(Line),JSON]),
     io:format("Inserting: ~s~n", [hd(Line)]),
     os:cmd(Command).


### PR DESCRIPTION
The rest of the documentation uses Riak's default HTTP port number 8098, and expresses HTTP URLs in the form `types/<name>/buckets/<name>` or `buckets/<name>` instead of the antiquated `riak/<name>`