### PR TITLE
Add note about manual URL requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Please let us know if you'd like to help out!
 
 >**Heads-up**
 >
-> When running a local instance of the site, you can't navigate from the splash page (the first page when you navigate to localhost:1313) to the most recent version of KV, TS, or CS. You will need to manually enter the version you want in the address bar of your browser. So, for instance, http://localhost:1313/riak/kv/2.2.0/ rather than http://localhost:1313/riak/kv/latest/.
+> When running a local instance of the site, you can't navigate from the splash page (the first page when you navigate to localhost:1313) to the index page of KV, TS, or CS. You will need to manually enter the version in the address bar of your browser. So, for instance, http://localhost:1313/riak/kv/2.2.0/ rather than http://localhost:1313/riak/kv/latest/.
 
 [hugo]: http://gohugo.io/
 [installing hugo]: http://gohugo.io/overview/installing/

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Please let us know if you'd like to help out!
 
 1. Play by visiting <http://localhost:1313>.
 
+>**Heads-up**
+>
+> When running a local instance of the site, you can't navigate from the splash page (the first page when you navigate to localhost:1313) to the most recent version of KV, TS, or CS. You will need to manually enter the version you want in the address bar of your browser. So, for instance, http://localhost:1313/riak/kv/2.2.0/ rather than http://localhost:1313/riak/kv/latest/.
+
 [hugo]: http://gohugo.io/
 [installing hugo]: http://gohugo.io/overview/installing/
 [homebrew]: http://brew.sh/


### PR DESCRIPTION
With the site redesign, the way the redirects from the splash page work has changed and is limited to/dependent on the S3 bucket. Which means that, in order to get from the splash page to the KV/TS/CS index page, you must manually enter version number in the URL. 

Alternatively, you can sit around thinking it/your laptop is broken like I did. But I don't recommend this approach.