### PR TITLE
Correctly link from the configuration reference to backend configuration references

### DIFF
--- a/content/riak/kv/2.0.0/configuring/reference.md
+++ b/content/riak/kv/2.0.0/configuring/reference.md
@@ -18,9 +18,13 @@ canonical_link: "https://docs.basho.com/riak/kv/latest/configuring/reference"
 
 [concept clusters]: ../../learn/concepts/clusters
 [plan backend bitcask]: ../../setup/planning/backend/bitcask
+[config backend bitcask]: ../../setup/planning/backend/bitcask/configuring-bitcask
 [plan backend leveldb]: ../../setup/planning/backend/leveldb
+[config backend leveldb]: ../../setup/planning/backend/leveldb/configuring-eleveldb
 [plan backend memory]: ../../setup/planning/backend/memory
+[config backend memory]: ../../setup/planning/backend/memory/#configuring-the-memory-backend
 [plan backend multi]: ../../setup/planning/backend/multi
+[config backend multi]: ../../setup/planning/backend/multi/#configuring-multiple-backends-1
 [use admin riak cli]: ../../using/admin/riak-cli
 [use admin riak-admin]: ../../using/admin/riak-admin
 [glossary aae]: ../../learn/glossary/#active-anti-entropy-aae
@@ -142,10 +146,10 @@ the cluster). Must be a power of 2. The minimum is 8 and the maximum is
 
 Riak enables you to choose from the following storage backends:
 
-* [Bitcask][plan backend bitcask] --- [configuration](#bitcask)
-* [LevelDB][plan backend leveldb] --- [configuration](#leveldb)
-* [Memory][plan backend memory] --- [configuration](#memory-backend)
-* [Multi][plan backend multi] --- [configuration](#multi-backend)
+* [Bitcask][plan backend bitcask] --- [configuration][config backend bitcask]
+* [LevelDB][plan backend leveldb] --- [configuration][config backend leveldb]
+* [Memory][plan backend memory] --- [configuration][config backend memory]
+* [Multi][plan backend multi] --- [configuration][config backend multi]
 
 <table class="riak-conf">
 <thead>

--- a/content/riak/kv/2.0.1/configuring/reference.md
+++ b/content/riak/kv/2.0.1/configuring/reference.md
@@ -18,9 +18,13 @@ canonical_link: "https://docs.basho.com/riak/kv/latest/configuring/reference"
 
 [concept clusters]: ../../learn/concepts/clusters
 [plan backend bitcask]: ../../setup/planning/backend/bitcask
+[config backend bitcask]: ../../setup/planning/backend/bitcask/configuring-bitcask
 [plan backend leveldb]: ../../setup/planning/backend/leveldb
+[config backend leveldb]: ../../setup/planning/backend/leveldb/configuring-eleveldb
 [plan backend memory]: ../../setup/planning/backend/memory
+[config backend memory]: ../../setup/planning/backend/memory/#configuring-the-memory-backend
 [plan backend multi]: ../../setup/planning/backend/multi
+[config backend multi]: ../../setup/planning/backend/multi/#configuring-multiple-backends-1
 [use admin riak cli]: ../../using/admin/riak-cli
 [use admin riak-admin]: ../../using/admin/riak-admin
 [glossary aae]: ../../learn/glossary/#active-anti-entropy-aae
@@ -142,10 +146,10 @@ the cluster). Must be a power of 2. The minimum is 8 and the maximum is
 
 Riak enables you to choose from the following storage backends:
 
-* [Bitcask][plan backend bitcask] --- [configuration](#bitcask)
-* [LevelDB][plan backend leveldb] --- [configuration](#leveldb)
-* [Memory][plan backend memory] --- [configuration](#memory-backend)
-* [Multi][plan backend multi] --- [configuration](#multi-backend)
+* [Bitcask][plan backend bitcask] --- [configuration][config backend bitcask]
+* [LevelDB][plan backend leveldb] --- [configuration][config backend leveldb]
+* [Memory][plan backend memory] --- [configuration][config backend memory]
+* [Multi][plan backend multi] --- [configuration][config backend multi]
 
 <table class="riak-conf">
 <thead>

--- a/content/riak/kv/2.0.2/configuring/reference.md
+++ b/content/riak/kv/2.0.2/configuring/reference.md
@@ -17,9 +17,13 @@ canonical_link: "https://docs.basho.com/riak/kv/latest/configuring/reference"
 
 [concept clusters]: ../../learn/concepts/clusters
 [plan backend bitcask]: ../../setup/planning/backend/bitcask
+[config backend bitcask]: ../../setup/planning/backend/bitcask/configuring-bitcask
 [plan backend leveldb]: ../../setup/planning/backend/leveldb
+[config backend leveldb]: ../../setup/planning/backend/leveldb/configuring-eleveldb
 [plan backend memory]: ../../setup/planning/backend/memory
+[config backend memory]: ../../setup/planning/backend/memory/#configuring-the-memory-backend
 [plan backend multi]: ../../setup/planning/backend/multi
+[config backend multi]: ../../setup/planning/backend/multi/#configuring-multiple-backends-1
 [use admin riak cli]: ../../using/admin/riak-cli
 [use admin riak-admin]: ../../using/admin/riak-admin
 [glossary aae]: ../../learn/glossary/#active-anti-entropy-aae
@@ -141,10 +145,10 @@ the cluster). Must be a power of 2. The minimum is 8 and the maximum is
 
 Riak enables you to choose from the following storage backends:
 
-* [Bitcask][plan backend bitcask] --- [configuration](#bitcask)
-* [LevelDB][plan backend leveldb] --- [configuration](#leveldb)
-* [Memory][plan backend memory] --- [configuration](#memory-backend)
-* [Multi][plan backend multi] --- [configuration](#multi-backend)
+* [Bitcask][plan backend bitcask] --- [configuration][config backend bitcask]
+* [LevelDB][plan backend leveldb] --- [configuration][config backend leveldb]
+* [Memory][plan backend memory] --- [configuration][config backend memory]
+* [Multi][plan backend multi] --- [configuration][config backend multi]
 
 <table class="riak-conf">
 <thead>

--- a/content/riak/kv/2.0.4/configuring/reference.md
+++ b/content/riak/kv/2.0.4/configuring/reference.md
@@ -18,9 +18,13 @@ canonical_link: "https://docs.basho.com/riak/kv/latest/configuring/reference"
 
 [concept clusters]: ../../learn/concepts/clusters
 [plan backend bitcask]: ../../setup/planning/backend/bitcask
+[config backend bitcask]: ../../setup/planning/backend/bitcask/configuring-bitcask
 [plan backend leveldb]: ../../setup/planning/backend/leveldb
+[config backend leveldb]: ../../setup/planning/backend/leveldb/configuring-eleveldb
 [plan backend memory]: ../../setup/planning/backend/memory
+[config backend memory]: ../../setup/planning/backend/memory/#configuring-the-memory-backend
 [plan backend multi]: ../../setup/planning/backend/multi
+[config backend multi]: ../../setup/planning/backend/multi/#configuring-multiple-backends-1
 [use admin riak cli]: ../../using/admin/riak-cli
 [use admin riak-admin]: ../../using/admin/riak-admin
 [glossary aae]: ../../learn/glossary/#active-anti-entropy-aae
@@ -142,10 +146,10 @@ the cluster). Must be a power of 2. The minimum is 8 and the maximum is
 
 Riak enables you to choose from the following storage backends:
 
-* [Bitcask][plan backend bitcask] --- [configuration](#bitcask)
-* [LevelDB][plan backend leveldb] --- [configuration](#leveldb)
-* [Memory][plan backend memory] --- [configuration](#memory-backend)
-* [Multi][plan backend multi] --- [configuration](#multi-backend)
+* [Bitcask][plan backend bitcask] --- [configuration][config backend bitcask]
+* [LevelDB][plan backend leveldb] --- [configuration][config backend leveldb]
+* [Memory][plan backend memory] --- [configuration][config backend memory]
+* [Multi][plan backend multi] --- [configuration][config backend multi]
 
 <table class="riak-conf">
 <thead>

--- a/content/riak/kv/2.0.5/configuring/reference.md
+++ b/content/riak/kv/2.0.5/configuring/reference.md
@@ -18,9 +18,13 @@ canonical_link: "https://docs.basho.com/riak/kv/latest/configuring/reference"
 
 [concept clusters]: ../../learn/concepts/clusters
 [plan backend bitcask]: ../../setup/planning/backend/bitcask
+[config backend bitcask]: ../../setup/planning/backend/bitcask/configuring-bitcask
 [plan backend leveldb]: ../../setup/planning/backend/leveldb
+[config backend leveldb]: ../../setup/planning/backend/leveldb/configuring-eleveldb
 [plan backend memory]: ../../setup/planning/backend/memory
+[config backend memory]: ../../setup/planning/backend/memory/#configuring-the-memory-backend
 [plan backend multi]: ../../setup/planning/backend/multi
+[config backend multi]: ../../setup/planning/backend/multi/#configuring-multiple-backends-1
 [use admin riak cli]: ../../using/admin/riak-cli
 [use admin riak-admin]: ../../using/admin/riak-admin
 [glossary aae]: ../../learn/glossary/#active-anti-entropy-aae
@@ -142,10 +146,10 @@ the cluster). Must be a power of 2. The minimum is 8 and the maximum is
 
 Riak enables you to choose from the following storage backends:
 
-* [Bitcask][plan backend bitcask] --- [configuration](#bitcask)
-* [LevelDB][plan backend leveldb] --- [configuration](#leveldb)
-* [Memory][plan backend memory] --- [configuration](#memory-backend)
-* [Multi][plan backend multi] --- [configuration](#multi-backend)
+* [Bitcask][plan backend bitcask] --- [configuration][config backend bitcask]
+* [LevelDB][plan backend leveldb] --- [configuration][config backend leveldb]
+* [Memory][plan backend memory] --- [configuration][config backend memory]
+* [Multi][plan backend multi] --- [configuration][config backend multi]
 
 <table class="riak-conf">
 <thead>

--- a/content/riak/kv/2.0.6/configuring/reference.md
+++ b/content/riak/kv/2.0.6/configuring/reference.md
@@ -18,9 +18,13 @@ canonical_link: "https://docs.basho.com/riak/kv/latest/configuring/reference"
 
 [concept clusters]: ../../learn/concepts/clusters
 [plan backend bitcask]: ../../setup/planning/backend/bitcask
+[config backend bitcask]: ../../setup/planning/backend/bitcask/configuring-bitcask
 [plan backend leveldb]: ../../setup/planning/backend/leveldb
+[config backend leveldb]: ../../setup/planning/backend/leveldb/configuring-eleveldb
 [plan backend memory]: ../../setup/planning/backend/memory
+[config backend memory]: ../../setup/planning/backend/memory/#configuring-the-memory-backend
 [plan backend multi]: ../../setup/planning/backend/multi
+[config backend multi]: ../../setup/planning/backend/multi/#configuring-multiple-backends-1
 [use admin riak cli]: ../../using/admin/riak-cli
 [use admin riak-admin]: ../../using/admin/riak-admin
 [glossary aae]: ../../learn/glossary/#active-anti-entropy-aae
@@ -142,10 +146,10 @@ the cluster). Must be a power of 2. The minimum is 8 and the maximum is
 
 Riak enables you to choose from the following storage backends:
 
-* [Bitcask][plan backend bitcask] --- [configuration](#bitcask)
-* [LevelDB][plan backend leveldb] --- [configuration](#leveldb)
-* [Memory][plan backend memory] --- [configuration](#memory-backend)
-* [Multi][plan backend multi] --- [configuration](#multi-backend)
+* [Bitcask][plan backend bitcask] --- [configuration][config backend bitcask]
+* [LevelDB][plan backend leveldb] --- [configuration][config backend leveldb]
+* [Memory][plan backend memory] --- [configuration][config backend memory]
+* [Multi][plan backend multi] --- [configuration][config backend multi]
 
 <table class="riak-conf">
 <thead>

--- a/content/riak/kv/2.0.7/configuring/reference.md
+++ b/content/riak/kv/2.0.7/configuring/reference.md
@@ -18,9 +18,13 @@ canonical_link: "https://docs.basho.com/riak/kv/latest/configuring/reference"
 
 [concept clusters]: ../../learn/concepts/clusters
 [plan backend bitcask]: ../../setup/planning/backend/bitcask
+[config backend bitcask]: ../../setup/planning/backend/bitcask/configuring-bitcask
 [plan backend leveldb]: ../../setup/planning/backend/leveldb
+[config backend leveldb]: ../../setup/planning/backend/leveldb/configuring-eleveldb
 [plan backend memory]: ../../setup/planning/backend/memory
+[config backend memory]: ../../setup/planning/backend/memory/#configuring-the-memory-backend
 [plan backend multi]: ../../setup/planning/backend/multi
+[config backend multi]: ../../setup/planning/backend/multi/#configuring-multiple-backends-1
 [use admin riak cli]: ../../using/admin/riak-cli
 [use admin riak-admin]: ../../using/admin/riak-admin
 [glossary aae]: ../../learn/glossary/#active-anti-entropy-aae
@@ -142,10 +146,10 @@ the cluster). Must be a power of 2. The minimum is 8 and the maximum is
 
 Riak enables you to choose from the following storage backends:
 
-* [Bitcask][plan backend bitcask] --- [configuration](#bitcask)
-* [LevelDB][plan backend leveldb] --- [configuration](#leveldb)
-* [Memory][plan backend memory] --- [configuration](#memory-backend)
-* [Multi][plan backend multi] --- [configuration](#multi-backend)
+* [Bitcask][plan backend bitcask] --- [configuration][config backend bitcask]
+* [LevelDB][plan backend leveldb] --- [configuration][config backend leveldb]
+* [Memory][plan backend memory] --- [configuration][config backend memory]
+* [Multi][plan backend multi] --- [configuration][config backend multi]
 
 <table class="riak-conf">
 <thead>

--- a/content/riak/kv/2.1.1/configuring/reference.md
+++ b/content/riak/kv/2.1.1/configuring/reference.md
@@ -18,9 +18,13 @@ canonical_link: "https://docs.basho.com/riak/kv/latest/configuring/reference"
 
 [concept clusters]: ../../learn/concepts/clusters
 [plan backend bitcask]: ../../setup/planning/backend/bitcask
+[config backend bitcask]: ../../setup/planning/backend/bitcask/configuring-bitcask
 [plan backend leveldb]: ../../setup/planning/backend/leveldb
+[config backend leveldb]: ../../setup/planning/backend/leveldb/configuring-eleveldb
 [plan backend memory]: ../../setup/planning/backend/memory
+[config backend memory]: ../../setup/planning/backend/memory/#configuring-the-memory-backend
 [plan backend multi]: ../../setup/planning/backend/multi
+[config backend multi]: ../../setup/planning/backend/multi/#configuring-multiple-backends-1
 [use admin riak cli]: ../../using/admin/riak-cli
 [use admin riak-admin]: ../../using/admin/riak-admin
 [glossary aae]: ../../learn/glossary/#active-anti-entropy-aae
@@ -142,10 +146,10 @@ the cluster). Must be a power of 2. The minimum is 8 and the maximum is
 
 Riak enables you to choose from the following storage backends:
 
-* [Bitcask][plan backend bitcask] --- [configuration](#bitcask)
-* [LevelDB][plan backend leveldb] --- [configuration](#leveldb)
-* [Memory][plan backend memory] --- [configuration](#memory-backend)
-* [Multi][plan backend multi] --- [configuration](#multi-backend)
+* [Bitcask][plan backend bitcask] --- [configuration][config backend bitcask]
+* [LevelDB][plan backend leveldb] --- [configuration][config backend leveldb]
+* [Memory][plan backend memory] --- [configuration][config backend memory]
+* [Multi][plan backend multi] --- [configuration][config backend multi]
 
 <table class="riak-conf">
 <thead>

--- a/content/riak/kv/2.1.3/configuring/reference.md
+++ b/content/riak/kv/2.1.3/configuring/reference.md
@@ -18,9 +18,13 @@ canonical_link: "https://docs.basho.com/riak/kv/latest/configuring/reference"
 
 [concept clusters]: ../../learn/concepts/clusters
 [plan backend bitcask]: ../../setup/planning/backend/bitcask
+[config backend bitcask]: ../../setup/planning/backend/bitcask/configuring-bitcask
 [plan backend leveldb]: ../../setup/planning/backend/leveldb
+[config backend leveldb]: ../../setup/planning/backend/leveldb/configuring-eleveldb
 [plan backend memory]: ../../setup/planning/backend/memory
+[config backend memory]: ../../setup/planning/backend/memory/#configuring-the-memory-backend
 [plan backend multi]: ../../setup/planning/backend/multi
+[config backend multi]: ../../setup/planning/backend/multi/#configuring-multiple-backends-1
 [use admin riak cli]: ../../using/admin/riak-cli
 [use admin riak-admin]: ../../using/admin/riak-admin
 [glossary aae]: ../../learn/glossary/#active-anti-entropy-aae
@@ -142,10 +146,10 @@ the cluster). Must be a power of 2. The minimum is 8 and the maximum is
 
 Riak enables you to choose from the following storage backends:
 
-* [Bitcask][plan backend bitcask] --- [configuration](#bitcask)
-* [LevelDB][plan backend leveldb] --- [configuration](#leveldb)
-* [Memory][plan backend memory] --- [configuration](#memory-backend)
-* [Multi][plan backend multi] --- [configuration](#multi-backend)
+* [Bitcask][plan backend bitcask] --- [configuration][config backend bitcask]
+* [LevelDB][plan backend leveldb] --- [configuration][config backend leveldb]
+* [Memory][plan backend memory] --- [configuration][config backend memory]
+* [Multi][plan backend multi] --- [configuration][config backend multi]
 
 <table class="riak-conf">
 <thead>

--- a/content/riak/kv/2.1.4/configuring/reference.md
+++ b/content/riak/kv/2.1.4/configuring/reference.md
@@ -18,9 +18,13 @@ canonical_link: "https://docs.basho.com/riak/kv/latest/configuring/reference"
 
 [concept clusters]: ../../learn/concepts/clusters
 [plan backend bitcask]: ../../setup/planning/backend/bitcask
+[config backend bitcask]: ../../setup/planning/backend/bitcask/configuring-bitcask
 [plan backend leveldb]: ../../setup/planning/backend/leveldb
+[config backend leveldb]: ../../setup/planning/backend/leveldb/configuring-eleveldb
 [plan backend memory]: ../../setup/planning/backend/memory
+[config backend memory]: ../../setup/planning/backend/memory/#configuring-the-memory-backend
 [plan backend multi]: ../../setup/planning/backend/multi
+[config backend multi]: ../../setup/planning/backend/multi/#configuring-multiple-backends-1
 [use admin riak cli]: ../../using/admin/riak-cli
 [use admin riak-admin]: ../../using/admin/riak-admin
 [glossary aae]: ../../learn/glossary/#active-anti-entropy-aae
@@ -142,10 +146,10 @@ the cluster). Must be a power of 2. The minimum is 8 and the maximum is
 
 Riak enables you to choose from the following storage backends:
 
-* [Bitcask][plan backend bitcask] --- [configuration](#bitcask)
-* [LevelDB][plan backend leveldb] --- [configuration](#leveldb)
-* [Memory][plan backend memory] --- [configuration](#memory-backend)
-* [Multi][plan backend multi] --- [configuration](#multi-backend)
+* [Bitcask][plan backend bitcask] --- [configuration][config backend bitcask]
+* [LevelDB][plan backend leveldb] --- [configuration][config backend leveldb]
+* [Memory][plan backend memory] --- [configuration][config backend memory]
+* [Multi][plan backend multi] --- [configuration][config backend multi]
 
 <table class="riak-conf">
 <thead>


### PR DESCRIPTION
**NOTE** that we may want to consider re-adding backend configuration references to /configuring/reference.md rather than linking to the specific backend page as this change does. I think it would be nice to have a single, canonical page that documents all major configuration options, though it is useful to discuss in detail the ramifications of any given configuration option.

Any other opinions?