### PR TITLE
Corrected `stanchion_host` to `listener`

### DIFF
--- a/content/riak/cs/2.0.0/tutorials/fast-track/local-testing-environment.md
+++ b/content/riak/cs/2.0.0/tutorials/fast-track/local-testing-environment.md
@@ -250,14 +250,14 @@ all interfaces.
 Change the following lines in `/etc/stanchion/stanchion.conf`
 
 ```stanchionconf
-stanchion_host = 127.0.0.1:8085
+listener = 127.0.0.1:8085
 riak_host = 127.0.0.1:8087
 ```
 
 to
 
 ```stanchionconf
-stanchion_host = 10.0.2.10:8085
+listener = 10.0.2.10:8085
 riak_host = 10.0.2.10:8087
 ```
 

--- a/content/riak/cs/2.0.1/tutorials/fast-track/local-testing-environment.md
+++ b/content/riak/cs/2.0.1/tutorials/fast-track/local-testing-environment.md
@@ -250,14 +250,14 @@ all interfaces.
 Change the following lines in `/etc/stanchion/stanchion.conf`
 
 ```stanchionconf
-stanchion_host = 127.0.0.1:8085
+listener = 127.0.0.1:8085
 riak_host = 127.0.0.1:8087
 ```
 
 to
 
 ```stanchionconf
-stanchion_host = 10.0.2.10:8085
+listener = 10.0.2.10:8085
 riak_host = 10.0.2.10:8087
 ```
 

--- a/content/riak/cs/2.1.0/tutorials/fast-track/local-testing-environment.md
+++ b/content/riak/cs/2.1.0/tutorials/fast-track/local-testing-environment.md
@@ -250,14 +250,14 @@ all interfaces.
 Change the following lines in `/etc/stanchion/stanchion.conf`
 
 ```stanchionconf
-stanchion_host = 127.0.0.1:8085
+listener = 127.0.0.1:8085
 riak_host = 127.0.0.1:8087
 ```
 
 to
 
 ```stanchionconf
-stanchion_host = 10.0.2.10:8085
+listener = 10.0.2.10:8085
 riak_host = 10.0.2.10:8087
 ```
 

--- a/content/riak/cs/2.1.1/tutorials/fast-track/local-testing-environment.md
+++ b/content/riak/cs/2.1.1/tutorials/fast-track/local-testing-environment.md
@@ -250,14 +250,14 @@ all interfaces.
 Change the following lines in `/etc/stanchion/stanchion.conf`
 
 ```stanchionconf
-stanchion_host = 127.0.0.1:8085
+listener = 127.0.0.1:8085
 riak_host = 127.0.0.1:8087
 ```
 
 to
 
 ```stanchionconf
-stanchion_host = 10.0.2.10:8085
+listener = 10.0.2.10:8085
 riak_host = 10.0.2.10:8087
 ```
 


### PR DESCRIPTION
The stanchion.conf file configures the IP address of the stanchion listener using the `listener` value not `stanchion_host`.  This is very likely copypasta.