### PR TITLE
Add appropriate flag for downgrading to rpm command

### DIFF
--- a/content/riak/ts/1.4.0/setup/downgrading.md
+++ b/content/riak/ts/1.4.0/setup/downgrading.md
@@ -91,7 +91,7 @@ sudo tar -czf riak_backup.tar.gz /var/lib/riak /etc/riak
 3\. Downgrade Riak TS:
 
 ```bash
-sudo rpm -Uvh »riakts_package_name«.rpm
+sudo rpm -Uvh --oldpackage »riakts_package_name«.rpm
 ```
 
 4\. Restart Riak TS:


### PR DESCRIPTION
I just saw that this was necessary while doing downgrade testing on Riak KV. There are no CentOS instructions for KV, but I found the TS instructions, which needed an additional flag.