### PR TITLE
Technically AAE is not "required" for Riak search

### DIFF
--- a/content/riak/kv/2.0.0/developing/usage/search.md
+++ b/content/riak/kv/2.0.0/developing/usage/search.md
@@ -30,9 +30,12 @@ to properly store and later query for values.
    (this also includes bucket type-index association)
 
 {{% note %}}
-Riak search requires active anti-entropy (AAE) to be enabled in your
-cluster.  AAE helps to ensure that the data is consistent between the
-Riak backends and the Solr indexes.  More information is in the 
+Riak search uses active anti-entropy (AAE) to ensure that the data is 
+consistent between the Riak backends and the Solr indexes.  When using 
+Riak search, you should not disable AAE without understanding the risks 
+of divergence between the data in the Riak backends and the Solr indexes 
+and how that can impact your application. More information about how 
+Riak search uses AAE is in the 
 [Riak search reference](../../../using/reference/search/#active-anti-entropy-aae).
 {{% /note %}}
 

--- a/content/riak/kv/2.0.1/developing/usage/search.md
+++ b/content/riak/kv/2.0.1/developing/usage/search.md
@@ -30,9 +30,12 @@ to properly store and later query for values.
    (this also includes bucket type-index association)
 
 {{% note %}}
-Riak search requires active anti-entropy (AAE) to be enabled in your
-cluster.  AAE helps to ensure that the data is consistent between the
-Riak backends and the Solr indexes.  More information is in the 
+Riak search uses active anti-entropy (AAE) to ensure that the data is 
+consistent between the Riak backends and the Solr indexes.  When using 
+Riak search, you should not disable AAE without understanding the risks 
+of divergence between the data in the Riak backends and the Solr indexes 
+and how that can impact your application. More information about how 
+Riak search uses AAE is in the 
 [Riak search reference](../../../using/reference/search/#active-anti-entropy-aae).
 {{% /note %}}
 

--- a/content/riak/kv/2.0.2/developing/usage/search.md
+++ b/content/riak/kv/2.0.2/developing/usage/search.md
@@ -30,9 +30,12 @@ to properly store and later query for values.
    (this also includes bucket type-index association)
 
 {{% note %}}
-Riak search requires active anti-entropy (AAE) to be enabled in your
-cluster.  AAE helps to ensure that the data is consistent between the
-Riak backends and the Solr indexes.  More information is in the 
+Riak search uses active anti-entropy (AAE) to ensure that the data is 
+consistent between the Riak backends and the Solr indexes.  When using 
+Riak search, you should not disable AAE without understanding the risks 
+of divergence between the data in the Riak backends and the Solr indexes 
+and how that can impact your application. More information about how 
+Riak search uses AAE is in the 
 [Riak search reference](../../../using/reference/search/#active-anti-entropy-aae).
 {{% /note %}}
 

--- a/content/riak/kv/2.0.4/developing/usage/search.md
+++ b/content/riak/kv/2.0.4/developing/usage/search.md
@@ -30,9 +30,12 @@ to properly store and later query for values.
    (this also includes bucket type-index association)
 
 {{% note %}}
-Riak search requires active anti-entropy (AAE) to be enabled in your
-cluster.  AAE helps to ensure that the data is consistent between the
-Riak backends and the Solr indexes.  More information is in the 
+Riak search uses active anti-entropy (AAE) to ensure that the data is 
+consistent between the Riak backends and the Solr indexes.  When using 
+Riak search, you should not disable AAE without understanding the risks 
+of divergence between the data in the Riak backends and the Solr indexes 
+and how that can impact your application. More information about how 
+Riak search uses AAE is in the 
 [Riak search reference](../../../using/reference/search/#active-anti-entropy-aae).
 {{% /note %}}
 

--- a/content/riak/kv/2.0.5/developing/usage/search.md
+++ b/content/riak/kv/2.0.5/developing/usage/search.md
@@ -30,9 +30,12 @@ to properly store and later query for values.
    (this also includes bucket type-index association)
 
 {{% note %}}
-Riak search requires active anti-entropy (AAE) to be enabled in your
-cluster.  AAE helps to ensure that the data is consistent between the
-Riak backends and the Solr indexes.  More information is in the 
+Riak search uses active anti-entropy (AAE) to ensure that the data is 
+consistent between the Riak backends and the Solr indexes.  When using 
+Riak search, you should not disable AAE without understanding the risks 
+of divergence between the data in the Riak backends and the Solr indexes 
+and how that can impact your application. More information about how 
+Riak search uses AAE is in the 
 [Riak search reference](../../../using/reference/search/#active-anti-entropy-aae).
 {{% /note %}}
 

--- a/content/riak/kv/2.0.6/developing/usage/search.md
+++ b/content/riak/kv/2.0.6/developing/usage/search.md
@@ -30,9 +30,12 @@ to properly store and later query for values.
    (this also includes bucket type-index association)
 
 {{% note %}}
-Riak search requires active anti-entropy (AAE) to be enabled in your
-cluster.  AAE helps to ensure that the data is consistent between the
-Riak backends and the Solr indexes.  More information is in the 
+Riak search uses active anti-entropy (AAE) to ensure that the data is 
+consistent between the Riak backends and the Solr indexes.  When using 
+Riak search, you should not disable AAE without understanding the risks 
+of divergence between the data in the Riak backends and the Solr indexes 
+and how that can impact your application. More information about how 
+Riak search uses AAE is in the 
 [Riak search reference](../../../using/reference/search/#active-anti-entropy-aae).
 {{% /note %}}
 

--- a/content/riak/kv/2.0.7/developing/usage/search.md
+++ b/content/riak/kv/2.0.7/developing/usage/search.md
@@ -30,9 +30,12 @@ to properly store and later query for values.
    (this also includes bucket type-index association)
 
 {{% note %}}
-Riak search requires active anti-entropy (AAE) to be enabled in your
-cluster.  AAE helps to ensure that the data is consistent between the
-Riak backends and the Solr indexes.  More information is in the 
+Riak search uses active anti-entropy (AAE) to ensure that the data is 
+consistent between the Riak backends and the Solr indexes.  When using 
+Riak search, you should not disable AAE without understanding the risks 
+of divergence between the data in the Riak backends and the Solr indexes 
+and how that can impact your application. More information about how 
+Riak search uses AAE is in the 
 [Riak search reference](../../../using/reference/search/#active-anti-entropy-aae).
 {{% /note %}}
 

--- a/content/riak/kv/2.1.1/developing/usage/search.md
+++ b/content/riak/kv/2.1.1/developing/usage/search.md
@@ -30,9 +30,12 @@ to properly store and later query for values.
    (this also includes bucket type-index association)
 
 {{% note %}}
-Riak search requires active anti-entropy (AAE) to be enabled in your
-cluster.  AAE helps to ensure that the data is consistent between the
-Riak backends and the Solr indexes.  More information is in the 
+Riak search uses active anti-entropy (AAE) to ensure that the data is 
+consistent between the Riak backends and the Solr indexes.  When using 
+Riak search, you should not disable AAE without understanding the risks 
+of divergence between the data in the Riak backends and the Solr indexes 
+and how that can impact your application. More information about how 
+Riak search uses AAE is in the 
 [Riak search reference](../../../using/reference/search/#active-anti-entropy-aae).
 {{% /note %}}
 

--- a/content/riak/kv/2.1.3/developing/usage/search.md
+++ b/content/riak/kv/2.1.3/developing/usage/search.md
@@ -30,9 +30,12 @@ to properly store and later query for values.
    (this also includes bucket type-index association)
 
 {{% note %}}
-Riak search requires active anti-entropy (AAE) to be enabled in your
-cluster.  AAE helps to ensure that the data is consistent between the
-Riak backends and the Solr indexes.  More information is in the 
+Riak search uses active anti-entropy (AAE) to ensure that the data is 
+consistent between the Riak backends and the Solr indexes.  When using 
+Riak search, you should not disable AAE without understanding the risks 
+of divergence between the data in the Riak backends and the Solr indexes 
+and how that can impact your application. More information about how 
+Riak search uses AAE is in the 
 [Riak search reference](../../../using/reference/search/#active-anti-entropy-aae).
 {{% /note %}}
 

--- a/content/riak/kv/2.1.4/developing/usage/search.md
+++ b/content/riak/kv/2.1.4/developing/usage/search.md
@@ -30,9 +30,12 @@ to properly store and later query for values.
    (this also includes bucket type-index association)
 
 {{% note %}}
-Riak search requires active anti-entropy (AAE) to be enabled in your
-cluster.  AAE helps to ensure that the data is consistent between the
-Riak backends and the Solr indexes.  More information is in the 
+Riak search uses active anti-entropy (AAE) to ensure that the data is 
+consistent between the Riak backends and the Solr indexes.  When using 
+Riak search, you should not disable AAE without understanding the risks 
+of divergence between the data in the Riak backends and the Solr indexes 
+and how that can impact your application. More information about how 
+Riak search uses AAE is in the 
 [Riak search reference](../../../using/reference/search/#active-anti-entropy-aae).
 {{% /note %}}
 

--- a/content/riak/kv/2.2.0/developing/usage/search.md
+++ b/content/riak/kv/2.2.0/developing/usage/search.md
@@ -30,9 +30,12 @@ to properly store and later query for values.
    (this also includes bucket type-index association)
 
 {{% note %}}
-Riak search requires active anti-entropy (AAE) to be enabled in your
-cluster.  AAE helps to ensure that the data is consistent between the
-Riak backends and the Solr indexes.  More information is in the 
+Riak search uses active anti-entropy (AAE) to ensure that the data is 
+consistent between the Riak backends and the Solr indexes.  When using 
+Riak search, you should not disable AAE without understanding the risks 
+of divergence between the data in the Riak backends and the Solr indexes 
+and how that can impact your application. More information about how 
+Riak search uses AAE is in the 
 [Riak search reference](../../../using/reference/search/#active-anti-entropy-aae).
 {{% /note %}}
 


### PR DESCRIPTION
Per the discussion in https://github.com/basho/basho_docs/pull/2341, changing "is required" to "should not be disabled" will be more accurate.  Added a few more words for color, ideally to dissuade people from disabling AAE in search use cases willy-nilly.  This is to address the concerns raised by @TheOnlyRew in https://github.com/basho/basho_docs/pull/2341