### PR TITLE
Add aioriak to supported riak versions.

### DIFF
--- a/content/riak/kv/2.1.3/developing/client-libraries.md
+++ b/content/riak/kv/2.1.3/developing/client-libraries.md
@@ -242,6 +242,9 @@ level of maturity and activity.
 
 #### Python
 
+* [Aioriak](https://github.com/rambler-digital-solutions/aioriak) 
+  --- Asyncio PBC Riak 2.0+ client library. (Based on official Basho 
+  python client)
 * [Riakasaurus](https://github.com/calston/riakasaurus) --- A Riak
   client library for Twisted (based on txriak)
 * [RiakKit](http://shuhaowu.com/riakkit) --- A small Python ORM that

--- a/content/riak/kv/2.2.0/developing/client-libraries.md
+++ b/content/riak/kv/2.2.0/developing/client-libraries.md
@@ -242,6 +242,9 @@ level of maturity and activity.
 
 #### Python
 
+* [Aioriak](https://github.com/rambler-digital-solutions/aioriak) 
+  --- Asyncio PBC Riak 2.0+ client library. (Based on official Basho 
+  python client)
 * [Riakasaurus](https://github.com/calston/riakasaurus) --- A Riak
   client library for Twisted (based on txriak)
 * [RiakKit](http://shuhaowu.com/riakkit) --- A small Python ORM that


### PR DESCRIPTION
Add link to asyncio python client library for next versions:

    - 2.1.3
    - 2.2.0