### PR TITLE
[secondary-indexes]: fix mapreduce key count example

### DIFF
--- a/content/riak/kv/2.0.0/developing/usage/secondary-indexes.md
+++ b/content/riak/kv/2.0.0/developing/usage/secondary-indexes.md
@@ -1985,7 +1985,7 @@ curl -XPOST localhost:8098/mapred\
 {
   "inputs": {
     "bucket": "people",
-    "index": "$bucket",
+    "index": "\$bucket",
     "key":"people"
   },
   "query": [

--- a/content/riak/kv/2.0.1/developing/usage/secondary-indexes.md
+++ b/content/riak/kv/2.0.1/developing/usage/secondary-indexes.md
@@ -1985,7 +1985,7 @@ curl -XPOST localhost:8098/mapred\
 {
   "inputs": {
     "bucket": "people",
-    "index": "$bucket",
+    "index": "\$bucket",
     "key":"people"
   },
   "query": [

--- a/content/riak/kv/2.0.2/developing/usage/secondary-indexes.md
+++ b/content/riak/kv/2.0.2/developing/usage/secondary-indexes.md
@@ -1984,7 +1984,7 @@ curl -XPOST localhost:8098/mapred\
 {
   "inputs": {
     "bucket": "people",
-    "index": "$bucket",
+    "index": "\$bucket",
     "key":"people"
   },
   "query": [

--- a/content/riak/kv/2.0.4/developing/usage/secondary-indexes.md
+++ b/content/riak/kv/2.0.4/developing/usage/secondary-indexes.md
@@ -1985,7 +1985,7 @@ curl -XPOST localhost:8098/mapred\
 {
   "inputs": {
     "bucket": "people",
-    "index": "$bucket",
+    "index": "\$bucket",
     "key":"people"
   },
   "query": [

--- a/content/riak/kv/2.0.5/developing/usage/secondary-indexes.md
+++ b/content/riak/kv/2.0.5/developing/usage/secondary-indexes.md
@@ -1985,7 +1985,7 @@ curl -XPOST localhost:8098/mapred\
 {
   "inputs": {
     "bucket": "people",
-    "index": "$bucket",
+    "index": "\$bucket",
     "key":"people"
   },
   "query": [

--- a/content/riak/kv/2.0.6/developing/usage/secondary-indexes.md
+++ b/content/riak/kv/2.0.6/developing/usage/secondary-indexes.md
@@ -1985,7 +1985,7 @@ curl -XPOST localhost:8098/mapred\
 {
   "inputs": {
     "bucket": "people",
-    "index": "$bucket",
+    "index": "\$bucket",
     "key":"people"
   },
   "query": [

--- a/content/riak/kv/2.0.7/developing/usage/secondary-indexes.md
+++ b/content/riak/kv/2.0.7/developing/usage/secondary-indexes.md
@@ -1985,7 +1985,7 @@ curl -XPOST localhost:8098/mapred\
 {
   "inputs": {
     "bucket": "people",
-    "index": "$bucket",
+    "index": "\$bucket",
     "key":"people"
   },
   "query": [

--- a/content/riak/kv/2.1.1/developing/usage/secondary-indexes.md
+++ b/content/riak/kv/2.1.1/developing/usage/secondary-indexes.md
@@ -1985,7 +1985,7 @@ curl -XPOST localhost:8098/mapred\
 {
   "inputs": {
     "bucket": "people",
-    "index": "$bucket",
+    "index": "\$bucket",
     "key":"people"
   },
   "query": [

--- a/content/riak/kv/2.1.3/developing/usage/secondary-indexes.md
+++ b/content/riak/kv/2.1.3/developing/usage/secondary-indexes.md
@@ -1985,7 +1985,7 @@ curl -XPOST localhost:8098/mapred\
 {
   "inputs": {
     "bucket": "people",
-    "index": "$bucket",
+    "index": "\$bucket",
     "key":"people"
   },
   "query": [

--- a/content/riak/kv/2.1.4/developing/usage/secondary-indexes.md
+++ b/content/riak/kv/2.1.4/developing/usage/secondary-indexes.md
@@ -1985,7 +1985,7 @@ curl -XPOST localhost:8098/mapred\
 {
   "inputs": {
     "bucket": "people",
-    "index": "$bucket",
+    "index": "\$bucket",
     "key":"people"
   },
   "query": [


### PR DESCRIPTION
In the current form, the (bash) shell will substitute
'$bucket' with the empty string (in most cases, unless
a '$bucket' variable already exists). The operation then
fails with

An error occurred parsing the inputs field.
[{unknown_field_type,<<"some_bucket_name">>}]

where the field type is the name of the first bucket
ever created.