### PR TITLE
Replaced assert() with print_r()

### DIFF
--- a/content/riak/kv/2.1.4/developing/getting-started/php/crud-operations.md
+++ b/content/riak/kv/2.1.4/developing/getting-started/php/crud-operations.md
@@ -75,9 +75,9 @@ $response3 = (new Command\Builder\FetchObject($riak))
                 ->build()
                 ->execute();
 
-assert($val1 == $response1->getObject()->getData());
-assert($val2 == $response2->getObject()->getData());
-assert($val3 == $response3->getObject()->getData());
+print_r($response1->getObject()->getData());
+print_r($response2->getObject()->getData());
+print_r($response3->getObject()->getData());
 ```
 
 That was easy.  We create a [Fetch Command](http://basho.github.io/riak-php-client/class-Basho.Riak.Command.Object.Fetch.html) from a [FetchObject Builder](http://basho.github.io/riak-php-client/class-Basho.Riak.Command.Builder.FetchObject.html). 


### PR DESCRIPTION
Since `assert()` was not showing anything, a simpler representation of the output would be to just print it via `print_r()`. 

Fix for issue https://github.com/basho/basho_docs/issues/2289