### PR TITLE
Ease consultation of HTTP data types API for advanced users

### DIFF
--- a/content/riak/kv/2.2.0/developing/api/http.md
+++ b/content/riak/kv/2.2.0/developing/api/http.md
@@ -46,9 +46,18 @@ Method | URL | Doc
 
 ## Riak-Data-Type-related Operations
 
+Method | URL
+:------|:----
+`GET` | `/types/<type>/buckets/<bucket>/datatypes/<key>`
+`POST` | `/types/<type>/buckets/<bucket>/datatypes`
+`POST` | `/types/<type>/buckets/<bucket>/datatypes/<key>`
+
 For documentation on the HTTP API for [Riak Data Types](/riak/kv/2.2.0/learn/concepts/crdts),
 see the `curl` examples in [Using Data Types](/riak/kv/2.2.0/developing/data-types/#usage-examples)
 and subpages e.g. [sets](/riak/kv/2.2.0/developing/data-types/sets).
+
+Advanced users may consult the technical documentation inside the Riak
+KV internal module `riak_kv_wm_crdt`.
 
 ## Query-related Operations
 


### PR DESCRIPTION
See current technical documentation in [edoc](https://github.com/basho/riak_kv/blob/a9ad5f2547d1f185eced3dd72f2eb65c70108f6e/src/riak_kv_wm_crdt.erl#L22-L120).

It looks like Basho publishes built edoc for client components e.g. [riakc](https://basho.github.io/riak-erlang-client/) but not for server components like riak_kv (that makes sense).