### PR TITLE
Dbrown riak ts fix

### DIFF
--- a/content/riak/ts/1.4.0/using/creating-activating.md
+++ b/content/riak/ts/1.4.0/using/creating-activating.md
@@ -118,7 +118,7 @@ sudo su riak
 This will put you in a shell as the riak user. Then run:
 
 ```sh
-riak-admin bucket-type create GeoCheckin '{"props":{"table_def": "CREATE TABLE GeoCheckin (id, SINT64 NOT NULL, region VARCHAR NOT NULL, state VARCHAR NOT NULL, time TIMESTAMP NOT NULL, weather VARCHAR NOT NULL, temperature DOUBLE, PRIMARY KEY ((id, QUANTUM(time, 15, 'm')), id, time))"}}'
+riak-admin bucket-type create GeoCheckin '{"props":{"table_def": "CREATE TABLE GeoCheckin (id SINT64 NOT NULL, region VARCHAR NOT NULL, state VARCHAR NOT NULL, time TIMESTAMP NOT NULL, weather VARCHAR NOT NULL, temperature DOUBLE, PRIMARY KEY ((id, QUANTUM(time, 15, 'm')), id, time))"}}'
 ```
 
 Please take care with the following:

--- a/content/riak/ts/1.4.0/using/creating-activating.md
+++ b/content/riak/ts/1.4.0/using/creating-activating.md
@@ -157,19 +157,17 @@ $ riak-admin bucket-type status GeoCheckin
 GeoCheckin is active
 ...
 ddl: {ddl_v1,<<"GeoCheckin">>,
-             [{riak_field_v1,<<"region">>,1,binary,false},
-              {riak_field_v1,<<"state">>,2,binary,false},
-              {riak_field_v1,<<"time">>,3,timestamp,false},
-              {riak_field_v1,<<"weather">>,4,binary,false},
-              {riak_field_v1,<<"temperature">>,5,double,true}],
-             {key_v1,[{hash_fn_v1,riak_ql_quanta,quantum,
-                                  {param_v1,[<<"region">>]},
-                      {param_v1,[<<"state">>]}]},
-                      [{param_v1,[<<"time">>]},15,m],
-                                  timestamp},
-             {key_v1,[{param_v1,[<<"time">>]},
-                      {param_v1,[<<"region">>]},
-                      {param_v1,[<<"state">>]}]}}
+             [{riak_field_v1,<<"id">>,1,sint64,false},
+              {riak_field_v1,<<"region">>,2,varchar,false},
+              {riak_field_v1,<<"state">>,3,varchar,false},
+              {riak_field_v1,<<"time">>,4,timestamp,false},
+              {riak_field_v1,<<"weather">>,5,varchar,false},
+              {riak_field_v1,<<"temperature">>,6,double,true}],
+             {key_v1,[{param_v1,[<<"id">>]},
+                      {hash_fn_v1,riak_ql_quanta,quantum,
+                                  [{param_v1,[<<"time">>]},15,m],
+                                  timestamp}]},
+             {key_v1,[{param_v1,[<<"id">>]},{param_v1,[<<"time">>]}]}}
 ```
 
 

--- a/content/riak/ts/1.4.0/using/planning.md
+++ b/content/riak/ts/1.4.0/using/planning.md
@@ -40,6 +40,7 @@ In order to create a working Riak TS table, you'll need to plan your table out. 
 CREATE TABLE GeoCheckin
 (
    id           SINT64    NOT NULL,
+   region       VARCHAR   NOT NULL,
    time         TIMESTAMP NOT NULL,
    region       VARCHAR   NOT NULL,
    state        VARCHAR   NOT NULL,

--- a/content/riak/ts/1.4.0/using/planning.md
+++ b/content/riak/ts/1.4.0/using/planning.md
@@ -41,9 +41,8 @@ CREATE TABLE GeoCheckin
 (
    id           SINT64    NOT NULL,
    region       VARCHAR   NOT NULL,
-   time         TIMESTAMP NOT NULL,
-   region       VARCHAR   NOT NULL,
    state        VARCHAR   NOT NULL,
+   time         TIMESTAMP NOT NULL,
    weather      VARCHAR   NOT NULL,
    temperature  DOUBLE,
    PRIMARY KEY (
@@ -133,6 +132,7 @@ The `PRIMARY KEY` describes both the partition key and local key. The partition 
 CREATE TABLE GeoCheckin
 (
    id           SINT64    NOT NULL,
+   region       VARCHAR   NOT NULL,
    state        VARCHAR   NOT NULL,
    time         TIMESTAMP NOT NULL,
    weather      VARCHAR   NOT NULL,

--- a/content/riak/ts/1.4.0/using/planning.md
+++ b/content/riak/ts/1.4.0/using/planning.md
@@ -214,7 +214,7 @@ The local key may also contain additional column names so long as they come afte
    )
 ```
 
-{{% note title="On Local Key Uniqueness" %}}
+{{% note title="On Key Uniqueness" %}}
 
 The Local Key in a Riak TS row is what makes that row's key/address unique from other rows.
 In the examples on this page and others we've used a composite key of
@@ -239,7 +239,7 @@ CREATE TABLE GeoCheckin
 )
 ```
 
-The omission of `region` and `state` from the key definition makes it shorter, and will also make any SQL queries shorter because we'll only need a minimum of id/time in our queries `WHERE` clauses.  
+The omission of `region` and `state` from the key definition makes it shorter, and will also make any SQL queries shorter because we'll only need a minimum of id/time in our queries `WHERE` clauses (see [Table Architecture](../../learn-about/tablearchitecture/) and [Querying Guidelines](../querying/guidelines/) for all the specifics about how different partition + local key layouts change the way you query data).  
 
 The downside to this schema is that you'll likely need to do one query per device, instead of being able to group multiple devices together based on their other defining characteristics such as region & state.
 

--- a/content/riak/ts/1.4.0/using/planning.md
+++ b/content/riak/ts/1.4.0/using/planning.md
@@ -219,7 +219,7 @@ The local key may also contain additional column names so long as they come afte
 The Local Key in a Riak TS row is what makes that row's key/address unique from other rows.
 In the examples on this page and others we've used a composite key of
 `region, state, time` because it can model different devices and groupings.  
-If you have another identifier such as an Integer (such as a device ID) that you can guarantee to be unique when combined with a timestamp, then you can have a shorter key definition.
+If you have another integer identifier, such as a device ID, you can guarantee to be unique when combined with a timestamp, then you can have a shorter key definition.
 
 The table definition for such a schema would be as follows:
 

--- a/content/riak/ts/1.4.0/using/planning.md
+++ b/content/riak/ts/1.4.0/using/planning.md
@@ -219,7 +219,7 @@ The local key may also contain additional column names so long as they come afte
 The Local Key in a Riak TS row is what makes that row's key/address unique from other rows.
 In the examples on this page and others we've used a composite key of
 `region, state, time` because it can model different devices and groupings.  
-If you have another integer identifier, such as a device ID, you can guarantee to be unique when combined with a timestamp, then you can have a shorter key definition.
+If you have another identifier, such as a device ID, that you can guarantee to be unique when combined with a timestamp, you can have a shorter key definition.
 
 The table definition for such a schema would be as follows:
 

--- a/content/riak/ts/1.4.0/using/querying/describe.md
+++ b/content/riak/ts/1.4.0/using/querying/describe.md
@@ -27,7 +27,7 @@ For example:
 DESCRIBE GeoCheckin
 ```
 
-Returns: 
+Returns:
 
 ```
 Column      | Type      | Is Null | Partition Key | Local Key | Interval | Unit
@@ -47,8 +47,8 @@ riak-shell>describe GeoCheckin;
 +-----------+---------+-------+-----------+---------+--------+----+
 |  Column   |  Type   |Is Null|Primary Key|Local Key|Interval|Unit|
 +-----------+---------+-------+-----------+---------+--------+----+
-| myfamily  | varchar | false |     1     |    1    |        |    |
-| myseries  | varchar | false |     2     |    2    |        |    |
+|  region   | varchar | false |     1     |    1    |        |    |
+|   state   | varchar | false |     2     |    2    |        |    |
 |   time    |timestamp| false |     3     |    3    |   15   | m  |
 |  weather  | varchar | false |           |         |        |    |
 |temperature| double  | true  |           |         |        |    |

--- a/content/riak/ts/1.4.0/using/querying/select.md
+++ b/content/riak/ts/1.4.0/using/querying/select.md
@@ -25,7 +25,7 @@ canonical_link: "https://docs.basho.com/riak/ts/latest/using/querying/select"
 [ISO 8601]: https://en.wikipedia.org/wiki/ISO_8601
 [learn timestamps accuracy]: /riak/ts/1.4.0/learn-about/timestamps/#reduced-accuracy
 
-You can use the SELECT statement in Riak TS to query your TS dataset. This document will show you how to run various queries using `SELECT`. 
+You can use the SELECT statement in Riak TS to query your TS dataset. This document will show you how to run various queries using `SELECT`.
 
 * See the [guidelines] for more information on limitations and rules for queries in TS.
 * See [aggregate functions] to learn how turn a set of rows in your Riak TS table into a value.


### PR DESCRIPTION
Dan noticed some things amiss with the TS example table and some of the client examples, so this PR covers:
- Removing erroneous comma causing errors when creating the GeoCheckin table.
- Update example response from status request to match the updated table creation command used for Riak TS 1.4.
- Add missing column from example table: The region column is not in this example snippet but is in most others. The inconsistency would cause issues for anyone following along.
