### PR TITLE
Use the correct format for data-modeling redirects

### DIFF
--- a/content/riak/kv/2.0.0/developing/data-modeling.md
+++ b/content/riak/kv/2.0.0/developing/data-modeling.md
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-target: "/riak/kv/2.0.0/learn/use-cases.md"
+target: "riak/kv/2.0.0/learn/use-cases/"
 ---
 
 This page exists solely to redirect from the generated URL to the above `target`

--- a/content/riak/kv/2.0.1/developing/data-modeling.md
+++ b/content/riak/kv/2.0.1/developing/data-modeling.md
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-target: "/riak/kv/2.0.1/learn/use-cases.md"
+target: "riak/kv/2.0.1/learn/use-cases/"
 ---
 
 This page exists solely to redirect from the generated URL to the above `target`

--- a/content/riak/kv/2.0.2/developing/data-modeling.md
+++ b/content/riak/kv/2.0.2/developing/data-modeling.md
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-target: "/riak/kv/2.0.2/learn/use-cases.md"
+target: "riak/kv/2.0.2/learn/use-cases/"
 ---
 
 This page exists solely to redirect from the generated URL to the above `target`

--- a/content/riak/kv/2.0.4/developing/data-modeling.md
+++ b/content/riak/kv/2.0.4/developing/data-modeling.md
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-target: "/riak/kv/2.0.4/learn/use-cases.md"
+target: "riak/kv/2.0.4/learn/use-cases/"
 ---
 
 This page exists solely to redirect from the generated URL to the above `target`

--- a/content/riak/kv/2.0.5/developing/data-modeling.md
+++ b/content/riak/kv/2.0.5/developing/data-modeling.md
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-target: "/riak/kv/2.0.5/learn/use-cases.md"
+target: "riak/kv/2.0.5/learn/use-cases/"
 ---
 
 This page exists solely to redirect from the generated URL to the above `target`

--- a/content/riak/kv/2.0.6/developing/data-modeling.md
+++ b/content/riak/kv/2.0.6/developing/data-modeling.md
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-target: "/riak/kv/2.0.6/learn/use-cases.md"
+target: "riak/kv/2.0.6/learn/use-cases/"
 ---
 
 This page exists solely to redirect from the generated URL to the above `target`

--- a/content/riak/kv/2.0.7/developing/data-modeling.md
+++ b/content/riak/kv/2.0.7/developing/data-modeling.md
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-target: "/riak/kv/2.0.7/learn/use-cases.md"
+target: "riak/kv/2.0.7/learn/use-cases/"
 ---
 
 This page exists solely to redirect from the generated URL to the above `target`

--- a/content/riak/kv/2.1.1/developing/data-modeling.md
+++ b/content/riak/kv/2.1.1/developing/data-modeling.md
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-target: "/riak/kv/2.1.1/learn/use-cases.md"
+target: "riak/kv/2.1.1/learn/use-cases/"
 ---
 
 This page exists solely to redirect from the generated URL to the above `target`

--- a/content/riak/kv/2.1.3/developing/data-modeling.md
+++ b/content/riak/kv/2.1.3/developing/data-modeling.md
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-target: "/riak/kv/2.1.3/learn/use-cases.md"
+target: "riak/kv/2.1.3/learn/use-cases/"
 ---
 
 This page exists solely to redirect from the generated URL to the above `target`

--- a/content/riak/kv/2.1.4/developing/data-modeling.md
+++ b/content/riak/kv/2.1.4/developing/data-modeling.md
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-target: "/riak/kv/2.1.4/learn/use-cases.md"
+target: "riak/kv/2.1.4/learn/use-cases/"
 ---
 
 This page exists solely to redirect from the generated URL to the above `target`

--- a/content/riak/kv/2.2.0/developing/data-modeling.md
+++ b/content/riak/kv/2.2.0/developing/data-modeling.md
@@ -1,6 +1,6 @@
 ---
 layout: redirect
-target: "/riak/kv/2.2.0/learn/use-cases.md"
+target: "riak/kv/2.2.0/learn/use-cases/"
 ---
 
 This page exists solely to redirect from the generated URL to the above `target`


### PR DESCRIPTION
Like it says on the tin. Fixes a typo from #2416 