### PR TITLE
Minor wording tweaks

### DIFF
--- a/content/riak/ts/1.6.0/configuring/riakconf.md
+++ b/content/riak/ts/1.6.0/configuring/riakconf.md
@@ -129,9 +129,9 @@ riak_kv.query.timeseries.max_returned_data_size = 10*1000*1000
 
 ### Maximum total size of query buffers held in memory
 
-`riak_kv.query.timeseries.qbuf_inmem_max`: Max heap size of the query buffer manager process before query buffers start to be written out to the leveldb backend.  Default value is "10MB".
+`riak_kv.query.timeseries.qbuf_inmem_max`: Max heap size of a query buffer manager process before its query buffer is written out to the leveldb backend.  Default value is "10MB".
 
-The query buffer manager tries to keep collected query results in memory for faster retrieval.  To avoid accumulating excessive amounts of data, this parameter sets the max process heap limit the query buffer manager can allocate before it dumps the entire query buffer with which the limit was hit, to the leveldb backend (and proceeds to add eventual chunks to it).
+For any `LIMIT` or `ORDER BY` timeseries queries, a query buffer manager is created. It initially stores query results in memory for faster retrieval.  To avoid accumulating excessive amounts of data, this parameter sets the max process heap limit the query buffer manager can allocate before it dumps the entire query buffer to the leveldb backend for further write and read activity.
 
 ```riak.conf
 riak_kv.query.timeseries.qbuf_inmem_max = "10MB"


### PR DESCRIPTION
* Avoid ambiguity on the non-singular nature of query buffer managers
* Clarify when query buffers are used

References code changes in https://github.com/basho/riak_kv/pull/1587

/cc @hmmr 