### PR TITLE
Fix typo

### DIFF
--- a/content/riak/kv/2.2.0/developing/api/protocol-buffers/dt-store.md
+++ b/content/riak/kv/2.2.0/developing/api/protocol-buffers/dt-store.md
@@ -78,7 +78,7 @@ a special value denoting `one` (`4294967295-1`), `quorum`
 
 Parameter | Description
 :---------|:-----------
-`key` | The key where the Data Type is stored. If not specified, Riak will assign a random key and return that key to the client is `return_body` is set to `true`.
+`key` | The key where the Data Type is stored. If not specified, Riak will assign a random key and return that key to the client if `return_body` is set to `true`.
 `context` | The opaque binary "context" that informs Riak which version of a data type the client has seen, analogous to [vector clocks](/riak/kv/2.2.0/learn/glossary/#vector-clock)
 `w` | Write quorum, i.e. how many replicas to write to before returning a successful response
 `dw` | Durable write quorum, i.e. how many replicas to commit to durable storage before returning a successful response


### PR DESCRIPTION
The typo fix is correct I believe.

Off-topic: I am a bit surprised that the PBC client needs to request the body for getting the key - I would expect that the client gets the key in response if not specified in request regardless from body.