### PR TITLE
Corrected alter-user commands that had typos

### DIFF
--- a/content/riak/kv/2.0.0/using/security/basics.md
+++ b/content/riak/kv/2.0.0/using/security/basics.md
@@ -319,27 +319,27 @@ Now, the `print-users` command should return this:
 ```
 
 **Note**: Usernames _cannot_ be changed using the `alter-user` command.
-If you attempt to do so by running `alter-user riakuser
-username=other-name`, for example, this will add the
+For example, running `riak-admin security alter-user riakuser
+username=other-name`, will instead add the
 `{"username","other-name"}` tuple to `riakuser`'s options.
 
 ### Managing Groups for a User
 
-If we have a user `jane_goodall` and we'd like to assign her to the
+If we have a user `riakuser` and we'd like to assign her to the
 `admin` group, we assign the value `admin` to the option `groups`:
 
 ```bash
-riak-admin security alter-user jane_goodall groups=admin
+riak-admin security alter-user riakuser groups=admin
 ```
 
-If we'd like to make the user `jane_goodall` both an `admin` and an
+If we'd like to make the user `riakuser` both an `admin` and an
 `archoverlord`:
 
 ```bash
-riak-admin alter-user jane_goodall groups=admin,archoverlord
+riak-admin security alter-user riakuser groups=admin,archoverlord
 ```
 
-There is no way to incrementally add groups; even if `jane_goodall` was
+There is no way to incrementally add groups; even if `riakuser` was
 already an `admin`, it is necessary to list it again when adding the
 `archoverlord` group. Thus, to remove a group from a user, use
 `alter-user` and list all *other* groups.
@@ -348,7 +348,7 @@ If the user should be removed from all groups, use `groups=` with no
 list:
 
 ```bash
-riak-admin alter-user jane_goodall groups=
+riak-admin security alter-user riakuser groups=
 ```
 
 ### Managing Groups for Groups
@@ -356,7 +356,7 @@ riak-admin alter-user jane_goodall groups=
 Groups can be added to other groups for cascading permissions.
 
 ```bash
-riak-admin alter-group admin groups=dev
+riak-admin security alter-group admin groups=dev
 ```
 
 ### Deleting a User or Group

--- a/content/riak/kv/2.0.1/using/security/basics.md
+++ b/content/riak/kv/2.0.1/using/security/basics.md
@@ -319,27 +319,27 @@ Now, the `print-users` command should return this:
 ```
 
 **Note**: Usernames _cannot_ be changed using the `alter-user` command.
-If you attempt to do so by running `alter-user riakuser
-username=other-name`, for example, this will add the
+For example, running `riak-admin security alter-user riakuser
+username=other-name`, will instead add the
 `{"username","other-name"}` tuple to `riakuser`'s options.
 
 ### Managing Groups for a User
 
-If we have a user `jane_goodall` and we'd like to assign her to the
+If we have a user `riakuser` and we'd like to assign her to the
 `admin` group, we assign the value `admin` to the option `groups`:
 
 ```bash
-riak-admin security alter-user jane_goodall groups=admin
+riak-admin security alter-user riakuser groups=admin
 ```
 
-If we'd like to make the user `jane_goodall` both an `admin` and an
+If we'd like to make the user `riakuser` both an `admin` and an
 `archoverlord`:
 
 ```bash
-riak-admin alter-user jane_goodall groups=admin,archoverlord
+riak-admin security alter-user riakuser groups=admin,archoverlord
 ```
 
-There is no way to incrementally add groups; even if `jane_goodall` was
+There is no way to incrementally add groups; even if `riakuser` was
 already an `admin`, it is necessary to list it again when adding the
 `archoverlord` group. Thus, to remove a group from a user, use
 `alter-user` and list all *other* groups.
@@ -348,7 +348,7 @@ If the user should be removed from all groups, use `groups=` with no
 list:
 
 ```bash
-riak-admin alter-user jane_goodall groups=
+riak-admin security alter-user riakuser groups=
 ```
 
 ### Managing Groups for Groups

--- a/content/riak/kv/2.0.1/using/security/basics.md
+++ b/content/riak/kv/2.0.1/using/security/basics.md
@@ -356,7 +356,7 @@ riak-admin security alter-user riakuser groups=
 Groups can be added to other groups for cascading permissions.
 
 ```bash
-riak-admin alter-group admin groups=dev
+riak-admin security alter-group admin groups=dev
 ```
 
 ### Deleting a User or Group

--- a/content/riak/kv/2.0.2/using/security/basics.md
+++ b/content/riak/kv/2.0.2/using/security/basics.md
@@ -318,27 +318,27 @@ Now, the `print-users` command should return this:
 ```
 
 **Note**: Usernames _cannot_ be changed using the `alter-user` command.
-If you attempt to do so by running `alter-user riakuser
-username=other-name`, for example, this will add the
+For example, running `riak-admin security alter-user riakuser
+username=other-name`, will instead add the
 `{"username","other-name"}` tuple to `riakuser`'s options.
 
 ### Managing Groups for a User
 
-If we have a user `jane_goodall` and we'd like to assign her to the
+If we have a user `riakuser` and we'd like to assign her to the
 `admin` group, we assign the value `admin` to the option `groups`:
 
 ```bash
-riak-admin security alter-user jane_goodall groups=admin
+riak-admin security alter-user riakuser groups=admin
 ```
 
-If we'd like to make the user `jane_goodall` both an `admin` and an
+If we'd like to make the user `riakuser` both an `admin` and an
 `archoverlord`:
 
 ```bash
-riak-admin alter-user jane_goodall groups=admin,archoverlord
+riak-admin security alter-user riakuser groups=admin,archoverlord
 ```
 
-There is no way to incrementally add groups; even if `jane_goodall` was
+There is no way to incrementally add groups; even if `riakuser` was
 already an `admin`, it is necessary to list it again when adding the
 `archoverlord` group. Thus, to remove a group from a user, use
 `alter-user` and list all *other* groups.
@@ -347,7 +347,7 @@ If the user should be removed from all groups, use `groups=` with no
 list:
 
 ```bash
-riak-admin alter-user jane_goodall groups=
+riak-admin security alter-user riakuser groups=
 ```
 
 ### Managing Groups for Groups

--- a/content/riak/kv/2.0.2/using/security/basics.md
+++ b/content/riak/kv/2.0.2/using/security/basics.md
@@ -12,6 +12,7 @@ menu:
 toc: true
 aliases:
   - /riak/2.0.2/ops/running/authz
+  - /riak/kv/2.0.2/ops/running/authz
 ---
 
 > **Note on Network security**
@@ -355,7 +356,7 @@ riak-admin security alter-user riakuser groups=
 Groups can be added to other groups for cascading permissions.
 
 ```bash
-riak-admin alter-group admin groups=dev
+riak-admin security alter-group admin groups=dev
 ```
 
 ### Deleting a User or Group

--- a/content/riak/kv/2.0.4/using/security/basics.md
+++ b/content/riak/kv/2.0.4/using/security/basics.md
@@ -319,27 +319,27 @@ Now, the `print-users` command should return this:
 ```
 
 **Note**: Usernames _cannot_ be changed using the `alter-user` command.
-If you attempt to do so by running `alter-user riakuser
-username=other-name`, for example, this will add the
+For example, running `riak-admin security alter-user riakuser
+username=other-name`, will instead add the
 `{"username","other-name"}` tuple to `riakuser`'s options.
 
 ### Managing Groups for a User
 
-If we have a user `jane_goodall` and we'd like to assign her to the
+If we have a user `riakuser` and we'd like to assign her to the
 `admin` group, we assign the value `admin` to the option `groups`:
 
 ```bash
-riak-admin security alter-user jane_goodall groups=admin
+riak-admin security alter-user riakuser groups=admin
 ```
 
-If we'd like to make the user `jane_goodall` both an `admin` and an
+If we'd like to make the user `riakuser` both an `admin` and an
 `archoverlord`:
 
 ```bash
-riak-admin alter-user jane_goodall groups=admin,archoverlord
+riak-admin security alter-user riakuser groups=admin,archoverlord
 ```
 
-There is no way to incrementally add groups; even if `jane_goodall` was
+There is no way to incrementally add groups; even if `riakuser` was
 already an `admin`, it is necessary to list it again when adding the
 `archoverlord` group. Thus, to remove a group from a user, use
 `alter-user` and list all *other* groups.
@@ -348,7 +348,7 @@ If the user should be removed from all groups, use `groups=` with no
 list:
 
 ```bash
-riak-admin alter-user jane_goodall groups=
+riak-admin security alter-user riakuser groups=
 ```
 
 ### Managing Groups for Groups

--- a/content/riak/kv/2.0.4/using/security/basics.md
+++ b/content/riak/kv/2.0.4/using/security/basics.md
@@ -356,7 +356,7 @@ riak-admin security alter-user riakuser groups=
 Groups can be added to other groups for cascading permissions.
 
 ```bash
-riak-admin alter-group admin groups=dev
+riak-admin security alter-group admin groups=dev
 ```
 
 ### Deleting a User or Group

--- a/content/riak/kv/2.0.5/using/security/basics.md
+++ b/content/riak/kv/2.0.5/using/security/basics.md
@@ -319,27 +319,27 @@ Now, the `print-users` command should return this:
 ```
 
 **Note**: Usernames _cannot_ be changed using the `alter-user` command.
-If you attempt to do so by running `alter-user riakuser
-username=other-name`, for example, this will add the
+For example, running `riak-admin security alter-user riakuser
+username=other-name`, will instead add the
 `{"username","other-name"}` tuple to `riakuser`'s options.
 
 ### Managing Groups for a User
 
-If we have a user `jane_goodall` and we'd like to assign her to the
+If we have a user `riakuser` and we'd like to assign her to the
 `admin` group, we assign the value `admin` to the option `groups`:
 
 ```bash
-riak-admin security alter-user jane_goodall groups=admin
+riak-admin security alter-user riakuser groups=admin
 ```
 
-If we'd like to make the user `jane_goodall` both an `admin` and an
+If we'd like to make the user `riakuser` both an `admin` and an
 `archoverlord`:
 
 ```bash
-riak-admin alter-user jane_goodall groups=admin,archoverlord
+riak-admin security alter-user riakuser groups=admin,archoverlord
 ```
 
-There is no way to incrementally add groups; even if `jane_goodall` was
+There is no way to incrementally add groups; even if `riakuser` was
 already an `admin`, it is necessary to list it again when adding the
 `archoverlord` group. Thus, to remove a group from a user, use
 `alter-user` and list all *other* groups.
@@ -348,7 +348,7 @@ If the user should be removed from all groups, use `groups=` with no
 list:
 
 ```bash
-riak-admin alter-user jane_goodall groups=
+riak-admin security alter-user riakuser groups=
 ```
 
 ### Managing Groups for Groups

--- a/content/riak/kv/2.0.5/using/security/basics.md
+++ b/content/riak/kv/2.0.5/using/security/basics.md
@@ -356,7 +356,7 @@ riak-admin security alter-user riakuser groups=
 Groups can be added to other groups for cascading permissions.
 
 ```bash
-riak-admin alter-group admin groups=dev
+riak-admin security alter-group admin groups=dev
 ```
 
 ### Deleting a User or Group

--- a/content/riak/kv/2.0.6/using/security/basics.md
+++ b/content/riak/kv/2.0.6/using/security/basics.md
@@ -319,27 +319,27 @@ Now, the `print-users` command should return this:
 ```
 
 **Note**: Usernames _cannot_ be changed using the `alter-user` command.
-If you attempt to do so by running `alter-user riakuser
-username=other-name`, for example, this will add the
+For example, running `riak-admin security alter-user riakuser
+username=other-name`, will instead add the
 `{"username","other-name"}` tuple to `riakuser`'s options.
 
 ### Managing Groups for a User
 
-If we have a user `jane_goodall` and we'd like to assign her to the
+If we have a user `riakuser` and we'd like to assign her to the
 `admin` group, we assign the value `admin` to the option `groups`:
 
 ```bash
-riak-admin security alter-user jane_goodall groups=admin
+riak-admin security alter-user riakuser groups=admin
 ```
 
-If we'd like to make the user `jane_goodall` both an `admin` and an
+If we'd like to make the user `riakuser` both an `admin` and an
 `archoverlord`:
 
 ```bash
-riak-admin alter-user jane_goodall groups=admin,archoverlord
+riak-admin security alter-user riakuser groups=admin,archoverlord
 ```
 
-There is no way to incrementally add groups; even if `jane_goodall` was
+There is no way to incrementally add groups; even if `riakuser` was
 already an `admin`, it is necessary to list it again when adding the
 `archoverlord` group. Thus, to remove a group from a user, use
 `alter-user` and list all *other* groups.
@@ -348,7 +348,7 @@ If the user should be removed from all groups, use `groups=` with no
 list:
 
 ```bash
-riak-admin alter-user jane_goodall groups=
+riak-admin security alter-user riakuser groups=
 ```
 
 ### Managing Groups for Groups

--- a/content/riak/kv/2.0.6/using/security/basics.md
+++ b/content/riak/kv/2.0.6/using/security/basics.md
@@ -356,7 +356,7 @@ riak-admin security alter-user riakuser groups=
 Groups can be added to other groups for cascading permissions.
 
 ```bash
-riak-admin alter-group admin groups=dev
+riak-admin security alter-group admin groups=dev
 ```
 
 ### Deleting a User or Group

--- a/content/riak/kv/2.0.7/using/security/basics.md
+++ b/content/riak/kv/2.0.7/using/security/basics.md
@@ -319,27 +319,27 @@ Now, the `print-users` command should return this:
 ```
 
 **Note**: Usernames _cannot_ be changed using the `alter-user` command.
-If you attempt to do so by running `alter-user riakuser
-username=other-name`, for example, this will add the
+For example, running `riak-admin security alter-user riakuser
+username=other-name`, will instead add the
 `{"username","other-name"}` tuple to `riakuser`'s options.
 
 ### Managing Groups for a User
 
-If we have a user `jane_goodall` and we'd like to assign her to the
+If we have a user `riakuser` and we'd like to assign her to the
 `admin` group, we assign the value `admin` to the option `groups`:
 
 ```bash
-riak-admin security alter-user jane_goodall groups=admin
+riak-admin security alter-user riakuser groups=admin
 ```
 
-If we'd like to make the user `jane_goodall` both an `admin` and an
+If we'd like to make the user `riakuser` both an `admin` and an
 `archoverlord`:
 
 ```bash
-riak-admin alter-user jane_goodall groups=admin,archoverlord
+riak-admin security alter-user riakuser groups=admin,archoverlord
 ```
 
-There is no way to incrementally add groups; even if `jane_goodall` was
+There is no way to incrementally add groups; even if `riakuser` was
 already an `admin`, it is necessary to list it again when adding the
 `archoverlord` group. Thus, to remove a group from a user, use
 `alter-user` and list all *other* groups.
@@ -348,7 +348,7 @@ If the user should be removed from all groups, use `groups=` with no
 list:
 
 ```bash
-riak-admin alter-user jane_goodall groups=
+riak-admin security alter-user riakuser groups=
 ```
 
 ### Managing Groups for Groups

--- a/content/riak/kv/2.0.7/using/security/basics.md
+++ b/content/riak/kv/2.0.7/using/security/basics.md
@@ -356,7 +356,7 @@ riak-admin security alter-user riakuser groups=
 Groups can be added to other groups for cascading permissions.
 
 ```bash
-riak-admin alter-group admin groups=dev
+riak-admin security alter-group admin groups=dev
 ```
 
 ### Deleting a User or Group

--- a/content/riak/kv/2.1.1/using/security/basics.md
+++ b/content/riak/kv/2.1.1/using/security/basics.md
@@ -319,27 +319,27 @@ Now, the `print-users` command should return this:
 ```
 
 **Note**: Usernames _cannot_ be changed using the `alter-user` command.
-If you attempt to do so by running `alter-user riakuser
-username=other-name`, for example, this will add the
+For example, running `riak-admin security alter-user riakuser
+username=other-name`, will instead add the
 `{"username","other-name"}` tuple to `riakuser`'s options.
 
 ### Managing Groups for a User
 
-If we have a user `jane_goodall` and we'd like to assign her to the
+If we have a user `riakuser` and we'd like to assign her to the
 `admin` group, we assign the value `admin` to the option `groups`:
 
 ```bash
-riak-admin security alter-user jane_goodall groups=admin
+riak-admin security alter-user riakuser groups=admin
 ```
 
-If we'd like to make the user `jane_goodall` both an `admin` and an
+If we'd like to make the user `riakuser` both an `admin` and an
 `archoverlord`:
 
 ```bash
-riak-admin alter-user jane_goodall groups=admin,archoverlord
+riak-admin security alter-user riakuser groups=admin,archoverlord
 ```
 
-There is no way to incrementally add groups; even if `jane_goodall` was
+There is no way to incrementally add groups; even if `riakuser` was
 already an `admin`, it is necessary to list it again when adding the
 `archoverlord` group. Thus, to remove a group from a user, use
 `alter-user` and list all *other* groups.
@@ -348,7 +348,7 @@ If the user should be removed from all groups, use `groups=` with no
 list:
 
 ```bash
-riak-admin alter-user jane_goodall groups=
+riak-admin security alter-user riakuser groups=
 ```
 
 ### Managing Groups for Groups

--- a/content/riak/kv/2.1.1/using/security/basics.md
+++ b/content/riak/kv/2.1.1/using/security/basics.md
@@ -356,7 +356,7 @@ riak-admin security alter-user riakuser groups=
 Groups can be added to other groups for cascading permissions.
 
 ```bash
-riak-admin alter-group admin groups=dev
+riak-admin security alter-group admin groups=dev
 ```
 
 ### Deleting a User or Group

--- a/content/riak/kv/2.1.3/using/security/basics.md
+++ b/content/riak/kv/2.1.3/using/security/basics.md
@@ -319,27 +319,27 @@ Now, the `print-users` command should return this:
 ```
 
 **Note**: Usernames _cannot_ be changed using the `alter-user` command.
-If you attempt to do so by running `alter-user riakuser
-username=other-name`, for example, this will add the
+For example, running `riak-admin security alter-user riakuser
+username=other-name`, will instead add the
 `{"username","other-name"}` tuple to `riakuser`'s options.
 
 ### Managing Groups for a User
 
-If we have a user `jane_goodall` and we'd like to assign her to the
+If we have a user `riakuser` and we'd like to assign her to the
 `admin` group, we assign the value `admin` to the option `groups`:
 
 ```bash
-riak-admin security alter-user jane_goodall groups=admin
+riak-admin security alter-user riakuser groups=admin
 ```
 
-If we'd like to make the user `jane_goodall` both an `admin` and an
+If we'd like to make the user `riakuser` both an `admin` and an
 `archoverlord`:
 
 ```bash
-riak-admin alter-user jane_goodall groups=admin,archoverlord
+riak-admin security alter-user riakuser groups=admin,archoverlord
 ```
 
-There is no way to incrementally add groups; even if `jane_goodall` was
+There is no way to incrementally add groups; even if `riakuser` was
 already an `admin`, it is necessary to list it again when adding the
 `archoverlord` group. Thus, to remove a group from a user, use
 `alter-user` and list all *other* groups.
@@ -348,7 +348,7 @@ If the user should be removed from all groups, use `groups=` with no
 list:
 
 ```bash
-riak-admin alter-user jane_goodall groups=
+riak-admin security alter-user riakuser groups=
 ```
 
 ### Managing Groups for Groups

--- a/content/riak/kv/2.1.3/using/security/basics.md
+++ b/content/riak/kv/2.1.3/using/security/basics.md
@@ -356,7 +356,7 @@ riak-admin security alter-user riakuser groups=
 Groups can be added to other groups for cascading permissions.
 
 ```bash
-riak-admin alter-group admin groups=dev
+riak-admin security alter-group admin groups=dev
 ```
 
 ### Deleting a User or Group

--- a/content/riak/kv/2.1.4/using/security/basics.md
+++ b/content/riak/kv/2.1.4/using/security/basics.md
@@ -319,27 +319,27 @@ Now, the `print-users` command should return this:
 ```
 
 **Note**: Usernames _cannot_ be changed using the `alter-user` command.
-If you attempt to do so by running `alter-user riakuser
-username=other-name`, for example, this will add the
+For example, running `riak-admin security alter-user riakuser
+username=other-name`, will instead add the
 `{"username","other-name"}` tuple to `riakuser`'s options.
 
 ### Managing Groups for a User
 
-If we have a user `jane_goodall` and we'd like to assign her to the
+If we have a user `riakuser` and we'd like to assign her to the
 `admin` group, we assign the value `admin` to the option `groups`:
 
 ```bash
-riak-admin security alter-user jane_goodall groups=admin
+riak-admin security alter-user riakuser groups=admin
 ```
 
-If we'd like to make the user `jane_goodall` both an `admin` and an
+If we'd like to make the user `riakuser` both an `admin` and an
 `archoverlord`:
 
 ```bash
-riak-admin alter-user jane_goodall groups=admin,archoverlord
+riak-admin security alter-user riakuser groups=admin,archoverlord
 ```
 
-There is no way to incrementally add groups; even if `jane_goodall` was
+There is no way to incrementally add groups; even if `riakuser` was
 already an `admin`, it is necessary to list it again when adding the
 `archoverlord` group. Thus, to remove a group from a user, use
 `alter-user` and list all *other* groups.
@@ -348,7 +348,7 @@ If the user should be removed from all groups, use `groups=` with no
 list:
 
 ```bash
-riak-admin alter-user jane_goodall groups=
+riak-admin security alter-user riakuser groups=
 ```
 
 ### Managing Groups for Groups

--- a/content/riak/kv/2.1.4/using/security/basics.md
+++ b/content/riak/kv/2.1.4/using/security/basics.md
@@ -356,7 +356,7 @@ riak-admin security alter-user riakuser groups=
 Groups can be added to other groups for cascading permissions.
 
 ```bash
-riak-admin alter-group admin groups=dev
+riak-admin security alter-group admin groups=dev
 ```
 
 ### Deleting a User or Group


### PR DESCRIPTION
Some of the instances of calls to riak-admin were missing `security` in the command. This PR fixes those.