### PR TITLE
Corrected description of `extract/1`

### DIFF
--- a/content/riak/kv/2.0.0/developing/usage/custom-extractors.md
+++ b/content/riak/kv/2.0.0/developing/usage/custom-extractors.md
@@ -38,8 +38,8 @@ We'll show you how to do so by way of example.
 Creating a custom extract involves creating an Erlang interface that
 implements two functions:
 
-* `extract/1` --- Takes the contents of the object and returns the
-    same contents and an empty list
+* `extract/1` --- Takes the contents of the object and calls `extract/2` 
+    with the same contents and an empty list
 * `extract/2` --- Takes the contents of the object and returns an Erlang
     [proplist](http://www.erlang.org/doc/man/proplists.html) with a
     single field name and a single value associated with that name

--- a/content/riak/kv/2.0.1/developing/usage/custom-extractors.md
+++ b/content/riak/kv/2.0.1/developing/usage/custom-extractors.md
@@ -38,8 +38,8 @@ We'll show you how to do so by way of example.
 Creating a custom extract involves creating an Erlang interface that
 implements two functions:
 
-* `extract/1` --- Takes the contents of the object and returns the
-    same contents and an empty list
+* `extract/1` --- Takes the contents of the object and calls `extract/2` 
+    with the same contents and an empty list
 * `extract/2` --- Takes the contents of the object and returns an Erlang
     [proplist](http://www.erlang.org/doc/man/proplists.html) with a
     single field name and a single value associated with that name

--- a/content/riak/kv/2.0.2/developing/usage/custom-extractors.md
+++ b/content/riak/kv/2.0.2/developing/usage/custom-extractors.md
@@ -12,6 +12,7 @@ menu:
 toc: true
 aliases:
   - /riak/2.0.2/dev/search/custom-extractors
+  - /riak/kv/2.0.2/dev/search/custom-extractors
 ---
 
 Solr, and by extension Riak Search, has default extractors for a wide
@@ -37,8 +38,8 @@ We'll show you how to do so by way of example.
 Creating a custom extract involves creating an Erlang interface that
 implements two functions:
 
-* `extract/1` --- Takes the contents of the object and returns the
-    same contents and an empty list
+* `extract/1` --- Takes the contents of the object and calls `extract/2` 
+    with the same contents and an empty list
 * `extract/2` --- Takes the contents of the object and returns an Erlang
     [proplist](http://www.erlang.org/doc/man/proplists.html) with a
     single field name and a single value associated with that name

--- a/content/riak/kv/2.0.4/developing/usage/custom-extractors.md
+++ b/content/riak/kv/2.0.4/developing/usage/custom-extractors.md
@@ -38,8 +38,8 @@ We'll show you how to do so by way of example.
 Creating a custom extract involves creating an Erlang interface that
 implements two functions:
 
-* `extract/1` --- Takes the contents of the object and returns the
-    same contents and an empty list
+* `extract/1` --- Takes the contents of the object and calls `extract/2` 
+    with the same contents and an empty list
 * `extract/2` --- Takes the contents of the object and returns an Erlang
     [proplist](http://www.erlang.org/doc/man/proplists.html) with a
     single field name and a single value associated with that name

--- a/content/riak/kv/2.0.5/developing/usage/custom-extractors.md
+++ b/content/riak/kv/2.0.5/developing/usage/custom-extractors.md
@@ -38,8 +38,8 @@ We'll show you how to do so by way of example.
 Creating a custom extract involves creating an Erlang interface that
 implements two functions:
 
-* `extract/1` --- Takes the contents of the object and returns the
-    same contents and an empty list
+* `extract/1` --- Takes the contents of the object and calls `extract/2` 
+    with the same contents and an empty list
 * `extract/2` --- Takes the contents of the object and returns an Erlang
     [proplist](http://www.erlang.org/doc/man/proplists.html) with a
     single field name and a single value associated with that name

--- a/content/riak/kv/2.0.6/developing/usage/custom-extractors.md
+++ b/content/riak/kv/2.0.6/developing/usage/custom-extractors.md
@@ -38,8 +38,8 @@ We'll show you how to do so by way of example.
 Creating a custom extract involves creating an Erlang interface that
 implements two functions:
 
-* `extract/1` --- Takes the contents of the object and returns the
-    same contents and an empty list
+* `extract/1` --- Takes the contents of the object and calls `extract/2` 
+    with the same contents and an empty list
 * `extract/2` --- Takes the contents of the object and returns an Erlang
     [proplist](http://www.erlang.org/doc/man/proplists.html) with a
     single field name and a single value associated with that name

--- a/content/riak/kv/2.0.7/developing/usage/custom-extractors.md
+++ b/content/riak/kv/2.0.7/developing/usage/custom-extractors.md
@@ -38,8 +38,8 @@ We'll show you how to do so by way of example.
 Creating a custom extract involves creating an Erlang interface that
 implements two functions:
 
-* `extract/1` --- Takes the contents of the object and returns the
-    same contents and an empty list
+* `extract/1` --- Takes the contents of the object and calls `extract/2` 
+    with the same contents and an empty list
 * `extract/2` --- Takes the contents of the object and returns an Erlang
     [proplist](http://www.erlang.org/doc/man/proplists.html) with a
     single field name and a single value associated with that name

--- a/content/riak/kv/2.1.1/developing/usage/custom-extractors.md
+++ b/content/riak/kv/2.1.1/developing/usage/custom-extractors.md
@@ -38,8 +38,8 @@ We'll show you how to do so by way of example.
 Creating a custom extract involves creating an Erlang interface that
 implements two functions:
 
-* `extract/1` --- Takes the contents of the object and returns the
-    same contents and an empty list
+* `extract/1` --- Takes the contents of the object and calls `extract/2` 
+    with the same contents and an empty list
 * `extract/2` --- Takes the contents of the object and returns an Erlang
     [proplist](http://www.erlang.org/doc/man/proplists.html) with a
     single field name and a single value associated with that name

--- a/content/riak/kv/2.1.3/developing/usage/custom-extractors.md
+++ b/content/riak/kv/2.1.3/developing/usage/custom-extractors.md
@@ -38,8 +38,8 @@ We'll show you how to do so by way of example.
 Creating a custom extract involves creating an Erlang interface that
 implements two functions:
 
-* `extract/1` --- Takes the contents of the object and returns the
-    same contents and an empty list
+* `extract/1` --- Takes the contents of the object and calls `extract/2` 
+    with the same contents and an empty list
 * `extract/2` --- Takes the contents of the object and returns an Erlang
     [proplist](http://www.erlang.org/doc/man/proplists.html) with a
     single field name and a single value associated with that name

--- a/content/riak/kv/2.1.4/developing/usage/custom-extractors.md
+++ b/content/riak/kv/2.1.4/developing/usage/custom-extractors.md
@@ -38,8 +38,8 @@ We'll show you how to do so by way of example.
 Creating a custom extract involves creating an Erlang interface that
 implements two functions:
 
-* `extract/1` --- Takes the contents of the object and returns the
-    same contents and an empty list
+* `extract/1` --- Takes the contents of the object and calls `extract/2` 
+    with the same contents and an empty list
 * `extract/2` --- Takes the contents of the object and returns an Erlang
     [proplist](http://www.erlang.org/doc/man/proplists.html) with a
     single field name and a single value associated with that name

--- a/content/riak/kv/2.2.0/developing/usage/custom-extractors.md
+++ b/content/riak/kv/2.2.0/developing/usage/custom-extractors.md
@@ -38,8 +38,8 @@ We'll show you how to do so by way of example.
 Creating a custom extract involves creating an Erlang interface that
 implements two functions:
 
-* `extract/1` --- Takes the contents of the object and returns the
-    same contents and an empty list
+* `extract/1` --- Takes the contents of the object and calls `extract/2` 
+    with the same contents and an empty list
 * `extract/2` --- Takes the contents of the object and returns an Erlang
     [proplist](http://www.erlang.org/doc/man/proplists.html) with a
     single field name and a single value associated with that name


### PR DESCRIPTION
Thanks to @lucafavatella for the report.  This fixes https://github.com/basho/basho_docs/issues/2347. 
Corrected the description of `extract/1` to say that it should be calling `extract/2`
with the passed in parameter and an empty list.