### PR TITLE
Added information about tiered LevelDB repair

### DIFF
--- a/content/riak/kv/2.2.0/using/repair-recovery/repairs.md
+++ b/content/riak/kv/2.2.0/using/repair-recovery/repairs.md
@@ -50,7 +50,7 @@ The `riak-admin repair-2i` command can be used to repair any stale or missing se
 The secondary indexes of a single partition can be repaired by executing:
 
 ```bash
-riak-admin repair-2i <Partition_ID>
+riak-admin repair-2i »Partition ID«
 ```
 
 The secondary indexes of every partition can be repaired by executing the same command, without a partition ID:
@@ -291,10 +291,10 @@ be repaired.
 2. Execute the repair for a single partition using the below command:
 
     ```erlang
-    riak_kv_vnode:repair(<Partition_ID>).
+    riak_kv_vnode:repair(»Partition ID«).
     ```
 
-    where `<Partition_ID>` is replaced by the ID of the partition to
+    where `»Partition_ID«` is replaced by the ID of the partition to
     repair. For example:
 
     ```erlang

--- a/content/riak/kv/2.2.0/using/repair-recovery/repairs.md
+++ b/content/riak/kv/2.2.0/using/repair-recovery/repairs.md
@@ -147,21 +147,23 @@ application:set_env(eleveldb, data_root, "").
 ```erlang
 Options = [].
 ```
-5\. For each corrupted LevelDB that you found using the [`find` command above](#checking-for-compaction-errors), run the following `repair` command, substituting the path to your LevelDB vnodes and the appropriate vnode number:
+
+5\. Set some supportive variables for the repair process.  These will be custom to your environment and specific repair needs.
+VNodeList should be a list of each corrupted LevelDB that you found using the [`find` command above](#checking-for-compaction-errors).
 
 ```erlang
 DataRoot = "»path to your data root«".
-VNodeNumber = "»vnode id you want to repair«".
-RepairPath = DataRoot ++ "/" ++ VNodeNumber.
-eleveldb:repair(RepairPath, Options).
+VNodeList = ["»vnode id you want to repair«", ...].
 ```
-If you are comfortable reading Erlang, this can be reduced to a one-liner:
+
+6\. Run the following commands, which will parse the information you provided and run eleveldb:repair over all of the VNode IDs that you listed in VNodeList.
 
 ```erlang
-eleveldb:repair("/»data root«/»vnode id«", Options).
+RepairPath = fun(DataRoot, VNodeNumber) -> Path = lists:flatten(DataRoot ++ "/" ++ VNodeNumber), io:format("Repairing ~s.~n",[Path]), Path end.
+[eleveldb:repair(RepairPath(DataRoot, VNodeList), Options) || VNodeNumber <- VNodeList].
 ```
 
-6\. This process may take several minutes. When it has completed successfully, you can restart the node and continue as usual.
+7\. This process may take several minutes. When it has completed successfully, you can restart the node and continue as usual.
 
 ```bash
 riak start
@@ -209,21 +211,21 @@ Options = [
 ].
 ```
 
-6\. For each corrupted LevelDB that you found using the [`find` command above](#checking-for-compaction-errors), run the following `repair` command, substituting the path to your LevelDB vnodes and the appropriate vnode number:
+6\. Set some supportive variables for the repair process.  These will be custom to your environment and specific repair needs.
+VNodeList should be a list of each corrupted LevelDB partitions that you found using the [`find` command above](#checking-for-compaction-errors) provided in double quotes.
 
 ```erlang
 DataRoot = "»path to your data root«".
-VNodeNumber = "»vnode id you want to repair«".
-RepairPath = DataRoot ++ "/" ++ VNodeNumber.
-eleveldb:repair(RepairPath, Options).
+VNodeList = ["»vnode id you want to repair«", ...].
 ```
-If you are comfortable reading Erlang, this can be reduced to a one-liner:
+
+7\. Run the following commands, which will parse the information you provided and run eleveldb:repair over all of the VNode IDs that you listed in VNodeList.
 
 ```erlang
-eleveldb:repair("/»data root«/»vnode id«", Options).
+RepairPath = fun(DataRoot, VNodeNumber) -> Path = lists:flatten(DataRoot ++ "/" ++ VNodeNumber), io:format("Repairing ~s.~n",[Path]), Path end.
+[eleveldb:repair(RepairPath(DataRoot, VNodeList), Options) || VNodeNumber <- VNodeList].
 ```
-
-7\. This process may take several minutes. When it has completed successfully, you can restart the node and continue as usual.
+8\. This process may take several minutes. When it has completed successfully, you can restart the node and continue as usual.
 
 ```bash
 riak start


### PR DESCRIPTION
Per #1976 (DOC-278), this incorporates the changes MVM mentioned for repairing LevelDB when tiered storage is enabled.