### PR TITLE
Fix installation instructions for stanchion on Ubuntu/Debian

### DIFF
--- a/content/riak/cs/2.0.0/cookbooks/installing.md
+++ b/content/riak/cs/2.0.0/cookbooks/installing.md
@@ -321,7 +321,7 @@ sudo bash -c "echo deb http://apt.basho.com $(lsb_release -sc) main > /etc/apt/s
 sudo apt-get update
 ```
 
-Now, install Riak CS:
+Now, install the `stanchion` package:
 
 ```bash
 sudo apt-get install stanchion

--- a/content/riak/cs/2.0.1/cookbooks/installing.md
+++ b/content/riak/cs/2.0.1/cookbooks/installing.md
@@ -321,7 +321,7 @@ sudo bash -c "echo deb http://apt.basho.com $(lsb_release -sc) main > /etc/apt/s
 sudo apt-get update
 ```
 
-Now, install Riak CS:
+Now, install the `stanchion` package:
 
 ```bash
 sudo apt-get install stanchion

--- a/content/riak/cs/2.1.0/cookbooks/installing.md
+++ b/content/riak/cs/2.1.0/cookbooks/installing.md
@@ -321,7 +321,7 @@ sudo bash -c "echo deb http://apt.basho.com $(lsb_release -sc) main > /etc/apt/s
 sudo apt-get update
 ```
 
-Now, install Riak CS:
+Now, install the `stanchion` package:
 
 ```bash
 sudo apt-get install stanchion

--- a/content/riak/cs/2.1.1/cookbooks/installing.md
+++ b/content/riak/cs/2.1.1/cookbooks/installing.md
@@ -321,7 +321,7 @@ sudo bash -c "echo deb http://apt.basho.com $(lsb_release -sc) main > /etc/apt/s
 sudo apt-get update
 ```
 
-Now, install Riak CS:
+Now, install the `stanchion` package:
 
 ```bash
 sudo apt-get install stanchion


### PR DESCRIPTION
Don't state to install Riak CS, when actually installing
the stanchion package.