### PR TITLE
Fix DOC-695 - force-replace command typo

### DIFF
--- a/content/riak/kv/2.0.0/using/admin/commands.md
+++ b/content/riak/kv/2.0.0/using/admin/commands.md
@@ -186,7 +186,7 @@ Reassigns all [data partitions][concept clusters] owned by one node to
 another node _without_ first handing off data.
 
 ```bash
-riak-admin force-replace <node_being_replaced> <replacement_node>
+riak-admin cluster force-replace <node_being_replaced> <replacement_node>
 ```
 
 Once the data partitions have been reassigned, the node that is being

--- a/content/riak/kv/2.0.0/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.0.0/using/cluster-operations/changing-cluster-info.md
@@ -303,7 +303,7 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
 <div class="note"><div class="title">Note</div>
-When using the `riak-admin force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
+When using the `riak-admin cluster force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
 </div>
 
 <a id="repeat"></a>

--- a/content/riak/kv/2.0.1/using/admin/commands.md
+++ b/content/riak/kv/2.0.1/using/admin/commands.md
@@ -186,7 +186,7 @@ Reassigns all [data partitions][concept clusters] owned by one node to
 another node _without_ first handing off data.
 
 ```bash
-riak-admin force-replace <node_being_replaced> <replacement_node>
+riak-admin cluster force-replace <node_being_replaced> <replacement_node>
 ```
 
 Once the data partitions have been reassigned, the node that is being

--- a/content/riak/kv/2.0.1/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.0.1/using/cluster-operations/changing-cluster-info.md
@@ -303,7 +303,7 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
 <div class="note"><div class="title">Note</div>
-When using the `riak-admin force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
+When using the `riak-admin cluster force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
 </div>
 
 <a id="repeat"></a>

--- a/content/riak/kv/2.0.2/using/admin/commands.md
+++ b/content/riak/kv/2.0.2/using/admin/commands.md
@@ -185,7 +185,7 @@ Reassigns all [data partitions][concept clusters] owned by one node to
 another node _without_ first handing off data.
 
 ```bash
-riak-admin force-replace <node_being_replaced> <replacement_node>
+riak-admin cluster force-replace <node_being_replaced> <replacement_node>
 ```
 
 Once the data partitions have been reassigned, the node that is being

--- a/content/riak/kv/2.0.2/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.0.2/using/cluster-operations/changing-cluster-info.md
@@ -303,7 +303,7 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
 <div class="note"><div class="title">Note</div>
-When using the `riak-admin force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
+When using the `riak-admin cluster force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
 </div>
 
 <a id="repeat"></a>

--- a/content/riak/kv/2.0.4/using/admin/commands.md
+++ b/content/riak/kv/2.0.4/using/admin/commands.md
@@ -186,7 +186,7 @@ Reassigns all [data partitions][concept clusters] owned by one node to
 another node _without_ first handing off data.
 
 ```bash
-riak-admin force-replace <node_being_replaced> <replacement_node>
+riak-admin cluster force-replace <node_being_replaced> <replacement_node>
 ```
 
 Once the data partitions have been reassigned, the node that is being

--- a/content/riak/kv/2.0.4/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.0.4/using/cluster-operations/changing-cluster-info.md
@@ -303,7 +303,7 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
 <div class="note"><div class="title">Note</div>
-When using the `riak-admin force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
+When using the `riak-admin cluster force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
 </div>
 
 <a id="repeat"></a>

--- a/content/riak/kv/2.0.5/using/admin/commands.md
+++ b/content/riak/kv/2.0.5/using/admin/commands.md
@@ -186,7 +186,7 @@ Reassigns all [data partitions][concept clusters] owned by one node to
 another node _without_ first handing off data.
 
 ```bash
-riak-admin force-replace <node_being_replaced> <replacement_node>
+riak-admin cluster force-replace <node_being_replaced> <replacement_node>
 ```
 
 Once the data partitions have been reassigned, the node that is being

--- a/content/riak/kv/2.0.5/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.0.5/using/cluster-operations/changing-cluster-info.md
@@ -303,7 +303,7 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
 <div class="note"><div class="title">Note</div>
-When using the `riak-admin force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
+When using the `riak-admin cluster force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
 </div>
 
 <a id="repeat"></a>

--- a/content/riak/kv/2.0.6/using/admin/commands.md
+++ b/content/riak/kv/2.0.6/using/admin/commands.md
@@ -186,7 +186,7 @@ Reassigns all [data partitions][concept clusters] owned by one node to
 another node _without_ first handing off data.
 
 ```bash
-riak-admin force-replace <node_being_replaced> <replacement_node>
+riak-admin cluster force-replace <node_being_replaced> <replacement_node>
 ```
 
 Once the data partitions have been reassigned, the node that is being

--- a/content/riak/kv/2.0.6/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.0.6/using/cluster-operations/changing-cluster-info.md
@@ -303,7 +303,7 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
 <div class="note"><div class="title">Note</div>
-When using the `riak-admin force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
+When using the `riak-admin cluster force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
 </div>
 
 <a id="repeat"></a>

--- a/content/riak/kv/2.0.7/using/admin/commands.md
+++ b/content/riak/kv/2.0.7/using/admin/commands.md
@@ -186,7 +186,7 @@ Reassigns all [data partitions][concept clusters] owned by one node to
 another node _without_ first handing off data.
 
 ```bash
-riak-admin force-replace <node_being_replaced> <replacement_node>
+riak-admin cluster force-replace <node_being_replaced> <replacement_node>
 ```
 
 Once the data partitions have been reassigned, the node that is being

--- a/content/riak/kv/2.0.7/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.0.7/using/cluster-operations/changing-cluster-info.md
@@ -303,7 +303,7 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
 <div class="note"><div class="title">Note</div>
-When using the `riak-admin force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
+When using the `riak-admin cluster force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
 </div>
 
 <a id="repeat"></a>

--- a/content/riak/kv/2.1.1/using/admin/commands.md
+++ b/content/riak/kv/2.1.1/using/admin/commands.md
@@ -186,7 +186,7 @@ Reassigns all [data partitions][concept clusters] owned by one node to
 another node _without_ first handing off data.
 
 ```bash
-riak-admin force-replace <node_being_replaced> <replacement_node>
+riak-admin cluster force-replace <node_being_replaced> <replacement_node>
 ```
 
 Once the data partitions have been reassigned, the node that is being

--- a/content/riak/kv/2.1.1/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.1.1/using/cluster-operations/changing-cluster-info.md
@@ -303,7 +303,7 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
 <div class="note"><div class="title">Note</div>
-When using the `riak-admin force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
+When using the `riak-admin cluster force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
 </div>
 
 <a id="repeat"></a>

--- a/content/riak/kv/2.1.3/using/admin/commands.md
+++ b/content/riak/kv/2.1.3/using/admin/commands.md
@@ -186,7 +186,7 @@ Reassigns all [data partitions][concept clusters] owned by one node to
 another node _without_ first handing off data.
 
 ```bash
-riak-admin force-replace <node_being_replaced> <replacement_node>
+riak-admin cluster force-replace <node_being_replaced> <replacement_node>
 ```
 
 Once the data partitions have been reassigned, the node that is being

--- a/content/riak/kv/2.1.3/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.1.3/using/cluster-operations/changing-cluster-info.md
@@ -303,7 +303,7 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
 <div class="note"><div class="title">Note</div>
-When using the `riak-admin force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
+When using the `riak-admin cluster force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
 </div>
 
 <a id="repeat"></a>

--- a/content/riak/kv/2.1.4/using/admin/commands.md
+++ b/content/riak/kv/2.1.4/using/admin/commands.md
@@ -186,7 +186,7 @@ Reassigns all [data partitions][concept clusters] owned by one node to
 another node _without_ first handing off data.
 
 ```bash
-riak-admin force-replace <node_being_replaced> <replacement_node>
+riak-admin cluster force-replace <node_being_replaced> <replacement_node>
 ```
 
 Once the data partitions have been reassigned, the node that is being

--- a/content/riak/kv/2.1.4/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.1.4/using/cluster-operations/changing-cluster-info.md
@@ -303,7 +303,7 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
 <div class="note"><div class="title">Note</div>
-When using the `riak-admin force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
+When using the `riak-admin cluster force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
 </div>
 
 <a id="repeat"></a>


### PR DESCRIPTION
`riak-admin force-replace` should be `riak-admin cluster
force-replace`

Fixes Issue #2272 (DOC-695) 