### PR TITLE
Not Quite Ready - Adding Java 2i streaming example

### DIFF
--- a/content/riak/kv/2.0.0/developing/usage/secondary-indexes.md
+++ b/content/riak/kv/2.0.0/developing/usage/secondary-indexes.md
@@ -1873,9 +1873,29 @@ The result:
 It is also possible to stream results:
 
 ```java
-/*
-  It is not currently possible to stream results using the Java client
-*/
+// Available in Riak Java Client 2.1.0 and later
+int pollTimeoutMS = 200;
+Namespace ns = new Namespace("indexes", "tweets");
+String indexName = "hashtags";
+
+BinIndexQuery indexQuery =
+    new BinIndexQuery.Builder(ns, indexName, "ri", "ru").build();
+
+final RiakFuture<BinIndexQuery.StreamingResponse, BinIndexQuery> streamingFuture =
+    client.executeAsyncStreaming(indexQuery, pollTimeoutMS);
+
+// For streaming commands, the future's value will be available before
+// the future is complete, so you may begin to pull results from the
+// provided iterator as soon as possible.
+final BinIndexQuery.StreamingResponse streamingResponse = streamingFuture.get();
+
+for (BinIndexQuery.Response.Entry e : streamingResponse)
+{
+    // Do something with key...
+}
+
+streamingFuture.await();
+Assert.assertTrue(streamingFuture.isDone());
 ```
 
 ```ruby

--- a/content/riak/kv/2.0.1/developing/usage/secondary-indexes.md
+++ b/content/riak/kv/2.0.1/developing/usage/secondary-indexes.md
@@ -1873,9 +1873,29 @@ The result:
 It is also possible to stream results:
 
 ```java
-/*
-  It is not currently possible to stream results using the Java client
-*/
+// Available in Riak Java Client 2.1.0 and later
+int pollTimeoutMS = 200;
+Namespace ns = new Namespace("indexes", "tweets");
+String indexName = "hashtags";
+
+BinIndexQuery indexQuery =
+    new BinIndexQuery.Builder(ns, indexName, "ri", "ru").build();
+
+final RiakFuture<BinIndexQuery.StreamingResponse, BinIndexQuery> streamingFuture =
+    client.executeAsyncStreaming(indexQuery, pollTimeoutMS);
+
+// For streaming commands, the future's value will be available before
+// the future is complete, so you may begin to pull results from the
+// provided iterator as soon as possible.
+final BinIndexQuery.StreamingResponse streamingResponse = streamingFuture.get();
+
+for (BinIndexQuery.Response.Entry e : streamingResponse)
+{
+    // Do something with key...
+}
+
+streamingFuture.await();
+Assert.assertTrue(streamingFuture.isDone());
 ```
 
 ```ruby

--- a/content/riak/kv/2.0.2/developing/usage/secondary-indexes.md
+++ b/content/riak/kv/2.0.2/developing/usage/secondary-indexes.md
@@ -1872,9 +1872,29 @@ The result:
 It is also possible to stream results:
 
 ```java
-/*
-  It is not currently possible to stream results using the Java client
-*/
+// Available in Riak Java Client 2.1.0 and later
+int pollTimeoutMS = 200;
+Namespace ns = new Namespace("indexes", "tweets");
+String indexName = "hashtags";
+
+BinIndexQuery indexQuery =
+    new BinIndexQuery.Builder(ns, indexName, "ri", "ru").build();
+
+final RiakFuture<BinIndexQuery.StreamingResponse, BinIndexQuery> streamingFuture =
+    client.executeAsyncStreaming(indexQuery, pollTimeoutMS);
+
+// For streaming commands, the future's value will be available before
+// the future is complete, so you may begin to pull results from the
+// provided iterator as soon as possible.
+final BinIndexQuery.StreamingResponse streamingResponse = streamingFuture.get();
+
+for (BinIndexQuery.Response.Entry e : streamingResponse)
+{
+    // Do something with key...
+}
+
+streamingFuture.await();
+Assert.assertTrue(streamingFuture.isDone());
 ```
 
 ```ruby

--- a/content/riak/kv/2.0.4/developing/usage/secondary-indexes.md
+++ b/content/riak/kv/2.0.4/developing/usage/secondary-indexes.md
@@ -1873,9 +1873,29 @@ The result:
 It is also possible to stream results:
 
 ```java
-/*
-  It is not currently possible to stream results using the Java client
-*/
+// Available in Riak Java Client 2.1.0 and later
+int pollTimeoutMS = 200;
+Namespace ns = new Namespace("indexes", "tweets");
+String indexName = "hashtags";
+
+BinIndexQuery indexQuery =
+    new BinIndexQuery.Builder(ns, indexName, "ri", "ru").build();
+
+final RiakFuture<BinIndexQuery.StreamingResponse, BinIndexQuery> streamingFuture =
+    client.executeAsyncStreaming(indexQuery, pollTimeoutMS);
+
+// For streaming commands, the future's value will be available before
+// the future is complete, so you may begin to pull results from the
+// provided iterator as soon as possible.
+final BinIndexQuery.StreamingResponse streamingResponse = streamingFuture.get();
+
+for (BinIndexQuery.Response.Entry e : streamingResponse)
+{
+    // Do something with key...
+}
+
+streamingFuture.await();
+Assert.assertTrue(streamingFuture.isDone());
 ```
 
 ```ruby

--- a/content/riak/kv/2.0.5/developing/usage/secondary-indexes.md
+++ b/content/riak/kv/2.0.5/developing/usage/secondary-indexes.md
@@ -1873,9 +1873,29 @@ The result:
 It is also possible to stream results:
 
 ```java
-/*
-  It is not currently possible to stream results using the Java client
-*/
+// Available in Riak Java Client 2.1.0 and later
+int pollTimeoutMS = 200;
+Namespace ns = new Namespace("indexes", "tweets");
+String indexName = "hashtags";
+
+BinIndexQuery indexQuery =
+    new BinIndexQuery.Builder(ns, indexName, "ri", "ru").build();
+
+final RiakFuture<BinIndexQuery.StreamingResponse, BinIndexQuery> streamingFuture =
+    client.executeAsyncStreaming(indexQuery, pollTimeoutMS);
+
+// For streaming commands, the future's value will be available before
+// the future is complete, so you may begin to pull results from the
+// provided iterator as soon as possible.
+final BinIndexQuery.StreamingResponse streamingResponse = streamingFuture.get();
+
+for (BinIndexQuery.Response.Entry e : streamingResponse)
+{
+    // Do something with key...
+}
+
+streamingFuture.await();
+Assert.assertTrue(streamingFuture.isDone());
 ```
 
 ```ruby

--- a/content/riak/kv/2.0.6/developing/usage/secondary-indexes.md
+++ b/content/riak/kv/2.0.6/developing/usage/secondary-indexes.md
@@ -1873,9 +1873,29 @@ The result:
 It is also possible to stream results:
 
 ```java
-/*
-  It is not currently possible to stream results using the Java client
-*/
+// Available in Riak Java Client 2.1.0 and later
+int pollTimeoutMS = 200;
+Namespace ns = new Namespace("indexes", "tweets");
+String indexName = "hashtags";
+
+BinIndexQuery indexQuery =
+    new BinIndexQuery.Builder(ns, indexName, "ri", "ru").build();
+
+final RiakFuture<BinIndexQuery.StreamingResponse, BinIndexQuery> streamingFuture =
+    client.executeAsyncStreaming(indexQuery, pollTimeoutMS);
+
+// For streaming commands, the future's value will be available before
+// the future is complete, so you may begin to pull results from the
+// provided iterator as soon as possible.
+final BinIndexQuery.StreamingResponse streamingResponse = streamingFuture.get();
+
+for (BinIndexQuery.Response.Entry e : streamingResponse)
+{
+    // Do something with key...
+}
+
+streamingFuture.await();
+Assert.assertTrue(streamingFuture.isDone());
 ```
 
 ```ruby

--- a/content/riak/kv/2.0.7/developing/usage/secondary-indexes.md
+++ b/content/riak/kv/2.0.7/developing/usage/secondary-indexes.md
@@ -1873,9 +1873,29 @@ The result:
 It is also possible to stream results:
 
 ```java
-/*
-  It is not currently possible to stream results using the Java client
-*/
+// Available in Riak Java Client 2.1.0 and later
+int pollTimeoutMS = 200;
+Namespace ns = new Namespace("indexes", "tweets");
+String indexName = "hashtags";
+
+BinIndexQuery indexQuery =
+    new BinIndexQuery.Builder(ns, indexName, "ri", "ru").build();
+
+final RiakFuture<BinIndexQuery.StreamingResponse, BinIndexQuery> streamingFuture =
+    client.executeAsyncStreaming(indexQuery, pollTimeoutMS);
+
+// For streaming commands, the future's value will be available before
+// the future is complete, so you may begin to pull results from the
+// provided iterator as soon as possible.
+final BinIndexQuery.StreamingResponse streamingResponse = streamingFuture.get();
+
+for (BinIndexQuery.Response.Entry e : streamingResponse)
+{
+    // Do something with key...
+}
+
+streamingFuture.await();
+Assert.assertTrue(streamingFuture.isDone());
 ```
 
 ```ruby

--- a/content/riak/kv/2.1.1/developing/usage/secondary-indexes.md
+++ b/content/riak/kv/2.1.1/developing/usage/secondary-indexes.md
@@ -1873,9 +1873,29 @@ The result:
 It is also possible to stream results:
 
 ```java
-/*
-  It is not currently possible to stream results using the Java client
-*/
+// Available in Riak Java Client 2.1.0 and later
+int pollTimeoutMS = 200;
+Namespace ns = new Namespace("indexes", "tweets");
+String indexName = "hashtags";
+
+BinIndexQuery indexQuery =
+    new BinIndexQuery.Builder(ns, indexName, "ri", "ru").build();
+
+final RiakFuture<BinIndexQuery.StreamingResponse, BinIndexQuery> streamingFuture =
+    client.executeAsyncStreaming(indexQuery, pollTimeoutMS);
+
+// For streaming commands, the future's value will be available before
+// the future is complete, so you may begin to pull results from the
+// provided iterator as soon as possible.
+final BinIndexQuery.StreamingResponse streamingResponse = streamingFuture.get();
+
+for (BinIndexQuery.Response.Entry e : streamingResponse)
+{
+    // Do something with key...
+}
+
+streamingFuture.await();
+Assert.assertTrue(streamingFuture.isDone());
 ```
 
 ```ruby

--- a/content/riak/kv/2.1.3/developing/usage/secondary-indexes.md
+++ b/content/riak/kv/2.1.3/developing/usage/secondary-indexes.md
@@ -1873,9 +1873,29 @@ The result:
 It is also possible to stream results:
 
 ```java
-/*
-  It is not currently possible to stream results using the Java client
-*/
+// Available in Riak Java Client 2.1.0 and later
+int pollTimeoutMS = 200;
+Namespace ns = new Namespace("indexes", "tweets");
+String indexName = "hashtags";
+
+BinIndexQuery indexQuery =
+    new BinIndexQuery.Builder(ns, indexName, "ri", "ru").build();
+
+final RiakFuture<BinIndexQuery.StreamingResponse, BinIndexQuery> streamingFuture =
+    client.executeAsyncStreaming(indexQuery, pollTimeoutMS);
+
+// For streaming commands, the future's value will be available before
+// the future is complete, so you may begin to pull results from the
+// provided iterator as soon as possible.
+final BinIndexQuery.StreamingResponse streamingResponse = streamingFuture.get();
+
+for (BinIndexQuery.Response.Entry e : streamingResponse)
+{
+    // Do something with key...
+}
+
+streamingFuture.await();
+Assert.assertTrue(streamingFuture.isDone());
 ```
 
 ```ruby

--- a/content/riak/kv/2.1.4/developing/usage/secondary-indexes.md
+++ b/content/riak/kv/2.1.4/developing/usage/secondary-indexes.md
@@ -1873,9 +1873,29 @@ The result:
 It is also possible to stream results:
 
 ```java
-/*
-  It is not currently possible to stream results using the Java client
-*/
+// Available in Riak Java Client 2.1.0 and later
+int pollTimeoutMS = 200;
+Namespace ns = new Namespace("indexes", "tweets");
+String indexName = "hashtags";
+
+BinIndexQuery indexQuery =
+    new BinIndexQuery.Builder(ns, indexName, "ri", "ru").build();
+
+final RiakFuture<BinIndexQuery.StreamingResponse, BinIndexQuery> streamingFuture =
+    client.executeAsyncStreaming(indexQuery, pollTimeoutMS);
+
+// For streaming commands, the future's value will be available before
+// the future is complete, so you may begin to pull results from the
+// provided iterator as soon as possible.
+final BinIndexQuery.StreamingResponse streamingResponse = streamingFuture.get();
+
+for (BinIndexQuery.Response.Entry e : streamingResponse)
+{
+    // Do something with key...
+}
+
+streamingFuture.await();
+Assert.assertTrue(streamingFuture.isDone());
 ```
 
 ```ruby


### PR DESCRIPTION
Adding streaming 2i example for Java client, applies to any 2.0+ Riak. 
Ready for review, but will not be ready for merging until the Java client PR is complete.

x-ref: basho/riak-java-client#677
