### PR TITLE
Remove incorrect information and point to correct information

### DIFF
--- a/content/riak/kv/2.0.7/using/repair-recovery/failure-recovery.md
+++ b/content/riak/kv/2.0.7/using/repair-recovery/failure-recovery.md
@@ -113,39 +113,10 @@ timeouts simply because many other requests are being serviced as well. Adding
 nodes to the cluster can reduce MapReduce failure in the long term by
 spreading load and increasing available CPU and IOPS.
 
+
 ## Cluster Recovery From Backups
-The general procedure for recovering a cluster from catastrophic failure
-involves:
 
-> **Note**
->
-> If you are restoring in an environment where the new nodes will have new network addresses (such as with AWS for example) or you will otherwise need to give the nodes new names, you will need to rename the nodes in the cluster.  After performing steps 1-8, use the instructions in the [Renaming Nodes](/riak/kv/2.0.7/using/cluster-operations/changing-cluster-info) document to finish restoring this cluster.
-
-1. Establish replacement cluster configured with the same number of nodes.
-2. Restore the Riak configuration on each of the nodes.
-3. Ensure that Riak is not running on any of the nodes.
-4. Remove any previous Riak data (e.g., from `/var/lib/riak`) to ensure that
-   the node is started with no data present.
-5. Restore the backup data to each node's data root (e.g, `/var/lib/riak`).
-6. If you are restoring in an environment where the new nodes will have new
-   network addresses (such as on AWS) or you will otherwise need to give the
-   nodes new names, you need to execute `riak-admin replace` to change the network name for every node in the cluster from each node.
-7. After renaming the nodes with `riak-admin replace` if necessary, you should
-   check the `vm.args` configuration file to ensure that each node has the
-   updated name.
-8. Make sure the [firewall settings](/riak/kv/2.0.7/using/security/) for the new
-   nodes allow the same traffic that was permitted between the old nodes.
-   The first node will not be able to start up if attempts to contact the
-   other down nodes hang instead of being refused.
-9. Start the first node and check that its name is correct; one way to do
-   this is to start the node, then attach to the node with `riak attach`.
-   You should see the node name as part of the prompt as in the example
-   below. Once you've verified the correct node name, exit the console
-   with CTRL-D.
-10. Execute `riak-admin member-status` on the node and verify that it
-   returns expected output.
-11. Start each of the remaining nodes, verifying the details in the same
-    manner as the first node.
+See [Changing Cluster Information](/riak/kv/2.1.4/using/cluster-operations/changing-cluster-info/#clusters-from-backups) for instructions on cluster recovery.
 
 <div class="info">
 <div class="title">Tip</div> If you are a licensed Riak Enterprise or CS customer and require assistance or further advice with a cluster recovery, please file a ticket with the <a href="https://help.basho.com">Basho Helpdesk</a>.

--- a/content/riak/kv/2.1.4/using/repair-recovery/failure-recovery.md
+++ b/content/riak/kv/2.1.4/using/repair-recovery/failure-recovery.md
@@ -114,38 +114,8 @@ nodes to the cluster can reduce MapReduce failure in the long term by
 spreading load and increasing available CPU and IOPS.
 
 ## Cluster Recovery From Backups
-The general procedure for recovering a cluster from catastrophic failure
-involves:
 
-> **Note**
->
-> If you are restoring in an environment where the new nodes will have new network addresses (such as with AWS for example) or you will otherwise need to give the nodes new names, you will need to rename the nodes in the cluster.  After performing steps 1-8, use the instructions in the [Renaming Nodes](/riak/kv/2.1.4/using/cluster-operations/changing-cluster-info) document to finish restoring this cluster.
-
-1. Establish replacement cluster configured with the same number of nodes.
-2. Restore the Riak configuration on each of the nodes.
-3. Ensure that Riak is not running on any of the nodes.
-4. Remove any previous Riak data (e.g., from `/var/lib/riak`) to ensure that
-   the node is started with no data present.
-5. Restore the backup data to each node's data root (e.g, `/var/lib/riak`).
-6. If you are restoring in an environment where the new nodes will have new
-   network addresses (such as on AWS) or you will otherwise need to give the
-   nodes new names, you need to execute `riak-admin replace` to change the network name for every node in the cluster from each node.
-7. After renaming the nodes with `riak-admin replace` if necessary, you should
-   check the `vm.args` configuration file to ensure that each node has the
-   updated name.
-8. Make sure the [firewall settings](/riak/kv/2.1.4/using/security/) for the new
-   nodes allow the same traffic that was permitted between the old nodes.
-   The first node will not be able to start up if attempts to contact the
-   other down nodes hang instead of being refused.
-9. Start the first node and check that its name is correct; one way to do
-   this is to start the node, then attach to the node with `riak attach`.
-   You should see the node name as part of the prompt as in the example
-   below. Once you've verified the correct node name, exit the console
-   with CTRL-D.
-10. Execute `riak-admin member-status` on the node and verify that it
-   returns expected output.
-11. Start each of the remaining nodes, verifying the details in the same
-    manner as the first node.
+See [Changing Cluster Information](/riak/kv/2.1.4/using/cluster-operations/changing-cluster-info/#clusters-from-backups) for instructions on cluster recovery.
 
 <div class="info">
 <div class="title">Tip</div> If you are a licensed Riak Enterprise or CS customer and require assistance or further advice with a cluster recovery, please file a ticket with the <a href="https://help.basho.com">Basho Helpdesk</a>.

--- a/content/riak/ts/1.4.0/index.md
+++ b/content/riak/ts/1.4.0/index.md
@@ -22,6 +22,7 @@ canonical_link: "https://docs.basho.com/riak/ts/latest"
 [querying]: using/querying/
 [supported clients]: developing/
 
+Make some change.
 
 Riak TS is a distributed NoSQL key/value store optimized for time series data. With TS, you can associate a number of data points with a specific point in time. TS uses discrete slices of time to co-locate data. For example, humidity and temperature readings from a meter reported during the same slice of time will be stored together on disk.
 

--- a/content/riak/ts/1.4.0/index.md
+++ b/content/riak/ts/1.4.0/index.md
@@ -22,7 +22,6 @@ canonical_link: "https://docs.basho.com/riak/ts/latest"
 [querying]: using/querying/
 [supported clients]: developing/
 
-Make some change.
 
 Riak TS is a distributed NoSQL key/value store optimized for time series data. With TS, you can associate a number of data points with a specific point in time. TS uses discrete slices of time to co-locate data. For example, humidity and temperature readings from a meter reported during the same slice of time will be stored together on disk.
 


### PR DESCRIPTION
Per @nerophon, the information in /repair-recovery/failure-recovery is incorrect, but the information in /cluster-operations/changing-cluster-info/ is correct. Updated the former to point to the latter (for now).