### PR TITLE
Add missing response section to yokozuna index delete and put

### DIFF
--- a/content/riak/kv/2.2.0/developing/api/protocol-buffers/yz-index-delete.md
+++ b/content/riak/kv/2.2.0/developing/api/protocol-buffers/yz-index-delete.md
@@ -26,3 +26,8 @@ message RpbYokozunaIndexDeleteReq {
     required bytes name  =  1;
 }
 ```
+
+## Response
+
+Returns a [RpbDelResp](/riak/kv/2.2.0/developing/api/protocol-buffers/#message-codes) code with no data on success.
+

--- a/content/riak/kv/2.2.0/developing/api/protocol-buffers/yz-index-put.md
+++ b/content/riak/kv/2.2.0/developing/api/protocol-buffers/yz-index-put.md
@@ -38,3 +38,8 @@ message RpbYokozunaIndex {
 
 Each message specifying an index must include the index's name as a
 binary (as `name`). Optionally, you can specify a [`schema`](/riak/kv/2.2.0/developing/usage/search-schemas) name and/or an `n_val`, i.e. the number of nodes on which the index is stored (for GET requests) or on which you wish the index to be stored (for PUT requests). An index's `n_val` must match the associated bucket's `n_val`.
+
+## Response
+
+Returns a [RpbPutResp](/riak/kv/2.2.0/developing/api/protocol-buffers/#message-codes) code with no data on success.
+


### PR DESCRIPTION
This adds the response code the developer should expect to receive from `RpbYokozunaIndexDeleteReq` and `RpbYokozunaIndexPutReq` requests.