### PR TITLE
Great Rework -- Review Test Part 2 -- Update CSS compilation logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,13 @@
 source "https://rubygems.org"
 ruby "2.2.5"
 
+#TOOD: This file is now out of date.
+#      We need to walk the gems and make sure that,
+#      1. Each gem is current
+#      2. Each gem is _used_
+
 gem "sass", "~>3.4.22"
+gem "autoprefixer-rails", "~>6.3.6"
 gem "sass-css-importer", ">=1.0.0.beta.0"
 gem "compass", "~>1.0.3"
 gem "sprockets", "~>3.7"

--- a/rake_libs/compile_css.rb
+++ b/rake_libs/compile_css.rb
@@ -1,37 +1,74 @@
-# This code was largely inspired by this SO question
-# http://stackoverflow.com/questions/25399962/compass-from-ruby-sasscompiler-not-found
-# with addtional code and configuraion options drawn from:
-# https://github.com/Compass/compass/blob/350bcaa544f594bca972aaa29a9bdfddceee5d4f/cli/lib/compass/exec/global_options_parser.rb
-# https://github.com/Compass/compass/blob/350bcaa544f594bca972aaa29a9bdfddceee5d4f/cli/lib/compass/exec/project_options_parser.rb
+#TODO: Let's get some comments up here, please.
+#TODO: We should probably explicity set the Autoprefixer browser versions, but
+#      I'm not yet sure how far back we want to support.
 
-#NOTE<drew.pirrone.brusse@gmail>: I made the choice here to start from the
-# above SO question and code snippets to make this call using the undocumented
-# Ruby API of Compass rather than building a shell call out of a Ruby string
-# and passing that to the OS layer. I don't know if it's the right choice, but
-# it's the choice I made. Hopefully no one gets bit by it.
 def compile_css(debug: false)
-  require 'compass'
-  require 'compass/sass_compiler'
-  require 'sass-css-importer'
+  require 'sass'
+  require 'autoprefixer-rails'
 
-  Compass.configuration.add_import_path "#{$css_source}/imports"
-  configs = {}
-  configs[:project_path]  = "."
-  configs[:http_path]     = "/"
-  configs[:sass_path]     = $css_source
-  configs[:css_path]      = $css_dest
-  configs[:cache_path]    = $cache_dir
-  configs[:images_path]   = "static/images/"
-  configs[:output_style]  = debug ? :nested : :compressed
-  configs[:line_comments] = debug ? true    : false
-  Compass.add_configuration(configs, "basho_docs_configs")
+  sass_options = {
+    :syntax         => :scss,
+    :cache          => true,
+    :cache_location => $cache_dir,
+    :load_paths     => [$css_source, "#{$css_source}/imports"],
+    :style          => debug ? :expanded : :compressed,
+    :line_comments  => debug ? true      : false,
+    :full_exception => debug ? true      : false,
+  }
 
-  # This will grab every .scss file in the $css_source directory, and run them
-  # through Compass, generating equivalently-named .css files in the static/css
-  # directory. We should try to keep the number of compiled sources to a minimum
-  # though, and simply add new/parsed scss/css files to `all.scss`.
-  compiler = Compass.sass_compiler({
-    :only_sass_files => Dir.glob("#{$css_source}/*.scss")
-  })
-  compiler.compile!
+  autoprefixer_browsers = [
+    # Piggyback off of Bootstrap's Official browser support policy:
+    # http://v4-alpha.getbootstrap.com/getting-started/browsers-devices/#supported-browsers
+    # Pulled from https://github.com/twbs/bootstrap/blob/v4-dev/grunt/autoprefixer-settings.js
+    'Chrome >= 35',
+    'Firefox >= 38',
+    'Edge >= 12',
+    'Explorer >= 9',
+    'iOS >= 8',
+    'Safari >= 8',
+    'Android 2.3',
+    'Android >= 4',
+    'Opera >= 12',
+  ]
+
+
+  Dir.glob("#{$css_source}/*.scss").each do |scss_file_path|
+    scss_file_name   = File.basename(scss_file_path)
+    output_file_name = scss_file_name.gsub(/\.scss$/, ".css")
+    output_file_path = "#{$css_dest}/#{output_file_name}"
+    public_file_path = "#{$hugo_dest}/css/#{output_file_name}"
+
+    # If we're running as debug, build the sourcemaps
+    if debug
+      (css_str, sass_map) = Sass::Engine.for_file(scss_file_path, sass_options)
+                            .render_with_sourcemap("#{output_file_name}.map")
+      prefixed_results = AutoprefixerRails.process(css_str, {
+        :map => {
+          :prev => sass_map.to_json({
+            :css_path       => public_file_path,
+            :sourcemap_path => "#{public_file_path}.map",
+          }),
+          :inline => false,
+        },
+        :from => scss_file_path,
+        :to   => public_file_path,
+        :browsers => autoprefixer_browsers,
+      })
+
+      File.write(output_file_path, prefixed_results.css)
+      log_write(output_file_path)
+      File.write("#{output_file_path}.map", prefixed_results.map)
+      log_write("#{output_file_path}.map")
+    else
+      css_str = Sass::Engine.for_file(scss_file_path, sass_options).render
+      prefixed_results = AutoprefixerRails.process(css_str, {
+        :from => scss_file_path,
+        :to   => public_file_path,
+        :browsers => autoprefixer_browsers,
+      })
+
+      File.write(output_file_path, prefixed_results.css)
+      log_write(output_file_path)
+    end
+  end
 end


### PR DESCRIPTION
This is a test to see how possible it is to parse up reviews for a change set that touches 50k lines (#2380). These different "parts" are going to be stacked, so the changes are cumulative. Mostly, they're so we can logically separate different change sets to (theoretically) simplify the review process. To run the code and build the actual website, the great_rework/aggregate branch should be used.

---

Like it says on the tin.
Note; this code will likely not run, 1) because the gemset at this commit hasn't been updated, and 2) there's nothing to build at this commit.