### PR TITLE
Backporting PR #2338

### DIFF
--- a/content/riak/kv/2.0.0/developing/api/http/search-query.md
+++ b/content/riak/kv/2.0.0/developing/api/http/search-query.md
@@ -61,10 +61,9 @@ has no documents associated with it:
     "start": 0
   },
   "responseHeader": {
+    "status": 0,
     "QTime": 10,
-    "params": { /* internal info from the query */ },
-    "wt": "json"
-  },
-  "status": 0
+    "params": { /* internal info from the query */ }
+  }
 }
 ```

--- a/content/riak/kv/2.0.1/developing/api/http/search-query.md
+++ b/content/riak/kv/2.0.1/developing/api/http/search-query.md
@@ -61,10 +61,9 @@ has no documents associated with it:
     "start": 0
   },
   "responseHeader": {
+    "status": 0,
     "QTime": 10,
-    "params": { /* internal info from the query */ },
-    "wt": "json"
-  },
-  "status": 0
+    "params": { /* internal info from the query */ }
+  }
 }
 ```

--- a/content/riak/kv/2.0.2/developing/api/http/search-query.md
+++ b/content/riak/kv/2.0.2/developing/api/http/search-query.md
@@ -60,10 +60,9 @@ has no documents associated with it:
     "start": 0
   },
   "responseHeader": {
+    "status": 0,
     "QTime": 10,
-    "params": { /* internal info from the query */ },
-    "wt": "json"
-  },
-  "status": 0
+    "params": { /* internal info from the query */ }
+  }
 }
 ```

--- a/content/riak/kv/2.0.4/developing/api/http/search-query.md
+++ b/content/riak/kv/2.0.4/developing/api/http/search-query.md
@@ -61,10 +61,9 @@ has no documents associated with it:
     "start": 0
   },
   "responseHeader": {
+    "status": 0,
     "QTime": 10,
-    "params": { /* internal info from the query */ },
-    "wt": "json"
-  },
-  "status": 0
+    "params": { /* internal info from the query */ }
+  }
 }
 ```

--- a/content/riak/kv/2.0.5/developing/api/http/search-query.md
+++ b/content/riak/kv/2.0.5/developing/api/http/search-query.md
@@ -61,10 +61,9 @@ has no documents associated with it:
     "start": 0
   },
   "responseHeader": {
+    "status": 0,
     "QTime": 10,
-    "params": { /* internal info from the query */ },
-    "wt": "json"
-  },
-  "status": 0
+    "params": { /* internal info from the query */ }
+  }
 }
 ```

--- a/content/riak/kv/2.0.6/developing/api/http/search-query.md
+++ b/content/riak/kv/2.0.6/developing/api/http/search-query.md
@@ -61,10 +61,9 @@ has no documents associated with it:
     "start": 0
   },
   "responseHeader": {
+    "status": 0,
     "QTime": 10,
-    "params": { /* internal info from the query */ },
-    "wt": "json"
-  },
-  "status": 0
+    "params": { /* internal info from the query */ }
+  }
 }
 ```

--- a/content/riak/kv/2.0.7/developing/api/http/search-query.md
+++ b/content/riak/kv/2.0.7/developing/api/http/search-query.md
@@ -61,10 +61,9 @@ has no documents associated with it:
     "start": 0
   },
   "responseHeader": {
+    "status": 0,
     "QTime": 10,
-    "params": { /* internal info from the query */ },
-    "wt": "json"
-  },
-  "status": 0
+    "params": { /* internal info from the query */ }
+  }
 }
 ```

--- a/content/riak/kv/2.1.1/developing/api/http/search-query.md
+++ b/content/riak/kv/2.1.1/developing/api/http/search-query.md
@@ -61,10 +61,9 @@ has no documents associated with it:
     "start": 0
   },
   "responseHeader": {
+    "status": 0,
     "QTime": 10,
-    "params": { /* internal info from the query */ },
-    "wt": "json"
-  },
-  "status": 0
+    "params": { /* internal info from the query */ }
+  }
 }
 ```

--- a/content/riak/kv/2.1.3/developing/api/http/search-query.md
+++ b/content/riak/kv/2.1.3/developing/api/http/search-query.md
@@ -61,10 +61,9 @@ has no documents associated with it:
     "start": 0
   },
   "responseHeader": {
+    "status": 0,
     "QTime": 10,
-    "params": { /* internal info from the query */ },
-    "wt": "json"
-  },
-  "status": 0
+    "params": { /* internal info from the query */ }
+  }
 }
 ```

--- a/content/riak/kv/2.1.4/developing/api/http/search-query.md
+++ b/content/riak/kv/2.1.4/developing/api/http/search-query.md
@@ -61,10 +61,9 @@ has no documents associated with it:
     "start": 0
   },
   "responseHeader": {
+    "status": 0,
     "QTime": 10,
-    "params": { /* internal info from the query */ },
-    "wt": "json"
-  },
-  "status": 0
+    "params": { /* internal info from the query */ }
+  }
 }
 ```


### PR DESCRIPTION
`wt` is a child of `params`, so it shouldn't be visible because `params` is
elided in the sample output.  This is a backport of PR #2338 