### PR TITLE
Great Rework Part 10 -- Draft the Version-Selector generation and interaction

### DIFF
--- a/dynamic/css/abstracts/_colors.scss
+++ b/dynamic/css/abstracts/_colors.scss
@@ -66,3 +66,21 @@ $gray         : $gray-38;
 $gray-light   : $gray-60;
 $gray-lighter : $gray-85;
 $white        : #ffffff;
+
+
+
+// Version Selector Color Pallet
+// =============================
+$version-color-1        : $orange;
+$version-color-1-light  : lighten($version-color-1, 10%);
+$version-color-2        : $orange-dark;
+$version-color-2-light  : lighten($version-color-2, 10%);
+$version-color-3        : $green;
+$version-color-3-light  : lighten($version-color-3, 10%);
+$version-color-4        : $cyan;
+$version-color-4-light  : lighten($version-color-4, 10%);
+$version-color-5        : $cyan-dark;
+$version-color-5-light  : lighten($version-color-5, 10%);
+$version-color-6        : $green-dark;
+$version-color-6-light  : lighten($version-color-6, 10%);
+$version-color-inactive : $gray-light;

--- a/dynamic/css/base/_formatting.scss
+++ b/dynamic/css/base/_formatting.scss
@@ -56,6 +56,11 @@
 }
 
 
+.hidden {
+  display: none;
+}
+
+
 
 .float-left {
   float: left;

--- a/dynamic/css/components/_version-selector.scss
+++ b/dynamic/css/components/_version-selector.scss
@@ -33,6 +33,8 @@
 /**
  * Version Selector Badge
  *TODO: quick description of why this is necessary? (which... I forget...)
+ *TODO: This should probably only be a pointer when JS is enabled, and there's a
+ *      (possibly-loaded) list to display on a click.
  */
 .version-selector__badge {
   cursor : pointer;

--- a/dynamic/css/components/_version-selector.scss
+++ b/dynamic/css/components/_version-selector.scss
@@ -29,6 +29,7 @@
   padding-left   : p2r(1px);  /* 2 */
 }
 
+
 /**
  * Version Selector Badge
  *TODO: quick description of why this is necessary? (which... I forget...)
@@ -36,6 +37,7 @@
 .version-selector__badge {
   cursor : pointer;
 }
+
 
 /**
  * Version Selector Drop-down Menu; Button Element
@@ -71,4 +73,168 @@
   @include downward-arrow(p2r(12px), $orange);
   position : relative;
   margin   : 0 auto 0.25rem auto;
+}
+
+
+/**
+ * Version Selector Drop-Down Menu; Block-Level List
+ * 1. This is interacting with the parent's `position: relative`, meaning that
+ *    the list will be positioned within the containing
+ *    `<div class="version-selector">`.
+ */
+.version-selector__list {
+  @extend           %sans;
+  position         : absolute; /* 1 */
+  width            : 100%;
+  margin           : 0;
+  padding          : 0;
+  list-style       : none;
+  list-style-image : none;
+}
+
+
+/**
+ * Version Selector Drop-Down Menu; List Elements
+ * 1. Not actually a desired style. This will (hopefully) motivate us to clean
+ *    up any background styles that aren't overridden in the below Per-Version
+ *    Background Colors section.
+ * 2. We want the anchor to take up the entire space its parent element will
+ *    provide, and this is one way of getting that to happen.
+ * 3. This padding would normally live on the element rather than the child
+ *    anchor, but if it's set on the element the anchor's height won't include
+ *    it. So we set the padding on the anchor.
+ */
+.version-selector__list-element {
+  background  : rgba(255,0,0,0.7); /* 1 */
+  border-top  : 1px solid white;
+  font-size   : 0.75rem;
+  text-align  : center;
+  color       : white;
+  // line-height : 1.2;
+
+  a {
+    color   : white;
+    cursor  : pointer;
+    display : block;  /* 2 */
+    height  : 100%;   /* 2 */
+    width   : 100%;   /* 2 */
+    padding-top: .25rem;
+    padding-bottom: .25rem;
+    // padding : p2r(5px) 0 p2r(6px) 0; /* 3 */
+    // padding : 0.3rem 0 0.375 0; /* 3 */
+  }
+}
+
+/**
+ * Version Selector Drop-Down Menu; Per-Section Topmost Element
+ */
+.version-selector__list-element--top {
+  @include rounded-corner(top, left, 0.25rem);
+  @include rounded-corner(top, right, 0.25rem);
+  border-top : none;
+}
+
+/**
+ * Version Selector Drop-Down Menu; Per-Section Bottommost Element
+ */
+.version-selector__list-element--bottom {
+  @include rounded-corner(bottom, left, 0.25rem);
+  @include rounded-corner(bottom, right, 0.25rem);
+  margin-bottom : 0.25rem;
+}
+
+/**
+ * Version Selector Drop-Down Menu; LTS tag modifier
+ * Heightens the given element, and adds the "LTS" text above it.
+ * 1. "\A" adds whitespace that _may be_ treated as a newline.
+ * 2. `pre` forces this text to act like a <pre>, and respect '\A' newlines.
+ * 3. I hate the kerning of this font all of a sudden... The periods and letter-
+ *    spacing are the best I can do to make it not look off.
+ * 4. FIXME: The LTS text is not included as part of the anchor, so it's not
+ *           selectable. We should play with this and see about getting it to
+ *           work as expected
+ *           Move the LTS text into the Hugo template?
+ *           negative margin, positive padding?
+ */
+.version-selector__list-element--lts {
+  padding-top: .15rem;
+  a { padding-top: 0; }
+
+  &::before {
+    @extend         %sans-bold;
+    line-height    : 1;
+    content        : "L.T.S\A"; /* 1, 3, 4 */
+    white-space    : pre;       /* 2 */
+    letter-spacing : p2r(1px);  /* 3 */
+    font-size      : 0.625rem;
+  }
+}
+
+
+
+/**
+ * Version Selector Drop-Down Menu; Per-Version Background Colors
+ */
+.version-selector__list-element--1 {
+  background : $version-color-1;
+  &:hover,
+  &.version-selector__list-element--current {
+    background : $version-color-1-light;
+  }
+}
+
+.version-selector__list-element--2 {
+  background : $version-color-2;
+  &:hover,
+  &.version-selector__list-element--current {
+    background : $version-color-2-light;
+  }
+}
+
+.version-selector__list-element--3 {
+  background : $version-color-3;
+  &:hover,
+  &.version-selector__list-element--current {
+    background : $version-color-3-light;
+  }
+}
+
+.version-selector__list-element--4 {
+  background : $version-color-4;
+  &:hover,
+  &.version-selector__list-element--current {
+    background : $version-color-4-light;
+  }
+}
+
+.version-selector__list-element--5 {
+  background : $version-color-5;
+  &:hover,
+  &.version-selector__list-element--current {
+    background : $version-color-5-light;
+  }
+}
+
+.version-selector__list-element--6 {
+  background : $version-color-6;
+  &:hover,
+  &.version-selector__list-element--current {
+    background : $version-color-6-light;
+  }
+}
+
+/* The current version and all disabled versions should not link out. */
+.version-selector__list-element--current  a,
+.version-selector__list-element--disabled a {
+  pointer-events : none;
+  cursor         : default;
+}
+
+/* Cheating a bit here by bumping the specificity of this rule to ensure the
+ * inactive color trumps other specifiers.
+ *TODO: Figure out if the specificity bump is necessary. We may be able to
+ *      generate the list s.t. elements are either `--[1-6]` or `--disabled`.
+ */
+.version-selector__list .version-selector__list-element--disabled {
+  background : $version-color-inactive;
 }

--- a/dynamic/css/layout/_wireframe.scss
+++ b/dynamic/css/layout/_wireframe.scss
@@ -71,6 +71,7 @@ $content-nav-width : 14rem;
  */
 .banner {
   position : fixed;
+  z-index  : 100;
   top      : 0;
   left     : 0; /* 1 */
   right    : 0; /* 1 */

--- a/dynamic/js/basho/tools/sem-ver.coffee
+++ b/dynamic/js/basho/tools/sem-ver.coffee
@@ -1,0 +1,92 @@
+###
+Semantic Version Helper Functions
+=================================
+
+This file defines the `window.SemVer` object that allows for quick and easy
+manipulations of and comparisons between typical X.Y.Z semantic version numbers.
+###
+
+
+#TODO: strict mode enables a pretty large number of runtime checks. We probably
+#      want to turn it off when we're deploy to prod.
+#      Perhaps we can figure out some way to enable it when building debug?
+'use strict'
+
+# Global Library object.
+SemVer = window.SemVer = {}
+
+# Min possible version (0.0.0) and max possible versions (∞.∞.∞)
+version_min = { major: 0;        minor: 0;        patch: 0        }
+version_max = { major: Infinity; minor: Infinity; patch: Infinity }
+
+
+# ```parse :: (Str) -> {Num, Num, Num}```
+# Convert a semantic version string (ex. `"2.1.4"`) to a version object with
+# explicit `major`, `minor`, and `patch` data members.
+SemVer.parse = (str) ->
+  v = /^[<>]?[=]?(\d+)\.?(\d+)?\.?(\d+)?/.exec(str)
+  return {
+    major: parseInt(v[1]) || 0
+    minor: parseInt(v[2]) || 0
+    patch: parseInt(v[3]) || 0
+  }
+
+
+# ```parseRange :: (Str) -> [{Num, Num, Num}, {Num, Num, Num}]```
+# Convert a semantic version range string (ex. '">=2.1.4"') into a tuple (list
+# of length 2, really) containing the minimum and maximum version in the
+# given range.
+#
+# The range string must be in one of the following forms;
+#   * Greater than             -- `">X.Y.Z"`
+#   * Greater than or equal    -- `">-X.Y.Z"`, `"X.Y.Z+"`
+#   * Less than                -- `"<X.Y.Z"`
+#   * Less than or equal       -- `"<-X.Y.Z"`, `"X.Y.Z-"`
+#   * Explicit range           -- `"A.B.C-X.Y.Z"`
+#   * Single version           -- `"X.Y.Z"`
+SemVer.parseRange = (str) ->
+  if str.match(/\+$/) or str.match(/^\>\=/)    # Greater than or equal to
+    return [SemVer.parse(str), version_max]
+  else if str.match(/^\>/)                     # Greater than
+    # This is explicitly greater than, so only include from the next version
+    version = SemVer.parse(str)
+    version.patch++
+    return [version, version_max]
+  else if str.match(/^\<\=/)                   # Less than or equal to
+    return [version_min, SemVer.parse(str)]
+  else if str.match(/\-$/) or str.match(/^\</) # Less than
+    # This is explicitly less than, so only include up to the previous version
+    version = SemVer.parse(str)
+    version.patch--
+    return [version_min, version]
+  else if str.match(/.+?\-.+?/)                # Explicit range
+    vs = str.split('-')
+    return [SemVer.parse(vs[0]), SemVer.parse(vs[1])]
+  else                                         # Single version
+    version = SemVer.parse(str)
+    return [version, version]
+
+
+# ```compare :: ({Num, Num, Num}, {Num, Num, Num}) -> Num```
+# Compare two semantic versions using typical comparator rules;
+#   <0 == `v1` is newer than `v2`
+#   0  == `v1` and `v2` are the same version
+#   >0 == `v2` is newer than `v1`
+SemVer.compare = (v1, v2) ->
+  if      (v1.major != v2.major) then return (v2.major - v1.major)
+  else if (v1.minor != v2.minor) then return (v2.minor - v1.minor)
+  else if (v1.patch != v2.patch) then return (v2.patch - v1.patch)
+  else                                return 0
+
+
+# ```isInRange :: ({Num, Num, Num},
+#                  [{Num, Num, Num}, {Num, Num, Num}]) -> Bool```
+# Checks to see if the given version is within the given range. It's assumed
+# that the range is ordered oldest to newest.
+SemVer.isInRange = (version, range) ->
+  [oldest, newest] = range
+  if SemVer.compare(version, oldest) > 0 or
+     SemVer.compare(version, newest) < 0
+    return false
+  else
+    return true

--- a/dynamic/js/basho/version-selector.coffee
+++ b/dynamic/js/basho/version-selector.coffee
@@ -1,0 +1,201 @@
+###
+Version Selector Generation and Interaction
+===========================================
+Requires sem-ver.coffee
+
+This file defines a series of calls and callbacks that apply to the generation
+of and interaction with the .version-selector element.
+
+The root-level .version-selector div will be generated as part of the Hugo
+compilation, but the version list will not. We don't want every generated HTML
+file within a project/version to be modified every time a new version of that
+project is released, so we've chosen to upload the version information as a JSON
+to our server and dynamically generate the version lists at load-time.
+
+Interaction is a simple mater of expanding (or simply showing) the list when the
+.version-selector div is clicked, and collapsing it (or hiding it) when anything
+else is clicked on.
+###
+
+#TODO: strict mode enables a pretty large number of runtime checks. We probably
+#      want to turn it off when we deploy to prod.
+#      Perhaps we can figure out some way to enable it when building debug?
+'use strict'
+
+
+# ```contentOfMeta :: (Str) -> Str or Undefined```
+# Fetch the content of a <meta> tag of the given name. If no tag of the given
+# name exists, `undefined` is returned.
+#TODO: Probably good to move this to a general utilities file
+contentOfMeta = (name) ->
+  return $('meta[name='+name+']').attr('content')
+
+
+# ```generateVersionLists :: () ->```
+# Build the Version Selector list dynamically, using fetched JSON and metadata
+# exposed by Hugo through <meta> tags.
+# There's no need to fetch the JSON or build this DOM element before the site is
+# rendered and interactable, so we're going to wrap the manipulation inside the
+# `.getJSON` callback _that's inside_ a `.ready()` callback. Double indirection,
+# baby.
+#TODO: Consider mark the version-selector as inactive until the list is built.
+#      This assumes it will take a substantial amount of time (1s or so) for the
+#      element to be created. It should probably also only go invalid when JS is
+#      enabled, and stay orange if we're never going to fetch the JSON...
+generateVersionLists = () ->
+  # Pull project/pathing information from the meta tags set up by Hugo
+  project              =  contentOfMeta("project")              # ex; riak_kv
+  current_version      =  contentOfMeta("version")              # ex; 2.1.4
+  project_relative_url =  contentOfMeta("project_relative_url") # ex; installing/
+
+  # The version_history <meta> tags will only exist if the front matter of the
+  # given content .md page contains them, so these may be `undefined`.
+  meta_version_hisotry_in = contentOfMeta("version_history_in")
+  version_range = undefined
+  meta_version_history_locations = contentOfMeta("version_history_locations")
+  versions_locations = []
+
+  if meta_version_hisotry_in
+    version_range = SemVer.parseRange(meta_version_hisotry_in)
+
+  if meta_version_history_locations
+    locations_json = JSON.parse(meta_version_history_locations)
+    versions_locations = for [range, path] in locations_json
+                         [SemVer.parseRange(range), path]
+
+  # Fetch the Project Descriptions from the server, and do all the heavy lifting
+  # inside the `success` callback.
+  $.getJSON('/data/project_descriptions.json',
+    (data) ->
+      version_selector_list_html = "" # Aggregator for the resulting HTML.
+
+      project_data = data[project]
+
+      project_path = project_data.path            # ex; /riak/kv
+      latest_rel   = project_data.latest          # ex; 2.1.4
+      lts_version  = project_data.lts             # ex; 2.0.7
+      archived_url = project_data['archived_url'] # undefined, or a complete URL
+
+      for release_set, set_index in project_data.releases.reverse()
+        # List depth is used for setting color. Our CSS only has colors from 1
+        # to 6, so cap anything deeper.
+        list_depth = Math.min(6, (set_index+1))
+
+        # We're want to act on the last element of the release set in the below
+        # loop. I can't think of a better way to do that this.
+        last_index = release_set.length - 1
+
+        for release_version, index in release_set.reverse()
+          release_sem_ver = SemVer.parse(release_version)
+
+          # Record if this release_version is within the version_range
+          in_version_range = not version_range or
+                             SemVer.isInRange(release_sem_ver, version_range)
+
+          # Start aggregating class modifiers that will be `.join("\n")`d
+          # together once all modifier have been added.
+          class_list = ["version-selector__list-element"]
+
+          if in_version_range
+            class_list.push("version-selector__list-element--"+list_depth)
+          else
+            class_list.push("version-selector__list-element--disabled")
+
+          if index == 0
+            class_list.push("version-selector__list-element--top")
+
+          if index == last_index
+            class_list.push("version-selector__list-element--bottom")
+
+          if release_version == lts_version
+            class_list.push("version-selector__list-element--lts")
+
+          if release_version == current_version
+            class_list.push("version-selector__list-element--current")
+
+          # The class list is complete.
+          # Build out the list contents and anchor based on metadata available.
+
+          # If the list element is --disabled or --current it should not include
+          # an active link, so skip giving them an href.
+          anchor_tag = ""
+          if (not in_version_range) or (release_version == current_version)
+            anchor_tag = '<a>'
+          else
+            # Give the versions_locations overrides a change to direct this
+            # release_version to a different project/version-relative url.
+            # If none of the ranges match (or if there are no ranges), default
+            # to the current page's project/version-relative url.
+            relative_url = project_relative_url
+            for [range, url] in versions_locations
+              if SemVer.isInRange(release_sem_ver, range)
+                relative_url = url
+                break
+
+            anchor = project_path+"/"+release_version+"/"+relative_url
+            anchor_tag = '<a href="'+anchor+'">'
+
+          # Build the full list element and add it to the
+          # `version_selector_list_html` aggregator.
+          #TODO: Consider importing a sprintf library.
+          #      Because JS doesn't ship w/ that functionality? For... reasons?
+          version_selector_list_html +=
+              '<li class="'+class_list.join("\n")+'">'+
+                anchor_tag+release_version+'</a>'+
+              '</li>\n'
+
+      # If this project has the optional `archived_url`, add a special "set"
+      # with only a link out to the archived content.
+      if archived_url
+        class_list = ["version-selector__list-element",
+                      "version-selector__list-element--6",
+                      "version-selector__list-element--top",
+                      "version-selector__list-element--bottom"]
+        version_selector_list_html +=
+          '<li class="'+class_list.join("\n")+'"><a href="'+archived_url+'">older</a></li>\n'
+
+      # What we've all been waiting for; make the DOM modification.
+      $(".version-selector__list").html(version_selector_list_html)
+    )
+
+
+
+## JQuery .ready() Execution
+## =========================
+$ ->
+  # Build the version list
+  generateVersionLists();
+
+  # Wire up interactions
+  version_badge = $('.version-selector__badge')
+  version_list  = $('.version-selector__list')
+
+  # When the badge is clicked, the list should toggle between shown and hidden.
+  version_badge.on('click',
+    () ->
+      if 0 < version_badge.attr('class').search(".version-selector__badge--selected")
+        version_list.hide()
+        version_badge.removeClass(".version-selector__badge--selected")
+      else
+        version_list.show()
+        version_badge.addClass(".version-selector__badge--selected")
+      # Consume the event to prevent propagation.
+      false
+  )
+
+  # When child elements of the list are clicked, nothing should occur. Just
+  # return `true` to allow the event to bubble up.
+  version_list.on('click', '.version-selector__list-element', () -> true )
+
+  # When the current or a disabled list element is clicked nothing should
+  # happen, so return `false` to consume the event.
+  version_list.on('click', '.version-selector__list-element--disabled', () -> false )
+  version_list.on('click', '.version-selector__list-element--current',  () -> false )
+
+  # When anything else in the document is clicked, we should hide the list.
+  $(document).on('click',
+    () ->
+      if 0 < version_badge.attr('class').search(".version-selector__badge--selected")
+        version_list.hide()
+        version_badge.removeClass(".version-selector__badge--selected")
+  )

--- a/dynamic/js/main.js
+++ b/dynamic/js/main.js
@@ -11,14 +11,32 @@
 
 //TODO: Make sure none of the code in here triggers a FOUC.
 
+
+
 /* Vendor Library Includes
  * -----------------------
  * Included one at a time to ensure all requirements are met
  */
+
 //= require ./vendor/modernizr-3.1.1.js
 //= require ./vendor/jquery-2.2.4.js
 //= require ./vendor/tether-1.1.0.js
 //= require ./vendor/bootstrap-v4.0.0-alpha.2-18ee98b.js
 //= require ./vendor/highlight-9.3.0.pack.js
 
-//TODO: Add Basho-specific code
+
+
+/* Basho Code Tools & Library Code
+ * -------------------------------
+ * Included one at a time to ensure all requirements are met
+ */
+
+//= require ./basho/tools/sem-ver.js
+
+
+/* Basho Code
+ * ----------
+ * Included one at a time to ensure all requirements are met
+ */
+
+//= require ./basho/version-selector.js

--- a/layouts/sandbox/single.html
+++ b/layouts/sandbox/single.html
@@ -165,7 +165,7 @@
           <div    class="version-selector__arrow"></div>
         </div>
 
-        <ol class="version-selector__list" hidden></ol>
+        <ol class="hidden   version-selector__list"></ol>
 
       </div>
 


### PR DESCRIPTION
Like it says on the tin.

This is the first commit that makes real use of the new JS layout. I'm happy to see it seems to work without issue.

Note that this is a draft. It's very likely that additions/changes to this set of colors may be included in future PRs, where the relevance of the additions/changes are more immediately apparent.

---

**THIS PR IS A WORK IN PROGRESS**
I've opened this as part of a set of stacked PRs so that I can more cleanly and more quickly share the work that I'm doing. Any changes made to this branch will likely come in the form of a force push, so local updates should be performed with

```
git checkout great_rework/10/version_selector_interaction
git fetch origin great_rework/10/version_selector_interaction
git reset origin/great_rework/10/version_selector_interaction --hard
```

Please feel free to comment on anything you see here; offer suggestions, provide corrections, raise concerns. the whole point of this exercise is to engender communication.

But _**do not merge this PR**_.
