### PR TITLE
Add clarifications around expected behavior in LIMIT/ORDER BY

### DIFF
--- a/content/riak/ts/1.5.0/configuring/riakconf.md
+++ b/content/riak/ts/1.5.0/configuring/riakconf.md
@@ -121,8 +121,8 @@ riak_kv.query.timeseries.max_quanta_span = 5000
 
 When a query is broken down into per-quantum subqueries, all subqueries are queued for execution. Starting from the arrival of the second result set, we estimate the projected query result size as:
 
-* `TotalQuerySize = AverageSubqueryResultSize * NumberOfSubqueries`, for regular queries without a `LIMIT` clause;
-* `TotalQuerySize = AverageSubqueryResultSize * LimitValue`, for queries with a `LIMIT` clause.
+* `TotalQuerySize = AverageSubqueryResultSize * NumberOfSubqueries`, for regular queries without a LIMIT or ORDER BY clause;
+* `TotalQuerySize = AverageSubqueryResultSize * LimitValue`, for queries with a LIMIT or ORDER BY clause.
 
 If the total size is found to exceed `max_returned_data_size`, the query is cancelled, with an error code 1022 ("Projected result of a SELECT query is too big").
 

--- a/content/riak/ts/1.5.0/using/querying/select/limit.md
+++ b/content/riak/ts/1.5.0/using/querying/select/limit.md
@@ -27,7 +27,7 @@ This document shows how to run various queries using `LIMIT`. See the [guideline
 {{% note title="A Note on Latency" %}}
 `LIMIT` uses on-disk query buffer to prevent overload, which adds some overhead and increases the query latency.
 
-You may adjust various parameters in [riak.conf][configuring] depending on how much memory your riak nodes will have, including `max_running_fsms`, `max_quanta_span`, `max_concurrent_queries`. It is also worth noting that `max_returned_data_size` is calculated differently for LIMIT statements; you can read more about that [here][configuring]. All of these settings impact the maximum size of data you can retrieve at one time, and it is important to understand your environmental limitations or you run the risk of an out-of-memory condition.
+You may adjust various parameters in [riak.conf](/riak/ts/1.5.0/configuring/riakconf/) depending on how much memory your riak nodes will have, including `max_running_fsms`, `max_quanta_span`, `max_concurrent_queries`. It is also worth noting that `max_returned_data_size` is calculated differently for LIMIT statements; you can read more about that [here](/riak/ts/1.5.0/configuring/riakconf/#maximum-returned-data-size). All of these settings impact the maximum size of data you can retrieve at one time, and it is important to understand your environmental limitations or you run the risk of an out-of-memory condition.
 
 However, the most effective means of speeding up your `LIMIT` queries is to place the query buffer directory (`timeseries_query_buffers_root_path`) on fast storage or in memory-backed /tmp directory.
 {{% /note %}}

--- a/content/riak/ts/1.5.0/using/querying/select/limit.md
+++ b/content/riak/ts/1.5.0/using/querying/select/limit.md
@@ -17,15 +17,19 @@ canonical_link: "https://docs.basho.com/riak/ts/latest/using/querying/limit/"
 
 [select]: /riak/ts/1.5.0/using/querying/select
 [query guidelines]: /riak/ts/1.5.0/using/querying/guidelines/
-[configuring]: /riak/ts/1.5.1/configuring/riakconf/#maximum-returned-data-size
+[configuring]: /riak/ts/1.5.0/configuring/riakconf/#maximum-returned-data-size
 
 
 The LIMIT statement is used with [`SELECT`][select] to return a limited number of results.
 
 This document shows how to run various queries using `LIMIT`. See the [guidelines][query guidelines] for more information on limitations and rules for queries in Riak TS.
 
-{{% note title="Warning" %}}
-The initial implementation of `LIMIT` in SELECT queries uses on-disk query buffer. It adds some overhead which increases the query latency, sometimes significantly.
+{{% note title="A Note on Latency" %}}
+`LIMIT` uses on-disk query buffer to prevent overload, which adds some overhead and increases the query latency.
+
+You may adjust various parameters in [riak.conf][configuring] depending on how much memory your riak nodes will have, including `max_running_fsms`, `max_quanta_span`, `max_concurrent_queries`. It is also worth noting that `max_returned_data_size` is calculated differently for LIMIT statements; you can read more about that [here][configuring]. All of these settings impact the maximum size of data you can retrieve at one time, and it is important to understand your environmental limitations or you run the risk of an out-of-memory condition.
+
+However, the most effective means of speeding up your `LIMIT` queries is to place the query buffer directory (`timeseries_query_buffers_root_path`) on fast storage or in memory-backed /tmp directory.
 {{% /note %}}
 
 
@@ -40,8 +44,6 @@ LIMIT «number_rows» [ OFFSET «offset_rows» ]
 ```
 
 The OFFSET modifier can be used with `LIMIT` to skip a specified number of results and return the remaining results ([example below](#offset-results)).
-
-Note that when using `LIMIT`, the `max_returned_data_size` is calculated differently. You can read more about how it is calculated [here][configuring].
 
 {{% note title="WARNING" %}}
 Before you run `SELECT` you must ensure the node issuing the query has adequate memory to receive the response. If the returning rows do not fit into the memory of the requesting node, the node is likely to fail.

--- a/content/riak/ts/1.5.0/using/querying/select/order-by.md
+++ b/content/riak/ts/1.5.0/using/querying/select/order-by.md
@@ -17,14 +17,20 @@ canonical_link: "https://docs.basho.com/riak/ts/latest/using/querying/select/ord
 
 [select]: /riak/ts/1.5.0/using/querying/select
 [query guidelines]: /riak/ts/1.5.0/using/querying/guidelines/
+[configuring]: /riak/ts/1.5.0/configuring/riakconf/#maximum-returned-data-size
 
 The ORDER BY statement is used with [`SELECT`][select] to sort results by one or more columns in ascending or descending order. `ORDER BY` is useful for operations such as returning the most recent results in a set.
 
 This document shows how to run various queries using `ORDER BY`. See the [guidelines][query guidelines] for more information on limitations and rules for queries in Riak TS.
 
-{{% note title="Warning" %}}
-The initial implementation of `ORDER BY` in SELECT queries uses on-disk query buffer. It adds some overhead which increases the query latency, sometimes significantly.
+{{% note title="A Note on Latency" %}}
+`ORDER BY` uses on-disk query buffer to prevent overload, which adds some overhead and increases the query latency.
+
+You may adjust various parameters in [riak.conf][configuring] depending on how much memory your riak nodes will have, including `max_running_fsms`, `max_quanta_span`, `max_concurrent_queries`. It is also worth noting that `max_returned_data_size` is calculated differently for ORDER BY statements; you can read more about that [here][configuring]. All of these settings impact the maximum size of data you can retrieve at one time, and it is important to understand your environmental limitations or you run the risk of an out-of-memory condition.
+
+However, the most effective means of speeding up your `ORDER BY` queries is to place the query buffer directory (`timeseries_query_buffers_root_path`) on fast storage or in memory-backed /tmp directory.
 {{% /note %}}
+
 
 ## Overview
 
@@ -37,6 +43,8 @@ ORDER BY column_name [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...]
 ```
 
 During an `ORDER BY` sort if two rows are equal according to the leftmost column, they are compared according to the next column, and so on.
+
+Note that when using `LIMIT`, the `max_returned_data_size` is calculated differently. You can read more about how it is calculated [here][configuring].
 
 ### Options
 

--- a/content/riak/ts/1.5.0/using/querying/select/order-by.md
+++ b/content/riak/ts/1.5.0/using/querying/select/order-by.md
@@ -26,7 +26,7 @@ This document shows how to run various queries using `ORDER BY`. See the [guidel
 {{% note title="A Note on Latency" %}}
 `ORDER BY` uses on-disk query buffer to prevent overload, which adds some overhead and increases the query latency.
 
-You may adjust various parameters in [riak.conf][configuring] depending on how much memory your riak nodes will have, including `max_running_fsms`, `max_quanta_span`, `max_concurrent_queries`. It is also worth noting that `max_returned_data_size` is calculated differently for ORDER BY statements; you can read more about that [here][configuring]. All of these settings impact the maximum size of data you can retrieve at one time, and it is important to understand your environmental limitations or you run the risk of an out-of-memory condition.
+You may adjust various parameters in [riak.conf](/riak/ts/1.5.0/configuring/riakconf/) depending on how much memory your riak nodes will have, including `max_running_fsms`, `max_quanta_span`, `max_concurrent_queries`. It is also worth noting that `max_returned_data_size` is calculated differently for ORDER BY statements; you can read more about that [here](/riak/ts/1.5.0/configuring/riakconf/#maximum-returned-data-size). All of these settings impact the maximum size of data you can retrieve at one time, and it is important to understand your environmental limitations or you run the risk of an out-of-memory condition.
 
 However, the most effective means of speeding up your `ORDER BY` queries is to place the query buffer directory (`timeseries_query_buffers_root_path`) on fast storage or in memory-backed /tmp directory.
 {{% /note %}}

--- a/content/riak/ts/1.5.1/configuring/riakconf.md
+++ b/content/riak/ts/1.5.1/configuring/riakconf.md
@@ -118,8 +118,8 @@ riak_kv.query.timeseries.max_quanta_span = 5000
 
 When a query is broken down into per-quantum subqueries, all subqueries are queued for execution. Starting from the arrival of the second result set, we estimate the projected query result size as:
 
-* `TotalQuerySize = AverageSubqueryResultSize * NumberOfSubqueries`, for regular queries without a `LIMIT` clause;
-* `TotalQuerySize = AverageSubqueryResultSize * LimitValue`, for queries with a `LIMIT` clause.
+* `TotalQuerySize = AverageSubqueryResultSize * NumberOfSubqueries`, for regular queries without a LIMIT or ORDER BY clause;
+* `TotalQuerySize = AverageSubqueryResultSize * LimitValue`, for queries with a LIMIT or ORDER BY clause.
 
 If the total size is found to exceed `max_returned_data_size`, the query is cancelled, with an error code 1022 ("Projected result of a SELECT query is too big").
 

--- a/content/riak/ts/1.5.1/using/querying/select/limit.md
+++ b/content/riak/ts/1.5.1/using/querying/select/limit.md
@@ -23,8 +23,12 @@ The LIMIT statement is used with [`SELECT`][select] to return a limited number o
 
 This document shows how to run various queries using `LIMIT`. See the [guidelines][query guidelines] for more information on limitations and rules for queries in Riak TS.
 
-{{% note title="Warning" %}}
-The initial implementation of `LIMIT` in SELECT queries uses on-disk query buffer. It adds some overhead which increases the query latency, sometimes significantly.
+{{% note title="A Note on Latency" %}}
+`LIMIT` uses on-disk query buffer to prevent overload, which adds some overhead and increases the query latency.
+
+You may adjust various parameters in [riak.conf][configuring] depending on how much memory your riak nodes will have, including `max_running_fsms`, `max_quanta_span`, `max_concurrent_queries`. It is also worth noting that `max_returned_data_size` is calculated differently for LIMIT statements; you can read more about that [here][configuring]. All of these settings impact the maximum size of data you can retrieve at one time, and it is important to understand your environmental limitations or you run the risk of an out-of-memory condition.
+
+However, the most effective means of speeding up your `LIMIT` queries is to place the query buffer directory (`timeseries_query_buffers_root_path`) on fast storage or in memory-backed /tmp directory.
 {{% /note %}}
 
 
@@ -39,9 +43,6 @@ LIMIT «number_rows» [ OFFSET «offset_rows» ]
 ```
 
 The OFFSET modifier can be used with `LIMIT` to skip a specified number of results and return the remaining results ([example below](#offset-results)).
-
-Note that when using `LIMIT`, the `max_returned_data_size` is calculated differently. You can read more about how it is calculated [here][configuring].
-
 
 {{% note title="WARNING" %}}
 Before you run `SELECT` you must ensure the node issuing the query has adequate memory to receive the response. If the returning rows do not fit into the memory of the requesting node, the node is likely to fail.

--- a/content/riak/ts/1.5.1/using/querying/select/limit.md
+++ b/content/riak/ts/1.5.1/using/querying/select/limit.md
@@ -26,7 +26,7 @@ This document shows how to run various queries using `LIMIT`. See the [guideline
 {{% note title="A Note on Latency" %}}
 `LIMIT` uses on-disk query buffer to prevent overload, which adds some overhead and increases the query latency.
 
-You may adjust various parameters in [riak.conf][configuring] depending on how much memory your riak nodes will have, including `max_running_fsms`, `max_quanta_span`, `max_concurrent_queries`. It is also worth noting that `max_returned_data_size` is calculated differently for LIMIT statements; you can read more about that [here][configuring]. All of these settings impact the maximum size of data you can retrieve at one time, and it is important to understand your environmental limitations or you run the risk of an out-of-memory condition.
+You may adjust various parameters in [riak.conf](/riak/ts/1.5.1/configuring/riakconf/) depending on how much memory your riak nodes will have, including `max_running_fsms`, `max_quanta_span`, `max_concurrent_queries`. It is also worth noting that `max_returned_data_size` is calculated differently for LIMIT statements; you can read more about that [here](/riak/ts/1.5.1/configuring/riakconf/#maximum-returned-data-size). All of these settings impact the maximum size of data you can retrieve at one time, and it is important to understand your environmental limitations or you run the risk of an out-of-memory condition.
 
 However, the most effective means of speeding up your `LIMIT` queries is to place the query buffer directory (`timeseries_query_buffers_root_path`) on fast storage or in memory-backed /tmp directory.
 {{% /note %}}

--- a/content/riak/ts/1.5.1/using/querying/select/order-by.md
+++ b/content/riak/ts/1.5.1/using/querying/select/order-by.md
@@ -17,14 +17,20 @@ canonical_link: "https://docs.basho.com/riak/ts/latest/using/querying/select/ord
 
 [select]: /riak/ts/1.5.1/using/querying/select
 [query guidelines]: /riak/ts/1.5.1/using/querying/guidelines/
+[configuring]: /riak/ts/1.5.1/configuring/riakconf/#maximum-returned-data-size
 
 The ORDER BY statement is used with [`SELECT`][select] to sort results by one or more columns in ascending or descending order. `ORDER BY` is useful for operations such as returning the most recent results in a set.
 
 This document shows how to run various queries using `ORDER BY`. See the [guidelines][query guidelines] for more information on limitations and rules for queries in Riak TS.
 
-{{% note title="Warning" %}}
-The initial implementation of `ORDER BY` in SELECT queries uses on-disk query buffer. It adds some overhead which increases the query latency, sometimes significantly.
+{{% note title="A Note on Latency" %}}
+`ORDER BY` uses on-disk query buffer to prevent overload, which adds some overhead and increases the query latency.
+
+You may adjust various parameters in [riak.conf][configuring] depending on how much memory your riak nodes will have, including `max_running_fsms`, `max_quanta_span`, `max_concurrent_queries`. It is also worth noting that `max_returned_data_size` is calculated differently for ORDER BY statements; you can read more about that [here][configuring]. All of these settings impact the maximum size of data you can retrieve at one time, and it is important to understand your environmental limitations or you run the risk of an out-of-memory condition.
+
+However, the most effective means of speeding up your `ORDER BY` queries is to place the query buffer directory (`timeseries_query_buffers_root_path`) on fast storage or in memory-backed /tmp directory.
 {{% /note %}}
+
 
 ## Overview
 

--- a/content/riak/ts/1.5.1/using/querying/select/order-by.md
+++ b/content/riak/ts/1.5.1/using/querying/select/order-by.md
@@ -26,7 +26,7 @@ This document shows how to run various queries using `ORDER BY`. See the [guidel
 {{% note title="A Note on Latency" %}}
 `ORDER BY` uses on-disk query buffer to prevent overload, which adds some overhead and increases the query latency.
 
-You may adjust various parameters in [riak.conf][configuring] depending on how much memory your riak nodes will have, including `max_running_fsms`, `max_quanta_span`, `max_concurrent_queries`. It is also worth noting that `max_returned_data_size` is calculated differently for ORDER BY statements; you can read more about that [here][configuring]. All of these settings impact the maximum size of data you can retrieve at one time, and it is important to understand your environmental limitations or you run the risk of an out-of-memory condition.
+You may adjust various parameters in [riak.conf](/riak/ts/1.5.1/configuring/riakconf/) depending on how much memory your riak nodes will have, including `max_running_fsms`, `max_quanta_span`, `max_concurrent_queries`. It is also worth noting that `max_returned_data_size` is calculated differently for ORDER BY statements; you can read more about that [here](/riak/ts/1.5.1/configuring/riakconf/#maximum-returned-data-size). All of these settings impact the maximum size of data you can retrieve at one time, and it is important to understand your environmental limitations or you run the risk of an out-of-memory condition.
 
 However, the most effective means of speeding up your `ORDER BY` queries is to place the query buffer directory (`timeseries_query_buffers_root_path`) on fast storage or in memory-backed /tmp directory.
 {{% /note %}}


### PR DESCRIPTION
Per Andrei, there is not a lot for someonet to do re: backend implementation of LIMIT/ORDER BY and their use of query buffers. However, there are a couple things they can pay attention to. Updated both 1.5.0 and 1.5.1 LIMIT/ORDER BY pages with that information and added ORDER BY to riakconf page.