### PR TITLE
Changed template to allow markdown in title attribute

### DIFF
--- a/layouts/shortcodes/note.html
+++ b/layouts/shortcodes/note.html
@@ -1,6 +1,6 @@
 <div class="note">
   {{ if .Get "title" }}
-    <div class="title">{{ with .Get "title" }}{{.}}{{ end }}</div>
+    <div class="title">{{ with .Get "title" }}{{ markdownify . }}{{ end }}</div>
   {{ end }}
   {{ .Inner }}
 </div>


### PR DESCRIPTION
This change will cause the contents of the title attribute to be markdownified.  The main upside is to allow for backticked items appearing in note titles to be drawn correctly.