### PR TITLE
Great Rework Part 04 -- CSS classes for controlling `display:`, `float:`, etc.

### DIFF
--- a/dynamic/css/base/_formatting.scss
+++ b/dynamic/css/base/_formatting.scss
@@ -1,0 +1,141 @@
+/**
+ * Formatting-Specific classes
+ * ===========================
+ * The classes defined below directly affect the flow of the HTML documents.
+ * Basic styles and class-specific styles should not alter the `display`,
+ * `float`, or `clear` properties. If an element needs to have those properties
+ * changed, one of the below classes should be applied alongside any other
+ * custom styles.
+ *
+ * We're not including classes designed to hide or partially hide elements here
+ * because Bootstrap provides those for us,
+ *     .invisible       -- `display: hidden`
+ *     .hidden-print    -- `display: none` in print media
+ *     .hidden-*-up     -- `display: none` when screen is equal/larger than *
+ *     .hidden-*-down   -- `display: none` when screen is equal/larger than *
+ *     .visible-print-* -- `display: *` in print media, otherwise `none`
+ *
+ * NB. All of the above styles are (correctly) modified with `!important`. This
+ * is because those styles (as with the below) are preemptive. The idea being
+ * that we _do not_ use these styles to override CSS defined elsewhere. Applying
+ * one of these classes to an HTML element is a statement of intent that _must_
+ * be honored.
+ *TODO: Work out how we might re-apply !important to the below. The issue that
+ *      lead me (drew.pirrone.brusse@gmaiil.com) to remove the !important
+ *      qualifiers was the interaction between my .inline-block and Bootstrap's
+ *      hidden-md-down. The former was consistently overriding the later.
+ */
+
+.inline {
+  display: inline;
+}
+
+.block {
+  display: block;
+}
+
+.inline-block {
+  display: inline-block;
+}
+
+
+.table {
+  display: table;
+}
+
+.inline-table {
+  display: inline-table;
+}
+
+.table-row {
+  display: table-row;
+}
+
+.table-cell {
+  display: table-cell;
+}
+
+
+
+.float-left {
+  float: left;
+}
+
+.float-right {
+  float: right;
+}
+
+
+
+.clear {
+  clear: both;
+}
+
+.clear-left {
+  clear: left;
+}
+
+.clear-right {
+  clear: right;
+}
+
+
+/**
+ * Responsive Formatting Classes
+ * -----------------------------
+ * The below classes are 'dynamically' generated using Sass loops, based on our
+ * $grid-breakpoints map. The code is largely based on Based on Bootstrap's
+ * `pull-${breakpoint}-(left|right)` code.
+ */
+
+@each $breakpoint in map-keys($grid-breakpoints) {
+  .inline-only-#{$breakpoint} {
+    display: none;
+  }
+  .block-only-#{$breakpoint} {
+    display: none;
+  }
+  .inline-block-only-#{$breakpoint} {
+    display: none;
+  }
+
+  @include media-breakpoint-only($breakpoint) {
+    .inline-only-#{$breakpoint} {
+      display: inline;
+    }
+    .block-only-#{$breakpoint} {
+      display: block;
+    }
+    .inline-block-only-#{$breakpoint} {
+      display: inline-block;
+    }
+  }
+}
+
+@each $breakpoint in map-keys($grid-breakpoints) {
+  @include wide-from($breakpoint) {
+    .float-left-#{$breakpoint}-up {
+      float: left;
+    }
+    .float-right-#{$breakpoint}-up {
+      float: right;
+    }
+    .float-none-#{$breakpoint}-up {
+      float: none;
+    }
+  }
+}
+
+@each $breakpoint in map-keys($grid-breakpoints) {
+  @include narrow-from($breakpoint) {
+    .float-left-#{$breakpoint}-down {
+      float: left;
+    }
+    .float-right-#{$breakpoint}-down {
+      float: right;
+    }
+    .float-none-#{$breakpoint}-down {
+      float: none;
+    }
+  }
+}

--- a/dynamic/css/main.scss
+++ b/dynamic/css/main.scss
@@ -14,6 +14,7 @@
 @import
   'base/fonts',
   'base/typography',
+  'base/formatting',
   'base/helpers',
   'base/base';
 


### PR DESCRIPTION
> The classes defined below directly affect the flow of the HTML documents.
> Basic styles and class-specific styles should not alter the `display`,
> `float`, or `clear` properties. If an element needs to have those properties
> changed, one of the below classes should be applied alongside any other
> custom styles.

This is a style of building flow that I'm not 100% sure of, but feel strongly about trying out. After all, if it's a common trick to include `<div style="clear: both">`, wouldn't it make both the CSS and the HTML more clear to precede those clearfixes with `<div style="float: left">`? (My answer is "yes", in case there was confusion.) Currently this _formatting.scss doesn't include positional information, which... I'm torn on. I would like to encode `position: fixed` in the HTML, same as floats and clears, but I'm suspicious that writing reactive CSS may not mesh well with that encoding scheme. I intend to revisit that specific question later, once the rework is in a more complete state.

---

**THIS PR IS A WORK IN PROGRESS**
I've opened this as part of a set of stacked PRs so that I can more cleanly and more quickly share the work that I'm doing. Any changes made to this branch will likely come in the form of a force push, so local updates should be performed with

```
git checkout great_rework/04/formatting_scss
git fetch origin great_rework/04/formatting_scss
git reset origin/great_rework/04/formatting_scss --hard
```

Please feel free to comment on anything you see here; offer suggestions, provide corrections, raise concerns. the whole point of this exercise is to engender communication.

But _**do not merge this PR**_.
