### PR TITLE
Great Rework Part 12 -- Basic JS-Driven Layout Additions / Modifications

### DIFF
--- a/dynamic/css/components/_table-of-contents.scss
+++ b/dynamic/css/components/_table-of-contents.scss
@@ -1,0 +1,54 @@
+/**
+ * Root Table of Contents element
+ * NB. This `margin-bottom` will be collapsed into the `margin-bottom` of the
+ *     parent .front-matter div when the EE-only flag is not present. This is
+ *     exactly what we want.
+ */
+.table-of-contents {
+  margin-bottom : 3rem;
+}
+
+/**
+ * Table of Contents "Content" Title
+ * 1. Zero the top margin s.t. margins for this component only need to be set on
+ *    the root .table-of-contents <nav>.
+ */
+.table-of-contents__title {
+  margin-top    : 0;       /* 1 */
+  margin-bottom : 0.5rem;
+}
+
+/**
+ * Wrapper Around the ToC <ol>
+ * We set the `column-count` on a wrapper around the <ol> so that we don't need
+ * to think about the visability of list items (numbers in this case) in the
+ * second or thrid columns.
+ */
+.table-of-contents__wrapper--multi {
+  @include wide-from(sm) {
+    column-count : 2;
+  }
+
+  @include wide-from(xl) {
+    column-count : 3;
+  }
+}
+
+/**
+ * <ol> List of Items.
+ * 1. Zero the bottom margin s.t. margins for this component only need to be set
+ *    on the root .table-of-contents <nav>.
+ */
+.table-of-contents__items {
+  margin-bottom : 0; /* 1 */
+}
+
+/**
+ * Individual <li> Item
+ * 1. Increase the font size and spacing between items to make mobile
+ *    interaction a bit easier, and tablet/monitor presentation a bit nicer.
+ */
+.table-of-contents__item {
+  font-size   : 110%;    /* 1 */
+  padding-top : .25rem;  /* 1 */
+}

--- a/dynamic/css/layout/_wireframe.scss
+++ b/dynamic/css/layout/_wireframe.scss
@@ -115,6 +115,7 @@ $content-nav-width : 14rem;
  *    original position. This is what acts as the effective padding.
  * 5. Don't include the spacer pseudo-element on "special" titles;
  *     * Front Matter <h1> title
+ *     * Table of Contents title
  */
   h1, h2, h3, h4, h5, h6 {
     &:before {             /* 1 */
@@ -131,7 +132,8 @@ $content-nav-width : 14rem;
         padding-top :  $article-padding-top-md-up;   /* 4 */
       }
     }
-    &.front-matter__title:before {              /* 5 */
+    &.front-matter__title:before,
+    &.table-of-contents__title:before {              /* 5 */
       display : none;
     }
   }

--- a/dynamic/css/main.scss
+++ b/dynamic/css/main.scss
@@ -31,6 +31,7 @@
   'components/downloads-btn.scss',
   'components/front-matter.scss',
   'components/menu-bars.scss',
+  'components/table-of-contents',
   'components/version-selector';
 
 // 6. Page-specific styles

--- a/dynamic/js/basho/anchorify-headings.coffee
+++ b/dynamic/js/basho/anchorify-headings.coffee
@@ -4,30 +4,33 @@ Heading Anchorification
 Relies on Hugo behavior; automatic generation of <h1>-<h6> 'id's.
 https://gohugo.io/extras/crossreferences/#how-to-generate-a-heading-anchor
 
-This file sets up a single onReady() call that will introspect into (nearly)
-every heading, extract that heading's pre-generated id, and wrap the heading in
-an anchor that links to the extracted id.
+This file immediately introspects into (nearly) every heading within the <main>
+element, extracts that heading's pre-generated id, and wraps the heading's
+`.innerHTML` in an anchor that links to the extracted id.
 ###
 
 
-## onReady() Executions
-## ====================
-$ ->
-  $("main").each ->
-    article = $(this)
-    headings = article.find('h1')
-      .add(article.find('h2'))
-      .add(article.find('h3'))
-      .add(article.find('h4'))
-      .add(article.find('h5'))
-      .add(article.find('h6'))
-    #TODO: Figure out if there are headings we don't want to act as links (e.g.
-    #      Table-of-Contents? Top-level titles?) and filter them out of the
-    #      `headings` list.
+## Immediate DOM Manipulations
+## ===========================
+#NB. This portion of code modifies all heading elements (<h1>-<h6>) that are
+#    children of <main>.
+#    THIS CODE MUST BE LOADED _AFTER_ THE CLOSING </main> TAG.
+$("main").each ->
+  main = $(this)
+  headings = main.find('h1')
+    .add(main.find('h2'))
+    .add(main.find('h3'))
+    .add(main.find('h4'))
+    .add(main.find('h5'))
+    .add(main.find('h6'))
+  #TODO: Figure out if there are headings we don't want to act as links (e.g.
+  #      Table-of-Contents? Top-level titles?) and filter them out of the
+  #      `headings` list. NB. This only grabs headers out of the <main> element,
+  #      so most of those are probably already out.
 
-    headings.each ->
-      that     = $(this) # Memoize the lookup.
-      id       = that.attr('id')
-      contents = that.html()
-      anchor   = "<a href=\"\##{id}\">#{contents}</a>"
-      that.html(anchor)
+  headings.each ->
+    that     = $(this) # Memoize the lookup.
+    id       = that.attr('id')
+    contents = that.html()
+    anchor   = "<a href=\"\##{id}\">#{contents}</a>"
+    that.html(anchor)

--- a/dynamic/js/basho/anchorify-headings.coffee
+++ b/dynamic/js/basho/anchorify-headings.coffee
@@ -1,0 +1,33 @@
+###
+Heading Anchorification
+=======================
+Relies on Hugo behavior; automatic generation of <h1>-<h6> 'id's.
+https://gohugo.io/extras/crossreferences/#how-to-generate-a-heading-anchor
+
+This file sets up a single onReady() call that will introspect into (nearly)
+every heading, extract that heading's pre-generated id, and wrap the heading in
+an anchor that links to the extracted id.
+###
+
+
+## onReady() Executions
+## ====================
+$ ->
+  $("main").each ->
+    article = $(this)
+    headings = article.find('h1')
+      .add(article.find('h2'))
+      .add(article.find('h3'))
+      .add(article.find('h4'))
+      .add(article.find('h5'))
+      .add(article.find('h6'))
+    #TODO: Figure out if there are headings we don't want to act as links (e.g.
+    #      Table-of-Contents? Top-level titles?) and filter them out of the
+    #      `headings` list.
+
+    headings.each ->
+      that     = $(this) # Memoize the lookup.
+      id       = that.attr('id')
+      contents = that.html()
+      anchor   = "<a href=\"\##{id}\">#{contents}</a>"
+      that.html(anchor)

--- a/dynamic/js/basho/toc-generator.coffee
+++ b/dynamic/js/basho/toc-generator.coffee
@@ -1,0 +1,45 @@
+###
+Table of Contents Generation
+============================
+Assumes that <h1>-<h6> elements wrap anchor elements (anchorify-headings.coffee
+does exactly that).
+
+This file sets up a single onReady() call that will introspect into (nearly)
+every heading, extract that heading's contents (making the assumption that the
+content is an anchor element), and construct a Table of Contents.
+###
+
+## onReady() Executions
+## ====================
+$ ->
+  $("main").each ->
+    toc = $(".table-of-contents")
+
+    # Early out in case `$display_toc == false`
+    return if toc.length == 0
+
+    h2s = $(this).find('h2')
+
+    # Early out in case there are fewer than 3 <h2> elements
+    return if h2s.length < 3
+
+    # Build DOM elements in JQuery, to be appended later.
+    toc_title   = $('<h3 class="table-of-contents__title">Contents</h3>')
+    toc_wrapper = $('<div class="table-of-contents__wrapper"/>')
+    toc_items   = $('<ol class ="table-of-contents__items"/>')
+
+    toc_wrapper.addClass("table-of-contents__wrapper--multi") if h2s.length >= 6
+
+    h2s.each ->
+      # Because this is being run after anchors have been applied to all
+      # header elements on the page, the `$(this).html()` will include the
+      # correct anchor.
+      content = $(this).html()
+      toc_items.append($("<li/>", {
+            class: "table-of-contents__item",
+            html:  $(this).html()
+          }))
+
+    toc_title.appendTo(toc)
+    toc_items.appendTo(toc_wrapper)
+    toc_wrapper.appendTo(toc)

--- a/dynamic/js/basho/toc-generator.coffee
+++ b/dynamic/js/basho/toc-generator.coffee
@@ -4,42 +4,48 @@ Table of Contents Generation
 Assumes that <h1>-<h6> elements wrap anchor elements (anchorify-headings.coffee
 does exactly that).
 
-This file sets up a single onReady() call that will introspect into (nearly)
-every heading, extract that heading's contents (making the assumption that the
-content is an anchor element), and construct a Table of Contents.
+This file immediately introspects into (nearly) every heading, extracts that
+heading's `.innerHTML` (making the assumption that the content is an anchor
+element), and construct a Table of Contents out of that content.
 ###
 
-## onReady() Executions
-## ====================
-$ ->
-  $("main").each ->
-    toc = $(".table-of-contents")
+## Immediate DOM Manipulations
+## ===========================
+#NB. This portion of code modifies the .table-of-contents element, and relies on
+#    all heading elements (<h1>-<h6>) that are children of the <main> element
+#    having already been created.
+#    THIS CODE MUST BE LOADED _AFTER_ THE CLOSING </main> TAG.
+$("main").each ->
+  toc = $(".table-of-contents")
 
-    # Early out in case `$display_toc == false`
-    return if toc.length == 0
+  # Early out in case the .table-of-contents element isn't present for
+  # modification (in case `$display_toc == false`).
+  return if toc.length == 0
 
-    h2s = $(this).find('h2')
+  h2s = $(this).find('h2')
 
-    # Early out in case there are fewer than 3 <h2> elements
-    return if h2s.length < 3
+  # Early out in case there are fewer than 3 <h2> elements
+  #TODO: Figure out if we should be removing the .table-of-contents element
+  #      here, of if an empty one doesn't influence the flow at all.
+  return if h2s.length < 3
 
-    # Build DOM elements in JQuery, to be appended later.
-    toc_title   = $('<h3 class="table-of-contents__title">Contents</h3>')
-    toc_wrapper = $('<div class="table-of-contents__wrapper"/>')
-    toc_items   = $('<ol class ="table-of-contents__items"/>')
+  # Build DOM elements in JQuery, to be appended later.
+  toc_title   = $('<h3 class="table-of-contents__title">Contents</h3>')
+  toc_wrapper = $('<div class="table-of-contents__wrapper"/>')
+  toc_items   = $('<ol class ="table-of-contents__items"/>')
 
-    toc_wrapper.addClass("table-of-contents__wrapper--multi") if h2s.length >= 6
+  toc_wrapper.addClass("table-of-contents__wrapper--multi") if h2s.length >= 6
 
-    h2s.each ->
-      # Because this is being run after anchors have been applied to all
-      # header elements on the page, the `$(this).html()` will include the
-      # correct anchor.
-      content = $(this).html()
-      toc_items.append($("<li/>", {
-            class: "table-of-contents__item",
-            html:  $(this).html()
-          }))
+  h2s.each ->
+    # Because this is being run after anchors have been applied to all
+    # header elements on the page, the `$(this).html()` will include the
+    # correct anchor.
+    content = $(this).html()
+    toc_items.append($("<li/>", {
+          class: "table-of-contents__item",
+          html:  $(this).html()
+        }))
 
-    toc_title.appendTo(toc)
-    toc_items.appendTo(toc_wrapper)
-    toc_wrapper.appendTo(toc)
+  toc_title.appendTo(toc)
+  toc_items.appendTo(toc_wrapper)
+  toc_wrapper.appendTo(toc)

--- a/dynamic/js/basho/toc-generator.coffee
+++ b/dynamic/js/basho/toc-generator.coffee
@@ -1,51 +1,45 @@
 ###
 Table of Contents Generation
 ============================
-Assumes that <h1>-<h6> elements wrap anchor elements (anchorify-headings.coffee
-does exactly that).
+This file immediately (not waiting for an on-ready events) introspects into all
+<h2> headings, extracts their `.innerHTML` content, and construct a Table of
+Contents out of that content.
 
-This file immediately introspects into (nearly) every heading, extracts that
-heading's `.innerHTML` (making the assumption that the content is an anchor
-element), and construct a Table of Contents out of that content.
+This file makes the assumption that all header elements have been given a unique
+ID (likely by Hugo) and been modified to wrap anchors that link to the given
+header ID.
+
+THIS FILE RELIES ON anchorify-headings.coffee
+THIS CODE MUST BE LOADED _AFTER_ THE CLOSING </main> TAG.
 ###
 
 ## Immediate DOM Manipulations
 ## ===========================
-#NB. This portion of code modifies the .table-of-contents element, and relies on
-#    all heading elements (<h1>-<h6>) that are children of the <main> element
-#    having already been created.
-#    THIS CODE MUST BE LOADED _AFTER_ THE CLOSING </main> TAG.
-$("main").each ->
-  toc = $(".table-of-contents")
 
-  # Early out in case the .table-of-contents element isn't present for
-  # modification (in case `$display_toc == false`).
-  return if toc.length == 0
+# Find the .table-of-contents element and early out in case it isn't present
+# (e.g. in case `$display_toc == false` in the Hugo template).
+toc = $(".table-of-contents")
+return if not toc.length
 
-  h2s = $(this).find('h2')
+# Finda all h2 elements and early out if there are fewer than 3 of them.
+h2s = $('main').find('h2')
+return if h2s.length < 3
 
-  # Early out in case there are fewer than 3 <h2> elements
-  #TODO: Figure out if we should be removing the .table-of-contents element
-  #      here, of if an empty one doesn't influence the flow at all.
-  return if h2s.length < 3
+# Build DOM elements in JQuery, to be appended later.
+toc_title   = $('<h3 class="table-of-contents__title">Contents</h3>')
+toc_wrapper = $('<div class="table-of-contents__wrapper"/>')
+toc_items   = $('<ol class ="table-of-contents__items"/>').appendTo(toc_wrapper)
 
-  # Build DOM elements in JQuery, to be appended later.
-  toc_title   = $('<h3 class="table-of-contents__title">Contents</h3>')
-  toc_wrapper = $('<div class="table-of-contents__wrapper"/>')
-  toc_items   = $('<ol class ="table-of-contents__items"/>')
+toc_wrapper.addClass("table-of-contents__wrapper--multi") if h2s.length >= 6
 
-  toc_wrapper.addClass("table-of-contents__wrapper--multi") if h2s.length >= 6
+h2s.each ->
+  # Because this is being run after anchors have been applied to all
+  # header elements on the page, the `$(this).html()` will include the
+  # correct anchor.
+  toc_items.append($("<li/>", {
+        class : "table-of-contents__item",
+        html  : $(this).html()
+      }))
 
-  h2s.each ->
-    # Because this is being run after anchors have been applied to all
-    # header elements on the page, the `$(this).html()` will include the
-    # correct anchor.
-    content = $(this).html()
-    toc_items.append($("<li/>", {
-          class: "table-of-contents__item",
-          html:  $(this).html()
-        }))
-
-  toc_title.appendTo(toc)
-  toc_items.appendTo(toc_wrapper)
-  toc_wrapper.appendTo(toc)
+toc_title.appendTo(toc)
+toc_wrapper.appendTo(toc)

--- a/dynamic/js/main.js
+++ b/dynamic/js/main.js
@@ -40,4 +40,5 @@
  */
 
 //= require ./basho/anchorify-headings.js
+//= require ./basho/toc-generator.js
 //= require ./basho/version-selector.js

--- a/dynamic/js/main.js
+++ b/dynamic/js/main.js
@@ -39,4 +39,5 @@
  * Included one at a time to ensure all requirements are met
  */
 
+//= require ./basho/anchorify-headings.js
 //= require ./basho/version-selector.js

--- a/layouts/sandbox/single.html
+++ b/layouts/sandbox/single.html
@@ -193,7 +193,13 @@
 {{- /* ======================================================================================== */}}
 {{- /* END {{ partial "banner.html" $HugoNode }}                                                */}}
 {{- /* ======================================================================================== */}}
+<!-- Variable Definitions
+     ====================
+{{ $HugoNode := . }}
 
+{{ $title_supertext := .Scratch.Get "title_supertext"      }}
+{{ $display_toc     := $HugoNode.Scratch.Get "display_toc" }}
+-->
 
   <article class="main-article" style="background-color:rgba(0, 0, 127, 0.5)">
 
@@ -207,6 +213,10 @@
 {{- end }}
         {{ $title }}
       </h1>
+
+{{- if $display_toc }}
+      <nav class="table-of-contents"></nav>
+{{- end            }}
 
     </header>
 


### PR DESCRIPTION
These include the dynamically generated Table of Contents, and the JS logic that wraps <h1>-<h6> text in self-referential anchors, as well as styles for both of those features.

---

**THIS PR IS A WORK IN PROGRESS**
I've opened this as part of a set of stacked PRs so that I can more cleanly and more quickly share the work that I'm doing. Any changes made to this branch will likely come in the form of a force push, so local updates should be performed with

```
git checkout great_rework/12/basic_layout_js
git fetch origin great_rework/12/basic_layout_js
git reset origin/great_rework/12/basic_layout_js --hard
```

Please feel free to comment on anything you see here; offer suggestions, provide corrections, raise concerns. the whole point of this exercise is to engender communication.

But _**do not merge this PR**_.
