### PR TITLE
Remove stale comment about reduce_count_inputs

### DIFF
--- a/content/riak/kv/2.0.0/developing/faq.md
+++ b/content/riak/kv/2.0.0/developing/faq.md
@@ -240,7 +240,7 @@ A:
   }
   ```
 
-  There is also a reduce function for counting inputs (available in the `master` branch of the github repo, to be released in the next version of Riak). This function can be used to count keys in a bucket without reading objects from disk:
+  There is also a reduce function for counting inputs. This function can be used to count keys in a bucket without reading objects from disk:
 
   ```json
   {

--- a/content/riak/kv/2.0.1/developing/faq.md
+++ b/content/riak/kv/2.0.1/developing/faq.md
@@ -240,7 +240,7 @@ A:
   }
   ```
 
-  There is also a reduce function for counting inputs (available in the `master` branch of the github repo, to be released in the next version of Riak). This function can be used to count keys in a bucket without reading objects from disk:
+  There is also a reduce function for counting inputs. This function can be used to count keys in a bucket without reading objects from disk:
 
   ```json
   {

--- a/content/riak/kv/2.0.2/developing/faq.md
+++ b/content/riak/kv/2.0.2/developing/faq.md
@@ -239,7 +239,7 @@ A:
   }
   ```
 
-  There is also a reduce function for counting inputs (available in the `master` branch of the github repo, to be released in the next version of Riak). This function can be used to count keys in a bucket without reading objects from disk:
+  There is also a reduce function for counting inputs. This function can be used to count keys in a bucket without reading objects from disk:
 
   ```json
   {

--- a/content/riak/kv/2.0.4/developing/faq.md
+++ b/content/riak/kv/2.0.4/developing/faq.md
@@ -240,7 +240,7 @@ A:
   }
   ```
 
-  There is also a reduce function for counting inputs (available in the `master` branch of the github repo, to be released in the next version of Riak). This function can be used to count keys in a bucket without reading objects from disk:
+  There is also a reduce function for counting inputs. This function can be used to count keys in a bucket without reading objects from disk:
 
   ```json
   {

--- a/content/riak/kv/2.0.5/developing/faq.md
+++ b/content/riak/kv/2.0.5/developing/faq.md
@@ -240,7 +240,7 @@ A:
   }
   ```
 
-  There is also a reduce function for counting inputs (available in the `master` branch of the github repo, to be released in the next version of Riak). This function can be used to count keys in a bucket without reading objects from disk:
+  There is also a reduce function for counting inputs. This function can be used to count keys in a bucket without reading objects from disk:
 
   ```json
   {

--- a/content/riak/kv/2.0.6/developing/faq.md
+++ b/content/riak/kv/2.0.6/developing/faq.md
@@ -240,7 +240,7 @@ A:
   }
   ```
 
-  There is also a reduce function for counting inputs (available in the `master` branch of the github repo, to be released in the next version of Riak). This function can be used to count keys in a bucket without reading objects from disk:
+  There is also a reduce function for counting inputs. This function can be used to count keys in a bucket without reading objects from disk:
 
   ```json
   {

--- a/content/riak/kv/2.0.7/developing/faq.md
+++ b/content/riak/kv/2.0.7/developing/faq.md
@@ -240,7 +240,7 @@ A:
   }
   ```
 
-  There is also a reduce function for counting inputs (available in the `master` branch of the github repo, to be released in the next version of Riak). This function can be used to count keys in a bucket without reading objects from disk:
+  There is also a reduce function for counting inputs. This function can be used to count keys in a bucket without reading objects from disk:
 
   ```json
   {

--- a/content/riak/kv/2.1.1/developing/faq.md
+++ b/content/riak/kv/2.1.1/developing/faq.md
@@ -240,7 +240,7 @@ A:
   }
   ```
 
-  There is also a reduce function for counting inputs (available in the `master` branch of the github repo, to be released in the next version of Riak). This function can be used to count keys in a bucket without reading objects from disk:
+  There is also a reduce function for counting inputs. This function can be used to count keys in a bucket without reading objects from disk:
 
   ```json
   {

--- a/content/riak/kv/2.1.3/developing/faq.md
+++ b/content/riak/kv/2.1.3/developing/faq.md
@@ -241,7 +241,7 @@ A:
   }
   ```
 
-  There is also a reduce function for counting inputs (available in the `master` branch of the github repo, to be released in the next version of Riak). This function can be used to count keys in a bucket without reading objects from disk:
+  There is also a reduce function for counting inputs. This function can be used to count keys in a bucket without reading objects from disk:
 
   ```json
   {

--- a/content/riak/kv/2.1.4/developing/faq.md
+++ b/content/riak/kv/2.1.4/developing/faq.md
@@ -241,7 +241,7 @@ A:
   }
   ```
 
-  There is also a reduce function for counting inputs (available in the `master` branch of the github repo, to be released in the next version of Riak). This function can be used to count keys in a bucket without reading objects from disk:
+  There is also a reduce function for counting inputs. This function can be used to count keys in a bucket without reading objects from disk:
 
   ```json
   {


### PR DESCRIPTION
The reduce_count_inputs method in riak_kv_mapreduce.erl has been part of Riak
releases since 2011, well before Riak 2.0 was released.