### PR TITLE
Correct Process

### DIFF
--- a/content/riak/kv/2.2.0/setup/downgrade.md
+++ b/content/riak/kv/2.2.0/setup/downgrade.md
@@ -163,7 +163,7 @@ Once both riak-admin aae-status and riak-admin search aae-status show values in 
 11\. If you chose not to increase the AAE concurrency via configuration and want to start Yokozuna without restarting the node, run `riak attach` and enter the following snippet:
 
 ```erlang
-riak_core_node_watcher:service_up(yokozuna, self()).
+riak_core_node_watcher:service_up(yokozuna,whereis(yz_solr_proc)).
 ```
     
 12\. Exit the attach session by pressing **Ctrl-G** then **q**.


### PR DESCRIPTION
Correct the upgrade/downgrade documentation process.  Particularly, replace the command that brings the Yokozuna service back up on a node after the AAE trees have been rebuilt.  The current command binds the pid to the `riak attach` shell rather than the Yokozuna process which causes the process to be unintentionally down'ed again when the shell is exited.