### PR TITLE
Great Rework Part 07 -- Draft the HTML wireframe

### DIFF
--- a/dynamic/css/layout/_wireframe.scss
+++ b/dynamic/css/layout/_wireframe.scss
@@ -1,0 +1,128 @@
+/**
+ * Basic Layouts
+ * =============
+ * This file may be a temporary. The intent is to keep it as minimal as possible
+ * while still communicating the essentials of the wireframe layout of a primary
+ * content page. Individual block layouts should be separated out into their own
+ * layout/*.scss files if they're too large to quickly parse here. When that
+ * should start happening is... yet to be determined. For now the rule of thumb
+ * is that this file should only contain positional and sizing styles for top-
+ * level block elements.
+ */
+
+// Styling Toggles
+// ===============
+// Toggle these to see what major changes in style will look like.
+// Gonna make life kinda hard until we come to consensus, but that's half the
+// point of this experiment. gl hf.
+
+// Whether or not the content navigation sidebar should be the full height of
+// the page. If so, the banner's width will be reduced by the width of the
+// content nav. If not, the content nav's height will be reduced by the height
+// of the banner.
+$content-nav-is-full-height : true;
+
+
+// Styling Variables
+// =================
+// SCSS variables used to determine the size of shared measurements.
+
+// The banner is necessarily a reactive element, as should be the buffer between
+// the bottom of the banner and the top of the primary content.
+$banner-height-sm-down : 3.5rem;
+$banner-buffer-sm-down : 0.5rem;
+$banner-height-md-up   : 4.0rem;
+$banner-buffer-md-up   : 0.5rem;
+
+// Total padding at the top of the <article> (and above <h#> elements) to keep
+// the .banner element from hiding text underneath it.
+$article-padding-top-sm-down : $banner-height-sm-down + $banner-buffer-sm-down;
+$article-padding-top-md-up   : $banner-height-md-up   + $banner-buffer-md-up;
+
+
+$content-nav-width : 14rem;
+
+
+
+/**
+ * Content Navigation
+ * POSITION & SIZE ONLY -- See _content-nav.scss for presentation.
+ * 1. This should be set in the markup, but is important to know.
+ */
+.content-nav {
+  // @extend .hidden-sm-down; /* 1 */
+  position: fixed;
+
+  @if $content-nav-is-full-height == true { top : 0;                    }
+  @else                                   { top : $banner-height-md-up; }
+  left : 0;
+
+  width  : $content-nav-width;
+  height : 100%;
+}
+
+
+
+/**
+ * Banner
+ * POSITION & SIZE ONLY -- See _banner.scss for presentation.
+ * 1. Fill the width of the body. This will hopefully be the width of the
+ *    screen, but the body content might push past that, and widen this as well.
+ */
+.banner {
+  position : fixed;
+  top      : 0;
+  left     : 0; /* 1 */
+  right    : 0; /* 1 */
+  height   : $banner-height-sm-down;
+
+  @include wide-from(md) {
+    @if $content-nav-is-full-height == true { left : $content-nav-width; }
+    @else                                   { left : 0;                  }
+    height : $banner-height-md-up;
+  }
+}
+
+
+
+/**
+ * Main Article
+ *
+ * 1. Top padding is set s.t. the Banner element doesn't hide text.
+ * 2. The Content Navigation is hidden until 'md' width, so we only have to set
+ *    the left margin at that point.
+ * 3. To properly pad <h#> elements when navigated to via id, we set both a
+ *    positive padding and a negative margin, maintaining their vertical
+ *    position while still affecting the height of the page on navigation.
+ */
+.main-article {
+  padding : $article-padding-top-sm-down 0.5rem 0 0.5rem;    /* 1 */
+
+  @include wide-from(md) {
+    padding     : $article-padding-top-md-up 1rem 0 0.5rem;  /* 1 */
+    margin-left : $content-nav-width;                        /* 2 */
+  }
+}
+
+h1, h2, h3, h4, h5, h6 {
+  //TODO: Consider making this a mixin
+  margin-top    : -$article-padding-top-sm-down; /*    3 */
+  padding-top   :  $article-padding-top-sm-down; /* 1, 3 */
+
+  @include wide-from(md) {
+    margin-top  : -$article-padding-top-md-up; /*    3 */
+    padding-top :  $article-padding-top-md-up; /* 1, 3 */
+  }
+}
+
+
+
+/**
+ * Content Footer
+ * POSITION & SIZE ONLY -- See _content-info-footer.scss for presentation.
+ */
+.content-info {
+  @include wide-from(md) {
+    margin-left : $content-nav-width;
+  }
+}

--- a/dynamic/css/layout/_wireframe.scss
+++ b/dynamic/css/layout/_wireframe.scss
@@ -87,13 +87,9 @@ $content-nav-width : 14rem;
 
 /**
  * Main Article
- *
  * 1. Top padding is set s.t. the Banner element doesn't hide text.
  * 2. The Content Navigation is hidden until 'md' width, so we only have to set
  *    the left margin at that point.
- * 3. To properly pad <h#> elements when navigated to via id, we set both a
- *    positive padding and a negative margin, maintaining their vertical
- *    position while still affecting the height of the page on navigation.
  */
 .main-article {
   padding : $article-padding-top-sm-down 0.5rem 0 0.5rem;    /* 1 */
@@ -102,16 +98,36 @@ $content-nav-width : 14rem;
     padding     : $article-padding-top-md-up 1rem 0 0.5rem;  /* 1 */
     margin-left : $content-nav-width;                        /* 2 */
   }
-}
 
-h1, h2, h3, h4, h5, h6 {
-  //TODO: Consider making this a mixin
-  margin-top    : -$article-padding-top-sm-down; /*    3 */
-  padding-top   :  $article-padding-top-sm-down; /* 1, 3 */
+/**
+ * Headings within the Main Article
+ * 1. We use a ::before pseudo element to insert an invisible block inside <h#>
+ *    elements that will act as padding to prevent the banner from hiding text
+ *    when we link to a given heading.
+ * 2. Don't render any contents, but do render the block.
+ * 3. I would have like to fill the contents with a description of this trick
+ *    (and explicitly set the height to 0 to prevent that description from
+ *    changing the height of the pseudo element), but I'm worried screen readers
+ *    would pick up that text, which would be completely useless to them.
+ * 4. By setting the margin-top to be the negative of the padding-top, we will
+ *    add height to the parent element without moving it relative to its
+ *    original position. This is what acts as the effective padding.
+ */
+  h1, h2, h3, h4, h5, h6 {
+    &:before {             /* 1 */
+      display    : block;  /* 1 */
+      visibility : hidden; /* 2 */
+      content    : " ";    /* 3 */
+      height     : 0;      /* 3 */
 
-  @include wide-from(md) {
-    margin-top  : -$article-padding-top-md-up; /*    3 */
-    padding-top :  $article-padding-top-md-up; /* 1, 3 */
+      margin-top    : -$article-padding-top-sm-down; /* 4 */
+      padding-top   :  $article-padding-top-sm-down; /* 4 */
+
+      @include wide-from(md) {
+        margin-top  : -$article-padding-top-md-up;   /* 4 */
+        padding-top :  $article-padding-top-md-up;   /* 4 */
+      }
+    }
   }
 }
 

--- a/dynamic/css/main.scss
+++ b/dynamic/css/main.scss
@@ -20,8 +20,8 @@
   'base/base';
 
 // 4. Layout-related sections
-// @import
-//   '';
+@import
+  'layout/wireframe';
 
 // 5. Components
 // @import

--- a/layouts/partials/sandbox/common_variables.html
+++ b/layouts/partials/sandbox/common_variables.html
@@ -1,0 +1,72 @@
+<!-- Site-wide Variables for Primary Content Pages
+     =============================================
+  Because of the way Go templates (and therefor Hugo) deal with scope, we're
+  going to extract and/or define a number of common variables here and save them
+  in the global `.Scratch` dictionary. This will allow us to extract common
+  variables across partial templates from a single canonical source.
+
+  Note that the below definitions make assumptions about the Front Matter
+  provided by the markdown content being rendered, and specifically that the
+  page being rendered is a primary content page. Please see the CONTRIBUTING.md
+  document for details on the Front Matter required for a well-formed page.
+
+  Notes:
+    * We use `(replace <str> <sub_str> "")` to remove `sub_str` from `str`
+    * .Permalink    == e.g. https://docs.basho.com/riak/kv/2.1.4/introduction/
+    * .Site.BaseURL == e.g. https://docs.basho.com/
+
+
+{{ $title_supertext           := .Params.title_supertext           }} {{/* ex; Small Title Text     */}}
+{{ $title                     := .Title                            }} {{/* ex; Primary Title Text   */}}
+{{ $description               := .Params.description               }} {{/* ex; Rich-preview summary */}}
+{{ $project                   := .Params.project                   }} {{/* ex; riak_kv              */}}
+{{ $version                   := .Params.project_version           }} {{/* ex; 2.1.4                */}}
+{{ $version_history_in        := .Params.version_history.in        }} {{/* See CONTRIBUTING.md      */}}
+{{ $version_history_locations := .Params.version_history.locations }} {{/* See CONTRIBUTING.md      */}}
+
+{{ $display_toc               := (index .Params "toc")                 | default true                                   }}
+{{ $commercial_offering       := (index .Params "commercial_offering") | default false                                  }}
+{{ $canonical_link            := (index .Params "canonical_link")      | default (replace .Permalink $version "latest") }}
+
+
+{{ $project_decription := (index .Site.Params.project_descriptions $project) }}
+
+{{ $project_path       := $project_decription.path                }} {{/* ex; /riak/kv                                   */}}
+{{ $version_path       := (printf "%s/%s" $project_path $version) }} {{/* ex; /riak/kv/2.1.4                             */}}
+{{ $releases           := $project_decription.releases            }} {{/* ex; [[2.0.0, 2.0.1, ...], [2.1.0, 2.1.2, ...]] */}}
+{{ $latest_version     := $project_decription.latest              }} {{/* ex; 2.1.4                                      */}}
+{{ $is_latest          := (eq $version $latest_version)           }} {{/* ex; true                                       */}}
+{{ $lts_version        := $project_decription.lts                 }} {{/* ex; 2.0.6                                      */}}
+{{ $is_lts             := (eq $version $lts_version)              }} {{/* ex; false                                      */}}
+{{ $archived_url       := $project_decription.archived_url        }} {{/* ex; http://docs.basho.com/riak/1.4.12/         */}}
+{{ $archived_path      := $project_decription.archived_path       }} {{/* ex; riak                                       */}}
+
+
+{{ $site_relative_url    := (printf "/%s" (replace .Permalink .Site.BaseURL ""))         }} {{/* ex; /riak/kv/2.1.4/introduction/ */}}
+{{ $project_relative_url := (replace $site_relative_url (printf "%s/" $version_path) "") }} {{/* ex; introduction/                */}}
+
+
+
+{{ .Scratch.Add "title_supertext"           $title_supertext           }}
+{{ .Scratch.Add "title"                     $title                     }}
+{{ .Scratch.Add "description"               $description               }}
+{{ .Scratch.Add "project"                   $project                   }}
+{{ .Scratch.Add "version"                   $version                   }}
+{{ .Scratch.Add "version_history_in"        $version_history_in        }}
+{{ .Scratch.Add "version_history_locations" $version_history_locations }}
+{{ .Scratch.Add "display_toc"               $display_toc               }}
+{{ .Scratch.Add "commercial_offering"       $commercial_offering       }}
+{{ .Scratch.Add "canonical_link"            $canonical_link            }}
+{{ .Scratch.Add "project_path"              $project_path              }}
+{{ .Scratch.Add "version_path"              $version_path              }}
+{{ .Scratch.Add "releases"                  $releases                  }}
+{{ .Scratch.Add "latest_version"            $latest_version            }}
+{{ .Scratch.Add "is_latest"                 $is_latest                 }}
+{{ .Scratch.Add "lts_version"               $lts_version               }}
+{{ .Scratch.Add "is_lts"                    $is_lts                    }}
+{{ .Scratch.Add "archived_url"              $archived_url              }}
+{{ .Scratch.Add "archived_path"             $archived_path             }}
+{{ .Scratch.Add "site_relative_url"         $site_relative_url         }}
+{{ .Scratch.Add "project_relative_url"      $project_relative_url      }}
+
+-->

--- a/layouts/sandbox/single.html
+++ b/layouts/sandbox/single.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+
+<!-- A Note on Template Design
+     =========================
+  Each block of grouped Go calls that can be wrapped should be wrapped in these
+  multi-line HTML comments so the compiled source might be a bit prettier to
+  look at; if unwrapped, every unmodified Go call will get its own newline, and
+  add an incredible amount of padding to the source.
+  All Go calls that can't be wrapped and are given their own line should be
+  invoked with the `{ { -` (without the spaces; Hugo would have interpreted that
+  as an unclosed action w/o them there.) syntax to remove the newline
+  immediately before the action is invoked.
+-->
+
+<!-- A Note on Class Naming Conventions
+     ==================================
+
+  Our classes are going to be pretty verbose. We're basing names off of the
+  Block__Element--Modifier[1] convention, which well let us focus heavily on
+  precise description (at the cost of brevity). This should lead to some
+  additional self-documentation in the HTML, and will definitely allow for more
+  descriptive SCSS. Bootstrap classes will be tacked on after our classes, where
+  necessary, and should be denoted with a leading `[bs]` class. It's a vain hope
+  of mine to eventually remove the Bootstrap library as a requisite for building
+  this site, and knowing beforehand where BS classes are used will help with
+  that immensely.
+
+  We've also moved a great deal of formatting information into the HTML, in the
+  form of float, clear, and display classes. SCSS should note when floating is
+  assumed, but modifications to the `float:` or `display:` properties should be
+  made as class additions in the HTML, and not as part of a named class.
+
+  [1]: http://getbem.com/
+-->
+
+<!-- Variable Definitions
+     ====================
+  We start this template with the "common_variables.html" partial that will
+  extract useful variables from content front matter, project descriptions, and
+  additional data files, and expose them through the global .Scratch object. For
+  each Template / Partial / Range entered, we can then selectively extract
+  specific variables from .Scratch that are useful in that context.
+
+  For every new partial, we define a $HugoNode local variable that will be the
+  top-level global context (the Hugo Node Object) s.t. we always have a
+  consistent method of querying the Hugo Node object that will not change in
+  Partials or Ranges.
+
+{{ partial "sandbox/common_variables.html" . }}
+
+{{ $HugoNode := . }}
+
+{{ $project   := $HugoNode.Scratch.Get "project"   }}
+{{ $version   := $HugoNode.Scratch.Get "version"   }}
+{{ $is_latest := $HugoNode.Scratch.Get "is_latest" }}
+{{ $is_lts    := $HugoNode.Scratch.Get "is_lts"    }}
+-->
+
+{{- /* ======================================================================================== */}}
+{{- /* {{ partial "head.html" $HugoNode }}                                                      */}}
+{{- /* ======================================================================================== */}}
+
+<!-- Variable Definitions
+     ====================
+{{ $HugoNode := . }}
+
+
+{{ $title_supertext      := .Scratch.Get "title_supertext"      }}
+{{ $title                := .Scratch.Get "title"                }}
+{{ $canonical_link       := .Scratch.Get "canonical_link"       }}
+{{ $project              := .Scratch.Get "project"              }}
+{{ $version              := .Scratch.Get "version"              }}
+{{ $site_relative_url    := .Scratch.Get "site_relative_url"    }}
+{{ $version_path         := .Scratch.Get "version_path"         }}
+{{ $project_relative_url := .Scratch.Get "project_relative_url" }}
+-->
+<head class="no-js" lang="en">
+  <meta charset="utf-8">
+  <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
+  <meta name="viewport" content="width=device-width">
+  <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
+
+  <title>{{ if $title_supertext }}{{ $title_supertext }} {{ end }}{{ $title }}</title>
+
+  <link href="/css/main.css" media="screen" rel="stylesheet" type="text/css">
+  <script src="/js/head.js" type="text/javascript"></script>
+
+{{- if $canonical_link }}
+  <link rel="canonical" href="{{ $canonical_link }}" />{{end}}
+
+{{- safeHTML `
+  <!-- The below meta tags are designed to allow JS code to use variables
+       defined in Hugo---our static site generator. -->` }}
+{{- if $project }}
+  <meta name="project" content="{{ $project }}">{{end}}
+{{- if $version }}
+  <meta name="version" content="{{ $version }}">{{end}}
+  <meta name="site_relative_url"    content='{{ $site_relative_url }}'>
+{{- if $version_path }}
+  <meta name="version_url"          content='{{ $version_path }}'>{{end}}
+  <meta name="project_relative_url" content='{{ $project_relative_url }}'>
+
+{{- if .Params.version_history.in }}
+  <meta name="version_history_in" content="{{ .Params.version_history.in }}">{{end}}
+{{- if .Params.version_history.locations }}
+  <meta name="version_history_locations" content="{{ .Params.version_history.locations | jsonify }}">{{end}}
+</head>
+
+{{- /* ======================================================================================== */}}
+{{- /* END {{ partial "head.html" $HugoNode }}                                                  */}}
+{{- /* ======================================================================================== */}}
+
+
+
+<body class="{{$project}} {{$version}} {{if $is_latest}}latest{{end}} {{if $is_lts}}lts{{end}}">
+
+{{- /* ======================================================================================== */}}
+{{- /* {{ partial "google_tag_manager.html" $HugoNode }}                                        */}}
+{{- /* ======================================================================================== */}}
+
+
+
+{{- /* ======================================================================================== */}}
+{{- /* {{ partial "content_navigation.html" $HugoNode }}                                        */}}
+{{- /* ======================================================================================== */}}
+
+  <nav class="content-nav   [bs] hidden-sm-down" style="background-color:rgba(127, 0, 0, 0.5)">
+    This is the sidenav.
+  </nav>
+
+{{- /* ======================================================================================== */}}
+{{- /* END {{ partial "content_navigation.html" $HugoNode }}                                    */}}
+{{- /* ======================================================================================== */}}
+
+
+
+{{- /* ======================================================================================== */}}
+{{- /* {{ partial "banner.html" $HugoNode }}                                                    */}}
+{{- /* ======================================================================================== */}}
+
+  <header class="banner" style="background-color:rgba(0, 127, 0, 0.5)">
+    This is the banner.
+  </header>
+
+{{- /* ======================================================================================== */}}
+{{- /* END {{ partial "banner.html" $HugoNode }}                                                */}}
+{{- /* ======================================================================================== */}}
+
+
+  <article class="main-article" style="background-color:rgba(0, 0, 127, 0.5)">
+
+
+
+    <header class="front-matter">
+
+      <div>
+{{- if $title_supertext }}
+        <h1 class="front-matter__title front-matter__title--supertext">{{ $title_supertext }}</h1>
+{{- end }}
+        <h1 class="front-matter__title">{{ $title }}</h1>
+      </div>
+
+    </header>
+
+
+
+    <main>
+      {{ $HugoNode.Content }}
+    </main>
+
+
+
+  </article>
+
+
+
+{{- /* ======================================================================================== */}}
+{{- /* {{ partial "footer.html" $HugoNode }}                                                    */}}
+{{- /* ======================================================================================== */}}
+
+  <footer class="content-info" style="background-color:rgba(0, 127, 127, 0.5)">
+    This is the Content Info Footer.
+  </footer>
+
+{{- /* ======================================================================================== */}}
+{{- /* END {{ partial "footer.html" $HugoNode }}                                                */}}
+{{- /* ======================================================================================== */}}
+
+
+
+{{- /* ======================================================================================== */}}
+{{- /* {{ partial "scripts.html" $HugoNode }}                                                   */}}
+{{- /* ======================================================================================== */}}
+  <script src="/js/main.js" type="text/javascript"></script>
+{{- /* ======================================================================================== */}}
+{{- /* END {{ partial "scripts.html" $HugoNode }}                                               */}}
+{{- /* ======================================================================================== */}}
+
+
+
+</body>
+</html>

--- a/layouts/sandbox/single.html
+++ b/layouts/sandbox/single.html
@@ -83,7 +83,6 @@
   <title>{{ if $title_supertext }}{{ $title_supertext }} {{ end }}{{ $title }}</title>
 
   <link href="/css/main.css" media="screen" rel="stylesheet" type="text/css">
-  <script src="/js/head.js" type="text/javascript"></script>
 
 {{- if $canonical_link }}
   <link rel="canonical" href="{{ $canonical_link }}" />{{end}}


### PR DESCRIPTION
Like it says on the tin.

Note that we're going to rework Hugo templates next to (rather than in-place of) the current style, hence the layout/sandbox/single.html and partials/sandbox/common_variables.html. The great_rework/WIP branch likely has a number of trash commits that add markdown files to the content/sandbox/ directory, allowing us to actually see what that template looks like rendered. This taken together will let me compare the old rendered pages to the new while running a single `rake hugo:server`.

Note that this is a draft. It's very likely that additions/changes to this set of colors may be included in future PRs, where the relevance of the additions/changes are more immediately apparent.

---

**THIS PR IS A WORK IN PROGRESS**
I've opened this as part of a set of stacked PRs so that I can more cleanly and more quickly share the work that I'm doing. Any changes made to this branch will likely come in the form of a force push, so local updates should be performed with

```
git checkout great_rework/07/wireframe
git fetch origin great_rework/07/wireframe
git reset origin/great_rework/07/wireframe --hard
```

Please feel free to comment on anything you see here; offer suggestions, provide corrections, raise concerns. the whole point of this exercise is to engender communication.

But _**do not merge this PR**_.
