### PR TITLE
Add CentOS to RHEL package title.

### DIFF
--- a/data/os_meta.yaml
+++ b/data/os_meta.yaml
@@ -28,7 +28,7 @@ rhel:
   image_src: "/images/shared/operating_system_branding/redhat.png"
   installing_instructions_page: "rhel-centos/"
 sles:
-  title: "SUSE Linux Enterprise Server"
+  title: "SuSE Linux Enterprise Server"
   image_src: "/images/shared/operating_system_branding/suse.png"
   installing_instructions_page: "suse/"
 smartos:

--- a/data/os_meta.yaml
+++ b/data/os_meta.yaml
@@ -24,7 +24,7 @@ osx:
   image_src: "/images/shared/operating_system_branding/mac.png"
   installing_instructions_page: "mac-osx/"
 rhel:
-  title: "Red Hat Enterprise Linux"
+  title: "RHEL & CentOS"
   image_src: "/images/shared/operating_system_branding/redhat.png"
   installing_instructions_page: "rhel-centos/"
 sles:


### PR DESCRIPTION
Per DOC-654, add CentOS to RHEL heading on downloads page to make the package compatibility clear. And change SUSE to SuSE.