### PR TITLE
Query info update

### DIFF
--- a/content/riak/ts/1.5.1/configuring/riakconf.md
+++ b/content/riak/ts/1.5.1/configuring/riakconf.md
@@ -37,11 +37,11 @@ The Riak TS configuration settings in riak.conf have changed. The old settings w
 
 Make certain the configuration file on each node gets the same parameters to avoid inconsistent behavior.
 
-Benchmarking of your use cases and traffic load is recommended when changing these parameters. Settings which are too permissive can result in a slow database under heavy load.
+Benchmarking of your use cases and traffic load is recommended when changing these parameters. Settings that are too permissive can result in a slow database under heavy load.
 
 ### Query timeout
 
-`riak_kv.query.timeseries.timeout`: the timeout for queries, after which a timeout error is returned. Default is '10s'.
+`riak_kv.query.timeseries.timeout`: the timeout for queries, after which a timeout error is returned. Default is 10s.
 
 ```riak.conf
 riak_kv.query.timeseries.timeout = 10s
@@ -98,18 +98,15 @@ riak_kv.query.timeseries.maximum_query_queue_length = 15
 
 ### Maximum quanta
 
-`riak_kv.query.timeseries.max_quanta_span`: the maximum number of quanta that a query can span. Default is 5000 (see bug note below).
+`riak_kv.query.timeseries.max_quanta_span`: the maximum number of quanta that a query can span. Default is 5000, maximum 10000.
 
-{{% note title="Bug" %}}
-Due to a bug, the `max_quanta_span` is capped at 1000, though the default will show in riak.conf as 5000.
-{{% /note %}}
 
 ```riak.conf
 riak_kv.query.timeseries.max_quanta_span = 5000
 ```
 
 {{% note %}}
-`riak_kv.query.timeseries.max_quanta_span` was intended to protect from SELECTing excessive amounts of data, with a default set to a low value (5). Now, we use a running estimation of projected query size to determine whether the query results can be safely returned to the client (see `max_returned_data_size` below).  The `max_quanta_span` parameter has been kept but is no longer the limiting factor.
+`riak_kv.query.timeseries.max_quanta_span` was originally designed to protect against data overload in queries. We have switched to a running estimation of projected query size to determine whether the query results can be safely returned to the client (see [`max_returned_data_size`](#maximum-returned-data-size) below).  The `max_quanta_span` still determines how many quanta a query can span, but is no longer the limiting factor in how much data a query may return.
 {{% /note %}}
 
 *This setting was formerly `timeseries_query_max_quanta_span`, please update accordingly.*
@@ -117,7 +114,7 @@ riak_kv.query.timeseries.max_quanta_span = 5000
 
 ### Maximum returned data size
 
-`riak_kv.query.timeseries.max_returned_data_size`: Largest estimated size, in bytes, of the data a query can return to the client. Default value is 10000000 (10 million).
+`riak_kv.query.timeseries.max_returned_data_size`: largest estimated size, in bytes, of the data a query can return to the client. Default value is 10000000 (10 million). If a query will exceed this value, the query will be cancelled.
 
 When a query is broken down into per-quantum subqueries, all subqueries are queued for execution. Starting from the arrival of the second result set, we estimate the projected query result size as:
 
@@ -133,9 +130,9 @@ riak_kv.query.timeseries.max_returned_data_size = 10*1000*1000
 
 ### Maximum subqueries
 
-`riak_kv.query.timeseries.max_running_fsms`: throttle the number of simultaneously running FSMs (i.e., processes collecting data for a single subquery). Default is 20.
+`riak_kv.query.timeseries.max_running_fsms`: throttle the number of simultaneously running FSMs (i.e. processes collecting data for a single subquery). Default is 20.
 
-This number times the max size of data chunks determines the maximum volume of data the coordinator will have to deal with at any given time.
+`max_running_fsms * maximum size of data chunks` will determine the maximum volume of data the coordinator will have to deal with at any given time.
 
 Increasing this parameter allows for faster execution of queries over many small quanta. Conversely, if your quanta are large, it may be advisable to limit the number of concurrent FSMs even further, depending on the expected size of data per quantum.
 
@@ -152,7 +149,7 @@ riak_kv.query.timeseries.max_running_fsms = 20
 
 `riak_kv.object.size.warning_threshold`, `riak_kv.object.size.maximum`: object size limits. Defaults are 50K and 500K, respectively.
 
-Note that Time Series default configuration now has smaller object sizes in order to improve performance.
+Note that Riak TS default configuration now has smaller object sizes in order to improve performance.
 
 ```riak.conf
 riak_kv.object.size.warning_threshold = 50K
@@ -162,12 +159,12 @@ riak_kv.object.size.maximum = 500K
 
 ### Query buffers root path
 
-`riak_kv.query.timeseries.qbuf_root_path`: Root path for leveldb instances backing node-local query buffers. Default is "$(platform_data_dir)/query_buffers".
+`riak_kv.query.timeseries.qbuf_root_path`: Root path for LevelDB instances backing node-local query buffers. Default is "$(platform_data_dir)/query_buffers".
 
-For queries with an `ORDER BY` clause and/or `LIMIT` or `OFFSET` keywords, a separate, slower, code path will be used, whereby data collected from vnodes will be stored in a temporary *query buffers*. Each query buffer is a disk-backed leveldb table, created as a subdirectory under `timeseries.qbuf_root_path` which will be deleted after the query is served.
+For queries with an ORDER BY clause and/or LIMIT or OFFSET keywords, a separate, slower code path will be used whereby data collected from vnodes will be stored in temporary *query buffers*. Each query buffer is a disk-backed LevelDB table, created as a subdirectory under `timeseries.qbuf_root_path`, which will be deleted after the query is served.
 
 {{% note %}}
-1. Placing it on a fast media, such as a dedicated SSD or a RAM-based disk such as `/tmp`, is recommended.
+1. Placing the root path on a fast media, such as a dedicated SSD or a RAM-based disk such as `/tmp`, is recommended.
 
 2. The contents of this directory will be deleted at node startup and shutdown. If you choose to specify a path outside of `$(platform_data_dir)`, make sure no other process reads or writes to it.
 {{% /note %}}

--- a/content/riak/ts/1.5.1/learn-about/tablearchitecture.md
+++ b/content/riak/ts/1.5.1/learn-about/tablearchitecture.md
@@ -155,7 +155,7 @@ The column names in the partition key are used to determine which vnodes handle 
 
 If both column names represent the same class or type of data for large numbers of writes, and the quanta that is specified has a large duration, only n_val vnodes will process the incoming writes. In these instances, Riak will not be able to parallelize the workload across CPUs.
 
-All keys and values are written contiguously on disk. For each co-located block of data a sub-query is created. Currently there is a default maximum of 5 sub-queries per single query to prevent overload; see [Configure Riak TS][configuring] for details on changing that value.
+All keys and values are written contiguously on disk. For each co-located block of data a sub-query is created. Currently there is a default maximum of 20 sub-queries per single query to prevent overload; see [Configure Riak TS][configuring] for details on changing that value.
 
 Choosing a quanta size involves tradeoffs. Small quanta are best for writes while large quanta are best for queries. You should choose your quanta according to your data needs.
 

--- a/content/riak/ts/1.5.1/using/querying/guidelines.md
+++ b/content/riak/ts/1.5.1/using/querying/guidelines.md
@@ -22,6 +22,7 @@ canonical_link: "https://docs.basho.com/riak/ts/latest/using/querying/guidelines
 [planning]: ../../planning#column-definitions
 [iso8601]: ../../../timerepresentations/
 [SELECT]: /riak/ts/1.5.1/using/querying/SELECT#iso_8601
+[configuring]: ../../../configuring/riakconf/
 
 
 Riak TS supports several kinds of queries of your TS data. To create the most successful queries possible, there are some guidelines and limitations you should know. 
@@ -52,7 +53,7 @@ All queries must cover the partition key fields and must use greater than and le
 
 All unquantized fields in your partition key must be included in the query as exact matches.
 
-Any quantized field in your partition key must be included in the query as a bounded range.
+Any quantized field in your partition key must be included in the query as a bounded range, or with equals.
 
 * Valid: `time > 1449864277000 and time < 1449864290000`
 * Invalid: `time > 1449864277000`
@@ -65,8 +66,8 @@ It is possible to use ISO 8601-compliant date/time strings rather than integer t
 
 ### Local Key
 
-For any field in the local key that is not in the partition key, your
-query can include any operator supported for that field's type. Bounded ranges are not required.
+
+Any field in the local key but not in the partition key can be queried with any operator supported for that field's type. Bounded ranges are not required. Any filter is allowed, including `OR` and `!=`
 
 ```
 PRIMARY KEY ((a,b),a,b,c)
@@ -74,7 +75,7 @@ PRIMARY KEY ((a,b),a,b,c)
 
 Here 'c' is in the local key only so does not have to be in the query.
 
-Column names from the local key must be compared using strict equality against literal values. No ranges are permitted, `!=` must not be used, and `or` will not work.
+[Column names][planning] from the local key must be compared using strict equality against literal values. No ranges are permitted, `!=` must not be used, and `OR` will not work.
 
 * Valid: `country_code = 'uk'`
 * Invalid: `(country_code = 'uk' or country_code = 'de')`
@@ -92,7 +93,7 @@ Column names from the local key must be compared using strict equality against l
 Before you begin querying, there are some guidelines to keep in mind.
 
 * Columns may not be compared against other columns in the query.
-* When using `or`, you must surround the expression with parentheses or your query will return an error.
+* When using `OR`, you must surround the expression with parentheses or your query will return an error.
 
 Basic queries return the full range of values between two given times for an instance within a class or type of data. In the example table, `state` is an instance within the `region`:
 
@@ -137,18 +138,27 @@ The following operators are supported for each data type:
 
 * Column to column comparisons are not currently supported.
 * Secondary indexing (2i) will not work with Riak TS.
-* Riak Search will not work with Riak TS.
+* Riak search will not work with Riak TS.
 * Queries are limited by the number of quanta they can span when specifying the time limits.
 
-#### Blob data in queries and primary keys
+### Blob data in queries and primary keys
 
 Blob data should be queried using integers in base 16 (hex) notation, preceded by `0x` using riak shell or by providing any block of data (e.g. binary, text or JSON) through a Riak client library.
 
 However, we do not recommend using blob columns in primary keys yet, due to limitations in the Riak TS 1.5 `list_keys` API.
 
-#### Quanta query range
 
-A query covering more than than the configured quanta span (1000 in Riak TS 1.5 due to a bug, see [Configuring](riak/ts/1.5.1/configuring/riakconf/) for more information) will generate an error like `Error (1025): Query spans too many quanta (1577160, max 1000)` and the query system will refuse to run it. 
+### Query parameters
+
+You can set [configurations in your riak.conf][configuring] to restrict or broaden your queries. There are three parameters, in particular, that will impact your queries.
+
+The query size is limited by the `max_returned_data_size` parameter. This parameter specifies the limit of data a query may fetch. When a query is made, the size of the data it will fetch is estimated and then checked against the `max_returned_data_size` parameter. If the estimation exceeds the limit, the query is cancelled.
+
+The `max_running_fsms` will impact how long your query will take. This parameter specifies the maximum number of subqueries that can be processed in parallel. For more information on this parameter, check out [Configuring Riak TS][configuring].
+
+The `max_quanta_span` parameter will limit the number of quanta a query can cover.
+
+A query covering more than than the configured quanta span will generate an error like 'Error (1025): Query spans too many quanta' and the query system will refuse to run it.
 
 In the example DDL below we set a quantum of 1 minute in the primary key:
 
@@ -164,6 +174,6 @@ CREATE TABLE GeoCheckin
                 location, user, time))
 ```
 
-The maximum time range we can query is 1000 minutes, anything beyond will fail.
+With the above quantum and with the default `max_quanta_span` of 5000,  the maximum timeframe we can query at a time is going to be 5000 minutes provided that the data returned from the query wouldn’t exceed the limits set in `max_returned_data_size`.
 
-See the Data Modeling section in [Table Architecture][table arch] for more information.
+See the Data Modeling section in [Table Architecture][table arch] for more information on selecting your quanta and setting parameters.

--- a/content/riak/ts/1.5.1/using/querying/select/limit.md
+++ b/content/riak/ts/1.5.1/using/querying/select/limit.md
@@ -17,6 +17,7 @@ canonical_link: "https://docs.basho.com/riak/ts/latest/using/querying/limit/"
 
 [select]: /riak/ts/1.5.1/using/querying/select
 [query guidelines]: /riak/ts/1.5.1/using/querying/guidelines/
+[configuring]: /riak/ts/1.5.1/configuring/riakconf/#maximum-returned-data-size
 
 The LIMIT statement is used with [`SELECT`][select] to return a limited number of results.
 
@@ -38,6 +39,8 @@ LIMIT «number_rows» [ OFFSET «offset_rows» ]
 ```
 
 The OFFSET modifier can be used with `LIMIT` to skip a specified number of results and return the remaining results ([example below](#offset-results)).
+
+Note that when using `LIMIT`, the `max_returned_data_size` is calculated differently. You can read more about how it is calculated [here][configuring].
 
 
 {{% note title="WARNING" %}}


### PR DESCRIPTION
1. Update /configuring/riakconf - Per DOC-756, ran through defaults and information in Configuring riak.conf page and updated where needed and clarified where I could.
2. Query guidelines and configuration update - Per DOC-756, update the guidelines page, table architecture page, and link to the configuration page from LIMIT.