### PR TITLE
Use Hugo shortcodes rather than `<div class="note">` elements

### DIFF
--- a/content/dataplatform/1.0.0/configuring/cache-proxy.md
+++ b/content/dataplatform/1.0.0/configuring/cache-proxy.md
@@ -57,9 +57,11 @@ If you skipped the configuration instructions or would otherwise like to set up 
 
 If you are curious about cache proxy's internal configuration or just want to look at your configuration to make sure it is correct or to see what hostname and port is being used, you can find it in `$BDP_PRIV/cache_proxy/config/cache_proxy_$CACHE_PROXY_PORT.yml`.
 
-<div class="note">
-This level of knowledge is not necessary for normal operation, but may come in handy when diagnosing and resolving issues, such as a firewall rule not allowing ingress to the cache proxy host on the configured port.
-</div>
+{{% note %}}
+This level of knowledge is not necessary for normal operation, but may come in
+handy when diagnosing and resolving issues, such as a firewall rule not
+allowing ingress to the cache proxy host on the configured port.
+{{% /note %}}
 
 
 Once you've opened the file, you might find the following settings helpful:

--- a/content/dataplatform/1.0.0/configuring/replace-spark-cluster-manager.md
+++ b/content/dataplatform/1.0.0/configuring/replace-spark-cluster-manager.md
@@ -111,15 +111,18 @@ ps -ef | grep [s]park-worker
 
 A successful activation should cause an output like the following (with the IP address and port number of the spark-master service you specified): `worker.Worker --webui-port 8081 spark://172.28.128.3:7077`.
 
-<div class="note">
-If you see a hostname rather than an IP address OR if this is your first time starting the worker service, you must:
+{{% note %}}
+If you see a hostname rather than an IP address OR if this is your first time
+starting the worker service, you must:
 
-1. Stop the service: `sudo data-platform-admin stop-service riak@»PUBLICIPOFWORKERNODE« my-spark-group my-spark-worker`
+1. Stop the service: `sudo data-platform-admin stop-service
+   riak@»PUBLICIPOFWORKERNODE« my-spark-group my-spark-worker`
 
 2. Kill the process: `sudo pkill -f deploy.worker.Worker`
 
-3. And then restart the service: `sudo data-platform-admin start-service riak@»PUBLICIPOFWORKERNODE« my-spark-group my-spark-worker`.
-</div>
+3. And then restart the service: `sudo data-platform-admin start-service
+   riak@»PUBLICIPOFWORKERNODE« my-spark-group my-spark-worker`.
+{{% /note %}}
 
 ### Verify The Services Are Running
 At this point, your BDP manager and Spark cluster should be ready to go! Here are some ways to verify that your Spark cluster is connected to the BDP manager and running correctly. 

--- a/content/dataplatform/1.0.0/configuring/setup-a-cluster.md
+++ b/content/dataplatform/1.0.0/configuring/setup-a-cluster.md
@@ -80,9 +80,10 @@ user@machine2:~$ sudo data-platform-admin join »NODENAME, ie riak@IPADDRESS)«
 
 Once your BDP nodes are started and joined together, make sure [riak_ensemble][riak_ensemble] has started.
 
-<div class="note">
-Basho Data Platform will not function correctly if `riak_ensemble` is not running. 
-</div>
+{{% note %}}
+Basho Data Platform will not function correctly if `riak_ensemble` is not
+running.
+{{% /note %}}
 
 To check the status of `riak_ensemble`:
 
@@ -113,9 +114,12 @@ Before enabling the leader election service, you must have enabled `riak_ensembl
 2. Find the line `## listener.leader_latch.internal = 127.0.0.1:5323`.
 3. Uncomment the line and set to your node's IP and port. (**Note:** Any port will work as long as it matches what you set in the Spark master step below.)
 
-<div class="note">
-The leader election service provides no authentication mechanism. We strongly suggest that you use a network shielded from external connection attempts, otherwise you run the risk of an attacker performing a Denial of Service attack against your cluster.
-</div>
+{{% note %}}
+The leader election service provides no authentication mechanism. We strongly
+suggest that you use a network shielded from external connection attempts,
+otherwise you run the risk of an attacker performing a Denial of Service
+attack against your cluster.
+{{% /note %}}
 
 Add any additional interface/port pairs to listen on and change the '.internal' to whatever name helps you identify your interfaces. For instance:
 
@@ -125,16 +129,18 @@ listener.leader_latch.external = 10.10.1.2:15323
 listener.leader_latch.testing = 192.168.0.42:12345
 ```
 
-<div class="note">
-Changes to the `listener.leader_latch` setting will not have an impact on a live running node. You must restart the node for changes to take effect.
-</div>
+{{% note %}}
+Changes to the `listener.leader_latch` setting will not have an impact on a
+live running node. You must restart the node for changes to take effect.
+{{% /note %}}
 
 
 ### Set Up Spark Cluster Metadata
 
-<div class="note">
-Follow these steps ONLY if you are running a Spark cluster. Otherwise, skip to Add Services.
-</div>
+{{% note %}}
+Follow these steps ONLY if you are running a Spark cluster. Otherwise, skip to
+Add Services.
+{{% /note %}}
 
 If you are running a Spark cluster, you need to connect it with BDP.
 

--- a/content/riak/cs/2.0.0/cookbooks/account-management.md
+++ b/content/riak/cs/2.0.0/cookbooks/account-management.md
@@ -24,12 +24,11 @@ curl -X POST http://localhost:8080/riak-cs/user \
   --data '{"email":"foobar@example.com", "name":"foo bar"}' \
 ```
 
-<div class="note">
-<div class="title">Note on admin users</div>
-By default, only the admin user may create new user accounts. If you
-need to create a user account without authenticating yourself, you must
-set `{anonymous_user_creation, true}` in the Riak CS `app.config`.
-</div>
+{{% note title="Note on admin users" %}}
+By default, only the admin user may create new user accounts. If you need to
+create a user account without authenticating yourself, you must set
+`{anonymous_user_creation, true}` in the Riak CS `app.config`.
+{{% /note %}}
 
 The submitted user document may be either JSON or XML, but the type
 should match the value of the `Content-Type` header used. Here are some
@@ -187,13 +186,12 @@ The documents should resemble the following examples.
 </UserUpdate>
 ```
 
-<div class="note">
-<div class="title">Note on update fields</div>
-The `new_key_secret` field (or `NewKeySecret` in XML) may be combined
-with other user update fields in the same request.  Currently, the only
-other supported field is status, but more may be added in the future.
-Unsupported fields are ignored.
-</div>
+{{% note title="Note on update fields" %}}
+The `new_key_secret` field (or `NewKeySecret` in XML) may be combined with
+other user update fields in the same request.  Currently, the only other
+supported field is status, but more may be added in the future. Unsupported
+fields are ignored.
+{{% /note %}}
 
 ## Retrieving a List of All Users
 
@@ -204,12 +202,11 @@ is rejected and a `403 Forbidden` error is returned. This request does
 not properly work with s3cmd, but can be performed using a less dogmatic
 tool such as [s3-curl](http://aws.amazon.com/code/128).
 
-<div class="info">
-<div class="title">Note on hostname</div>
-You must modify the `@endpoints` variable in the `s3curl.pl` script to
-include your Riak CS hostname so that the following example will return
-the list of users.
-</div>
+{{% note title="Note on hostname" %}}
+You must modify the `@endpoints` variable in the `s3curl.pl` script to include
+your Riak CS hostname so that the following example will return the list of
+users.
+{{% /note %}}
 
 A sample URL for a user listing request looks like this:
 

--- a/content/riak/cs/2.0.0/cookbooks/command-line-tools.md
+++ b/content/riak/cs/2.0.0/cookbooks/command-line-tools.md
@@ -84,11 +84,10 @@ Stops all applications and starts without restarting the Erlang VM.
 riak-cs reboot
 ```
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The <code>riak-cs reboot</code> command has been deprecated. We
-recommend using the <code>riak-cs restart</code> command instead.
-</div>
+{{% note title="Deprecation notice" %}}
+The `riak-cs reboot` command has been deprecated. We recommend using the
+`riak-cs restart` command instead.
+{{% /note %}}
 
 #### ping
 
@@ -524,12 +523,10 @@ Riak CS version 1.5 offers support for supercluster operations. The
 `supercluster` command interface enables you to interact with that system.
 More information can be found in [Riak CS Supercluster Support](/riak/cs/2.0.0/cookbooks/supercluster).
 
-<div class="note">
-<div class="title">Note: technical preview</div>
+{{% note title="Note: technical preview" %}}
 Riak CS supercluster support is available only as a technical preview for
-users of Riak CS installations with support for Multi-Datacenter
-Replication.
-</div>
+users of Riak CS installations with support for Multi-Datacenter Replication.
+{{% /note %}}
 
 #### list-members
 

--- a/content/riak/cs/2.0.0/cookbooks/configuration/dragondisk.md
+++ b/content/riak/cs/2.0.0/cookbooks/configuration/dragondisk.md
@@ -59,12 +59,10 @@ save an account. The following describes the process for doing so.
 * Enter the Riak CS public interface HTTP port into the **HTTP Port**
   field.
 
-<div class="note">
-<div class="title">Note on HTTPS</div>
-If you'll be using HTTPS, be sure to enter the correct public HTTPS port
-into the **HTTPS Port** field and click the **Connect
-using SSL/HTTS** check box.
-</div>
+{{% note title="Note on HTTPS" %}}
+If you'll be using HTTPS, be sure to enter the correct public HTTPS port into
+the **HTTPS Port** field and click the **Connect using SSL/HTTS** check box.
+{{% /note %}}
 
 * Click **OK** to save the account configuration.
 
@@ -163,12 +161,10 @@ save an account. The following describes the process for doing so.
 * Enter the Riak CS public interface HTTP port into the **HTTP Port**
   field.
 
-<div class="note">
-<div class="title">Note on HTTPS</div>
-If you'll be using HTTPS, be sure to enter the correct public HTTPS port
-into the **HTTPS Port** field and click the **Connect using SSL/HTTS**
-check box.
-</div>
+{{% note title="Note on HTTPS" %}}
+If you'll be using HTTPS, be sure to enter the correct public HTTPS port into
+the **HTTPS Port** field and click the **Connect using SSL/HTTS** check box.
+{{% /note %}}
 
 * Click **OK** to save the account configuration.
 
@@ -268,12 +264,10 @@ save an account. The following describes the process for doing so.
 * Enter the Riak CS public interface HTTP port into the **HTTP Port**
   field.
 
-<div class="note">
-<div class="title">Note on HTTPS</div>
-If you'll be using HTTPS, be sure to enter the correct public HTTPS port
-into the **HTTPS Port** field and click the **Connect using SSL/HTTS**
-check box.
-</div>
+{{% note title="Note on HTTPS" %}}
+If you'll be using HTTPS, be sure to enter the correct public HTTPS port into
+the **HTTPS Port** field and click the **Connect using SSL/HTTS** check box.
+{{% /note %}}
 
 * Click **OK** to save the account configuration.
 

--- a/content/riak/cs/2.0.0/cookbooks/configuration/multi-datacenter.md
+++ b/content/riak/cs/2.0.0/cookbooks/configuration/multi-datacenter.md
@@ -14,12 +14,10 @@ aliases:
   - /riak/cs/2.0.0/cookbooks/configuration/Configuring-MDC/
 ---
 
-<div class="note">
-<div class="title">Riak CS Enterprise requires a separate download</div>
-Please note that Riak CS Enterprise requires a download separate from
-the open-source Riak CS, which will not work in conjunction with Riak
-Enterprise.
-</div>
+{{% note title="Riak CS Enterprise requires a separate download" %}}
+Please note that Riak CS Enterprise requires a download separate from the
+open-source Riak CS, which will not work in conjunction with Riak Enterprise.
+{{% /note %}}
 
 Configuring Multi-Datacenter Replication in Riak CS requires the
 addition of a new group of settings to the `app.config` configuration

--- a/content/riak/cs/2.0.0/cookbooks/configuration/reference.md
+++ b/content/riak/cs/2.0.0/cookbooks/configuration/reference.md
@@ -92,23 +92,25 @@ Most of the settings you will need to manipulate have been ported into the newer
 such as setting up customized `lager` streams -- that will need to be configured
 in `advanced.config`.
 
-<div class="note"><div class="title">A Note About Time Values</div>
+{{% note title="A Note About Time Values" %}}
 In the `app.config` configuration files, time periods were generally written
 as either seconds or milliseconds, with no real indication of which was being
 used. With the update to `riak-cs.conf`, all values that describe a period of
-time are written as an integer and a character, describing the unit of time and
-the number of times that unit should be repeated for the period. For example
-`31d` represents 31 days, `6h` represents six hours, `6000ms` represents 6,000
-milliseconds.</br>
-The full list of valid time units are as follows:</br>
-`f` -- Fortnights</br>
-`w` -- Weeks</br>
-`d` -- Days</br>
-`h` -- Hours</br>
-`m` -- Minutes</br>
-`s` -- Seconds</br>
-`ms` -- Milliseconds</br>
-</div>
+time are written as an integer and a character, describing the unit of time
+and the number of times that unit should be repeated for the period. For
+example `31d` represents 31 days, `6h` represents six hours, `6000ms`
+represents 6,000 milliseconds.
+
+The full list of valid time units are as follows:
+
+`f` -- Fortnights
+`w` -- Weeks
+`d` -- Days
+`h` -- Hours
+`m` -- Minutes
+`s` -- Seconds
+`ms` -- Milliseconds
+{{% /note %}}
 
 The tables below will show settings for both `riak-cs.conf` and
 `advanced.config`/`app.config` where applicable, organized by functionality.

--- a/content/riak/cs/2.0.0/cookbooks/configuration/riak-cs.md
+++ b/content/riak/cs/2.0.0/cookbooks/configuration/riak-cs.md
@@ -73,13 +73,12 @@ You will also need to set the host listener for Riak CS:
    port number does not conflict with the `riak_host` port number of the Riak
    node and the Riak CS node that are running on the same machine.
 
-<div class="note">
-<div class="title">Note on IP addresses</div>
-The IP address you enter here must match the IP address specified for
-the Protocol Buffers interface in the Riak <code>riak.conf</code> file
-unless Riak CS is running on a completely different network, in which
-case address translation is required.
-</div>
+{{% note title="Note on IP addresses" %}}
+The IP address you enter here must match the IP address specified for the
+Protocol Buffers interface in the Riak `riak.conf` file unless Riak CS is
+running on a completely different network, in which case address translation
+is required.
+{{% /note %}}
 
 After making any changes to the `riak-cs.conf` file in Riak CS,
 [restart](/riak/cs/2.0.0/cookbooks/command-line-tools/#riak-cs) the node if it is already running.
@@ -144,13 +143,12 @@ The admin user is authorized to perform actions such as creating users or
 obtaining billing statistics. An admin user account is no different from any
 other user account. **You must create an admin user to use Riak CS**.
 
-<div class="note">
-<div class="title">Note on anonymous user creation</div>
-Before creating an admin user, you must first set `anonymous_user_creation = on`
-in the Riak CS `riak-cs.conf` (or set `{anonymous_user_creation, true}` in the
-old-style `advanced.config`/`app.config`). You may disable this again once the
-admin user has been created.
-</div>
+{{% note title="Note on anonymous user creation" %}}
+Before creating an admin user, you must first set `anonymous_user_creation =
+on` in the Riak CS `riak-cs.conf` (or set `{anonymous_user_creation, true}` in
+the old-style `advanced.config`/`app.config`). You may disable this again once
+the admin user has been created.
+{{% /note %}}
 
 To create an account for the admin user, use an HTTP `POST` request with the
 username you want to use for the admin account. The following is an
@@ -413,11 +411,11 @@ settings are available through the `riak-cs.conf` configuration file.**
 * `gc_batch_size` --- This option represents the size used for paginating the
   results of the secondary index query. The default value is 1000.
 
-<div class="note"><div class="title">Deprecated Configurations</div>
+{{% note title="Deprecated Configurations" %}}
 While Riak CS 2.0.0 still allows the configuration of `gc_paginated_indexes`,
 it is strongly recommended that these settings not be used. This setting has
-been deprecated, and <em>will be removed</em> in the next major release.
-</div>
+been deprecated, and _will be removed_ in the next major release.
+{{% /note %}}
 
 ## Other Riak CS Settings
 

--- a/content/riak/cs/2.0.0/cookbooks/configuration/riak-for-cs.md
+++ b/content/riak/cs/2.0.0/cookbooks/configuration/riak-for-cs.md
@@ -155,12 +155,11 @@ buckets.default.allow_mult = true
 This will enable Riak to create [siblings](/riak/kv/2.1.3/learn/concepts/causal-context/#siblings), which is necessary for Riak CS to function. If you are connecting to Riak CS from a [client library](/riak/kv/2.1.3/developing/client-libraries), don't worry: you will not have to manage [conflict resolution](/riak/kv/2.1.3/developing/usage/conflict-resolution), as all Riak CS
 operations are strongly consistent by definition.
 
-<div class="note">
-<div class="title">Note on <code>allow_mult</code></div>
+{{% note title="Note on `allow_mult`" %}}
 Any Riak node that also supports Riak CS should have `allow_mult` set to
-`true` at all times. Riak CS will refuse to start if `allow_mult` is
-set to `false`.
-</div>
+`true` at all times. Riak CS will refuse to start if `allow_mult` is set to
+`false`.
+{{% /note %}}
 
 ## Specifying the Nodename and IP Address
 
@@ -248,12 +247,11 @@ the `pb` value in `advanced.config`/`app.config`) file must match the values for
 `riak_host` in the Riak CS `riak-cs.config` and Stanchion `stanchion.conf` (or
 `riak_host` the relative `advanced.config`/`app.config`) files.
 
-<div class="note">
-<div class="title">Note on port numbers</div>
-A different port number might be required if the port number conflicts
-with ports used by another application or if you use a load balancer or
-proxy server.
-</div>
+{{% note title="Note on port numbers" %}}
+A different port number might be required if the port number conflicts with
+ports used by another application or if you use a load balancer or proxy
+server.
+{{% /note %}}
 
 It is also recommended that users insure that the size of Riak's
 `protobuf.backlog` (or in the `advanced.config`/`app.config` files, the

--- a/content/riak/cs/2.0.0/cookbooks/configuration/stanchion.md
+++ b/content/riak/cs/2.0.0/cookbooks/configuration/stanchion.md
@@ -60,11 +60,11 @@ listener = 127.0.0.1:8080
             ]}
 ```
 
-<div class="note"><div class="title">Note on matching IP addresses</div>
+{{% note title="Note on matching IP addresses" %}}
 The IP address you enter here must match the IP address specified for the
-<code>stanchion_host</code> variable in the Riak <code>riak.conf</code> file and
-the Riak CS <code>riak-cs.conf</code> file.
-</div>
+`stanchion_host` variable in the Riak `riak.conf` file and the Riak CS
+`riak-cs.conf` file.
+{{% /note %}}
 
 If you want to use SSL, make sure the `ssl.certfile` and `ssl.keyfile` settings
 are not commented out, and have been set correctly.

--- a/content/riak/cs/2.0.0/cookbooks/configuration/transmit.md
+++ b/content/riak/cs/2.0.0/cookbooks/configuration/transmit.md
@@ -17,7 +17,10 @@ aliases:
 [Transmit](https://www.panic.com/transmit/) is an S3-compatible client with a
 graphical user interface for Mac OS X. The following guide describes configuration of Transmit for use with Riak CS.
 
-<div class="info"><div class="title">Note</div>S3 support was added in Transmit version 4.4, so ensure that you're following along with a version that supports S3 before continuing.</div>
+{{% note title="Note" %}}
+S3 support was added in Transmit version 4.4, so ensure that you're following
+along with a version that supports S3 before continuing.
+{{% /note %}}
 
 ## Define a Connection
 

--- a/content/riak/cs/2.0.0/cookbooks/designate-admin-user.md
+++ b/content/riak/cs/2.0.0/cookbooks/designate-admin-user.md
@@ -13,9 +13,8 @@ editing and replacing the `admin_key` and `admin_secret` in `app.config`
 with the user's credentials. Once this is done, do not forget to update
 the same credentials in the Stanchion `app.config` as well.
 
-<div class="note">
-<div class="title">Note on the admin role</div>
-This is a powerful role and gives the designee administrative
-capabilities within the system. As such, caution should be used to
-protect the access credentials of the admin user.
-</div>
+{{% note title="Note on the admin role" %}}
+This is a powerful role and gives the designee administrative capabilities
+within the system. As such, caution should be used to protect the access
+credentials of the admin user.
+{{% /note %}}

--- a/content/riak/cs/2.0.0/cookbooks/garbage-collection.md
+++ b/content/riak/cs/2.0.0/cookbooks/garbage-collection.md
@@ -42,14 +42,13 @@ that can be divided into two essential phases:
 
 These two phases are described in more detail in the following sections.
 
-<div class="note">
-<div class="title">Note on manifest pruning</div>
+{{% note title="Note on manifest pruning" %}}
 A Riak CS object's manifest is updated any time a write, i.e. a `PUT` or
 `DELETE` request, is issued, which means that manifest sizes can grow
 significantly over time. This can lead to latency problems. Riak CS's GC
-subsystem will prune these manifests. If you're experiencing
-manifest-related issues, we would recommend using GC.
-</div>
+subsystem will prune these manifests. If you're experiencing manifest-related
+issues, we would recommend using GC.
+{{% /note %}}
 
 ## Synchronous GC Actions
 

--- a/content/riak/cs/2.0.0/cookbooks/monitoring-and-metrics.md
+++ b/content/riak/cs/2.0.0/cookbooks/monitoring-and-metrics.md
@@ -225,10 +225,9 @@ dtrace -qn 'erlang*:::user_trace* /arg2 == 703/ {printf("pid %s: mod %s op %s: u
 dtrace -qn 'erlang*:::user_trace* /arg2 == 705/ {printf("pid %s: %s:%s\n", copyinstr(arg0), copyinstr(arg6), copyinstr(arg7));}'
 ```
 
-<div class="info">
-<div class="title">Note on DTrace Support</div>
-Work on packaging of Riak CS for SmartOS and other operating systems
-with DTrace support is ongoing with the goal of providing enhanced
-ability to diagnose low-level issues in instances of Riak CS running on
-such operating systems.
-</div>
+{{% note title="Note on DTrace Support" %}}
+Work on packaging of Riak CS for SmartOS and other operating systems with
+DTrace support is ongoing with the goal of providing enhanced ability to
+diagnose low-level issues in instances of Riak CS running on such operating
+systems.
+{{% /note %}}

--- a/content/riak/cs/2.0.0/cookbooks/multi-datacenter-overview.md
+++ b/content/riak/cs/2.0.0/cookbooks/multi-datacenter-overview.md
@@ -26,12 +26,10 @@ synchronization.
 
 If you are interested, sign up for a [developer trial](http://info.basho.com/RiakCS1.1_DeveloperTrialRequest.html) of Riak CS Enterprise or [contact us](http://basho.com/contact/) for more information.
 
-<div class="note">
-<div class="title">Riak CS Enterprise requires a separate download</div>
-Please note that Riak CS Enterprise requires a download separate from
-the open-source Riak CS, which will not work in conjunction with Riak
-Enterprise.
-</div>
+{{% note title="Riak CS Enterprise requires a separate download" %}}
+Please note that Riak CS Enterprise requires a download separate from the
+open-source Riak CS, which will not work in conjunction with Riak Enterprise.
+{{% /note %}}
 
 ## Multi-Datacenter Replication
 

--- a/content/riak/cs/2.0.0/cookbooks/multipart-upload-overview.md
+++ b/content/riak/cs/2.0.0/cookbooks/multipart-upload-overview.md
@@ -26,10 +26,9 @@ may be uploaded in parallel. In Riak CS they are designed to both behave
 like Amazon S3 multipart uploads and to utilize the same user-facing
 API.
 
-<div class="note">
-<div class="title">Note on file size limit</div>
+{{% note title="Note on file size limit" %}}
 The size limit on individual parts of a multipart upload is 5 gigabytes.
-</div>
+{{% /note %}}
 
 There are three phases to a multipart upload: **initiation**, **parts
 upload**, and **completion**. Each phase is described in more detail

--- a/content/riak/cs/2.0.0/cookbooks/querying-access-statistics.md
+++ b/content/riak/cs/2.0.0/cookbooks/querying-access-statistics.md
@@ -17,12 +17,11 @@ Access statistics are tracked on a per-user basis as rollups for slices
 of time. Querying these statistics is done via the
 `/riak-cs/usage/$USER_KEY_ID` resource.
 
-<div class="note">
-<div class="title">Note on terminology</div>
-In this and other documents in the Riak CS documentation, the terms
-"storage" and "billing" are used interchangeably. The same goes for the
-terms "usage" and access.
-</div>
+{{% note title="Note on terminology" %}}
+In this and other documents in the Riak CS documentation, the terms "storage"
+and "billing" are used interchangeably. The same goes for the terms "usage"
+and access.
+{{% /note %}}
 
 For information about how access statistics are logged, please read
 [Usage and Billing Data](/riak/cs/2.0.0/cookbooks/usage-and-billing-data).

--- a/content/riak/cs/2.0.0/cookbooks/querying-storage-statistics.md
+++ b/content/riak/cs/2.0.0/cookbooks/querying-storage-statistics.md
@@ -17,12 +17,11 @@ Storage statistics are tracked on a per-user basis, as rollups for
 slices of time. Querying these statistics is done via the
 `/riak-cs/usage/$USER_KEY_ID` resource.
 
-<div class="note">
-<div class="title">Note on terminology</div>
-In this and other documents in the Riak CS documentation, the terms
-"storage" and "billing" are used interchangeably. The same goes for the
-terms "usage" and access.
-</div>
+{{% note title="Note on terminology" %}}
+In this and other documents in the Riak CS documentation, the terms "storage"
+and "billing" are used interchangeably. The same goes for the terms "usage"
+and access.
+{{% /note %}}
 
 
 > **Note**:

--- a/content/riak/cs/2.0.0/cookbooks/rolling-upgrades.md
+++ b/content/riak/cs/2.0.0/cookbooks/rolling-upgrades.md
@@ -23,30 +23,35 @@ Be sure to check the Riak CS [Version Compatibility](/riak/cs/2.0.0/cookbooks/ve
 As Riak CS 2.0.0 only works with Riak 2.0.5, the underlying Riak installation
 *must* be upgraded to Riak 2.0.5.
 
-<div class="note"><div class="title">Note on upgrading from Riak CS < 1.5.4</div>
+{{% note title="Note on upgrading from Riak CS < 1.5.4" %}}
 <a href="https://github.com/basho/riak_cs/blob/release/1.5/RELEASE-NOTES.md#notes-on-upgrading">
 Some key objects changed names</a> after the upgrade. Applications may need to
-change their behaviour due to this bugfix.</div>
+change their behaviour due to this bugfix.
+{{% /note %}}
 
-<div class="note"><div class="title">Note on upgrading from Riak CS < 1.5.1</div>
+{{% note title="Note on upgrading from Riak CS < 1.5.1" %}}
 <a href="https://github.com/basho/riak_cs/blob/release/1.5/RELEASE-NOTES.md#notes-on-upgrading-1">
 Bucket number limitation per user</a> have been introduced in 1.5.1. Users who
 have more than 100 buckets cannot create any bucket after the upgrade unless
-the limit is extended in the system configuration.</div>
+the limit is extended in the system configuration.
+{{% /note %}}
 
-<div class="note"><div class="title">Note on upgrading From Riak CS 1.4.x</div>
+{{% note title="Note on upgrading From Riak CS 1.4.x" %}}
 An operational procedure
 <a href="https://github.com/basho/riak_cs/blob/release/1.5/RELEASE-NOTES.md#incomplete-multipart-uploads">
-to clean up incomplete multipart under deleted buckets</a> is needed. Otherwise
-new buckets with names that used to exist in the past can't be created. The
-operation will fail with a `409 Conflict` error.<br/><br/>
+to clean up incomplete multipart under deleted buckets</a> is needed.
+Otherwise new buckets with names that used to exist in the past can't be
+created. The operation will fail with a `409 Conflict` error.
+
+
 
 Leeway seconds and disk space should also be carefully watched during the
 upgrade, because timestamp management of garbage collection has changed since
 the 1.5.0 release. Consult the
- <a href="https://github.com/basho/riak_cs/blob/release/1.5/RELEASE-NOTES.md#leeway-seconds-and-disk-space">
-Leeway seconds and disk space</a> section of the 1.5 release notes
-for a more detailed description.</div>
+<a href="https://github.com/basho/riak_cs/blob/release/1.5/RELEASE-NOTES.md#leeway-seconds-and-disk-space">
+Leeway seconds and disk space</a> section of the 1.5 release notes for a more
+detailed description.
+{{% /note %}}
 
 1. Stop Riak, Riak CS, and Stanchion:
 

--- a/content/riak/cs/2.0.0/cookbooks/supercluster.md
+++ b/content/riak/cs/2.0.0/cookbooks/supercluster.md
@@ -13,12 +13,11 @@ aliases:
   - /riakcs/2.0.0/cookbooks/supercluster/
 ---
 
-<div class="note">
-<div class="title">Technical Preview</div>
-Riak CS Supercluster is currently in technical preview mode and is
-available only to <a href="http://basho.com/riak-enterprise/">Riak
-Enterprise</a> customers. It is not yet suitable for production use.
-</div>
+{{% note title="Technical Preview" %}}
+Riak CS Supercluster is currently in technical preview mode and is available
+only to <a href="http://basho.com/riak-enterprise/">Riak Enterprise</a>
+customers. It is not yet suitable for production use.
+{{% /note %}}
 
 While [Riak CS Enterprise](http://basho.com/riak-enterprise) enables
 you to distribute Riak CS objects across multiple data centers in a

--- a/content/riak/cs/2.0.0/cookbooks/usage-and-billing-data.md
+++ b/content/riak/cs/2.0.0/cookbooks/usage-and-billing-data.md
@@ -17,12 +17,11 @@ Like many other object storage systems, Riak CS gathers a variety of
 usage statistics and makes them available through its administrative
 API.
 
-<div class="note">
-<div class="title">Note on terminology</div>
-In this and other documents in the Riak CS documentation, the terms
-"storage" and "billing" are used interchangeably. The same goes for the
-terms "usage" and access.
-</div>
+{{% note title="Note on terminology" %}}
+In this and other documents in the Riak CS documentation, the terms "storage"
+and "billing" are used interchangeably. The same goes for the terms "usage"
+and access.
+{{% /note %}}
 
 ## Access Statistics
 
@@ -252,17 +251,15 @@ stats.storage.schedule.2 = 1800
 {storage_schedule, ["0600", "1800"]}
 ```
 
-<div class="note">
-<div class="title">Note on archive periods</div>
-When using multiple times in a storage schedule, they must be scheduled
-for different archive periods (see details for `storage_archive_period`
-in the **Archival** section below). Extra scheduled times in the same
-archive period are skipped. This is intended to allow more than one Riak
-CS node to calculate storage statistics concurrently, as they will take
-notice of users already calculated by other nodes and skip them (see
-details in the Manual Triggering section about overriding this
-behavior).
-</div>
+{{% note title="Note on archive periods" %}}
+When using multiple times in a storage schedule, they must be scheduled for
+different archive periods (see details for `storage_archive_period` in the
+**Archival** section below). Extra scheduled times in the same archive period
+are skipped. This is intended to allow more than one Riak CS node to calculate
+storage statistics concurrently, as they will take notice of users already
+calculated by other nodes and skip them (see details in the Manual Triggering
+section about overriding this behavior).
+{{% /note %}}
 
 By default, no schedule is specified, so the storage calculation is
 never done automatically.

--- a/content/riak/cs/2.0.0/references/apis/storage/openstack/delete-container.md
+++ b/content/riak/cs/2.0.0/references/apis/storage/openstack/delete-container.md
@@ -10,7 +10,7 @@ aliases:
 
 Deletes a container.
 
-<div class="note"><div clas="title">Note</div>All objects in the container must be deleted before you can delete the container.</div>
+<div class="note"><div class="title">Note</div>All objects in the container must be deleted before you can delete the container.</div>
 
 ## Requests
 

--- a/content/riak/cs/2.0.0/references/apis/storage/openstack/delete-container.md
+++ b/content/riak/cs/2.0.0/references/apis/storage/openstack/delete-container.md
@@ -10,7 +10,10 @@ aliases:
 
 Deletes a container.
 
-<div class="note"><div class="title">Note</div>All objects in the container must be deleted before you can delete the container.</div>
+{{% note title="Note" %}}
+All objects in the container must be deleted before you can delete the
+container.
+{{% /note %}}
 
 ## Requests
 

--- a/content/riak/cs/2.0.0/references/apis/storage/s3/delete-bucket.md
+++ b/content/riak/cs/2.0.0/references/apis/storage/s3/delete-bucket.md
@@ -11,7 +11,9 @@ aliases:
 
 The `DELETE Bucket` operation deletes the bucket specified in the URI.
 
-<div class="note"><div class="title">Note</div>All objects in the bucket must be deleted before you can delete the bucket.</div>
+{{% note title="Note" %}}
+All objects in the bucket must be deleted before you can delete the bucket.
+{{% /note %}}
 
 ## Requests
 

--- a/content/riak/cs/2.0.0/references/apis/storage/s3/delete-bucket.md
+++ b/content/riak/cs/2.0.0/references/apis/storage/s3/delete-bucket.md
@@ -11,7 +11,7 @@ aliases:
 
 The `DELETE Bucket` operation deletes the bucket specified in the URI.
 
-<div class="note"><div clas="title">Note</div>All objects in the bucket must be deleted before you can delete the bucket.</div>
+<div class="note"><div class="title">Note</div>All objects in the bucket must be deleted before you can delete the bucket.</div>
 
 ## Requests
 

--- a/content/riak/cs/2.0.0/references/apis/storage/s3/put-bucket-policy.md
+++ b/content/riak/cs/2.0.0/references/apis/storage/s3/put-bucket-policy.md
@@ -11,7 +11,10 @@ aliases:
 
 The `PUT Bucket policy` operation uses the `policy` subresource to add or replace the policy on an existing bucket. If the bucket already has a policy, the one in this request completely replaces it. To perform this operation, you must be the bucket owner.
 
-<div class="note"><div class="title">Note</div>Currently only the `aws:SourceIp` and `aws:SecureTransport` policy conditions are supported.</div>
+{{% note title="Note" %}}
+Currently only the `aws:SourceIp` and `aws:SecureTransport` policy conditions
+are supported.
+{{% /note %}}
 
 ## Requests
 

--- a/content/riak/cs/2.0.0/references/apis/storage/s3/put-bucket.md
+++ b/content/riak/cs/2.0.0/references/apis/storage/s3/put-bucket.md
@@ -48,7 +48,10 @@ Authorization: signature_value
     <LocationConstraint>BucketRegion</LocationConstraint>
   </CreateBucketConfiguration>
 ```
-<div class="note"><div class="title">Note</div>This example includes some request headers. The Request Headers section contains the complete list of headers.</div>
+{{% note title="Note" %}}
+This example includes some request headers. The Request Headers section
+contains the complete list of headers.
+{{% /note %}}
 
 ### Request Parameters
 

--- a/content/riak/cs/2.0.0/references/apis/storage/s3/put-object-copy.md
+++ b/content/riak/cs/2.0.0/references/apis/storage/s3/put-object-copy.md
@@ -18,10 +18,10 @@ PUT Object (Copy) offers the option to specify the permissions you want to grant
 * Specify a predefined ACL using the `x-amz-acl` request header. More information about predefined ACLs is available [here](http://docs.amazonwebservices.com/AmazonS3/latest/dev/ACLOverview.html#CannedACL).
 * Specify access permissions explicitly using the `x-amz-grant-read`, `x-amz-grant-write`, `x-amz-grant-read-acp`, `x-amz-grant-write-acp`, `x-amz-grant-full-control` headers, which map to the set of ACL permissions supported by Amazon S3.
 
-<div class="note">
-<div class="title">Note</div>
-You can use either a predefined ACL or specify access permissions explicitly, not both.
-</div>
+{{% note title="Note" %}}
+You can use either a predefined ACL or specify access permissions explicitly,
+not both.
+{{% /note %}}
 
 *Note*: You can configure an application to use the `100-continue` HTTP status code, which sends the Request Headers prior to sending the request body. Doing so prevents sending the message body when the message is rejected based on the headers, for example, due to authentication failure or redirect).
 

--- a/content/riak/cs/2.0.0/references/apis/storage/s3/put-object.md
+++ b/content/riak/cs/2.0.0/references/apis/storage/s3/put-object.md
@@ -25,10 +25,10 @@ PUT Object offers the option to specify the permissions you want to grant to spe
 * Specify a predefined ACL using the x-amz-acl request header. More information about predefined ACLs is available [here](http://docs.amazonwebservices.com/AmazonS3/latest/dev/ACLOverview.html#CannedACL).
 * Specify access permissions explicitly using the x-amz-grant-read, x-amz-grant-write, x-amz-grant-read-acp, x-amz-grant-write-acp, x-amz-grant-full-control headers, which map to the set of ACL permissions supported by Amazon S3.
 
-<div class="note">
-<div class="title">Note</div>
-You can use either a predefined ACL or specify access permissions explicitly, not both.
-</div>
+{{% note title="Note" %}}
+You can use either a predefined ACL or specify access permissions explicitly,
+not both.
+{{% /note %}}
 
 ## Requests
 

--- a/content/riak/cs/2.0.0/tutorials/fast-track/local-testing-environment.md
+++ b/content/riak/cs/2.0.0/tutorials/fast-track/local-testing-environment.md
@@ -201,10 +201,10 @@ to use the custom backend provided by Riak CS. You'll have to use the old-style
 ].
 ```
 
-<div class="note"><div class="title">Note on OS-specific paths</div>
+{{% note title="Note on OS-specific paths" %}}
 The path for `add_paths` may be `/usr/lib/riak-cs` or `/usr/lib64/riak-cs`
 depending on your operating system.
-</div>
+{{% /note %}}
 
 Next, set your interface IP addresses in the `riak.conf` file. In a
 production environment, you'd likely have multiple NICs, but for this
@@ -393,9 +393,9 @@ You can use this same process to create additional Riak CS users. To
 make this user the admin user, we set these keys in the Riak CS
 `riak-cs.conf` and `stanchion.conf` files.
 
-<div class="note"><div class="title">Note on admin keys</div>
+{{% note title="Note on admin keys" %}}
 The same admin keys will need to be set on all nodes of the cluster.
-</div>
+{{% /note %}}
 
 Change the following lines in `/etc/riak-cs/riak-cs.conf` on all Riak CS
 machines:

--- a/content/riak/cs/2.0.1/cookbooks/account-management.md
+++ b/content/riak/cs/2.0.1/cookbooks/account-management.md
@@ -24,12 +24,11 @@ curl -X POST http://localhost:8080/riak-cs/user \
   --data '{"email":"foobar@example.com", "name":"foo bar"}' \
 ```
 
-<div class="note">
-<div class="title">Note on admin users</div>
-By default, only the admin user may create new user accounts. If you
-need to create a user account without authenticating yourself, you must
-set `{anonymous_user_creation, true}` in the Riak CS `app.config`.
-</div>
+{{% note title="Note on admin users" %}}
+By default, only the admin user may create new user accounts. If you need to
+create a user account without authenticating yourself, you must set
+`{anonymous_user_creation, true}` in the Riak CS `app.config`.
+{{% /note %}}
 
 The submitted user document may be either JSON or XML, but the type
 should match the value of the `Content-Type` header used. Here are some
@@ -187,13 +186,12 @@ The documents should resemble the following examples.
 </UserUpdate>
 ```
 
-<div class="note">
-<div class="title">Note on update fields</div>
-The `new_key_secret` field (or `NewKeySecret` in XML) may be combined
-with other user update fields in the same request.  Currently, the only
-other supported field is status, but more may be added in the future.
-Unsupported fields are ignored.
-</div>
+{{% note title="Note on update fields" %}}
+The `new_key_secret` field (or `NewKeySecret` in XML) may be combined with
+other user update fields in the same request.  Currently, the only other
+supported field is status, but more may be added in the future. Unsupported
+fields are ignored.
+{{% /note %}}
 
 ## Retrieving a List of All Users
 
@@ -204,12 +202,11 @@ is rejected and a `403 Forbidden` error is returned. This request does
 not properly work with s3cmd, but can be performed using a less dogmatic
 tool such as [s3-curl](http://aws.amazon.com/code/128).
 
-<div class="info">
-<div class="title">Note on hostname</div>
-You must modify the `@endpoints` variable in the `s3curl.pl` script to
-include your Riak CS hostname so that the following example will return
-the list of users.
-</div>
+{{% note title="Note on hostname" %}}
+You must modify the `@endpoints` variable in the `s3curl.pl` script to include
+your Riak CS hostname so that the following example will return the list of
+users.
+{{% /note %}}
 
 A sample URL for a user listing request looks like this:
 

--- a/content/riak/cs/2.0.1/cookbooks/command-line-tools.md
+++ b/content/riak/cs/2.0.1/cookbooks/command-line-tools.md
@@ -84,11 +84,10 @@ Stops all applications and starts without restarting the Erlang VM.
 riak-cs reboot
 ```
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The <code>riak-cs reboot</code> command has been deprecated. We
-recommend using the <code>riak-cs restart</code> command instead.
-</div>
+{{% note title="Deprecation notice" %}}
+The `riak-cs reboot` command has been deprecated. We recommend using the
+`riak-cs restart` command instead.
+{{% /note %}}
 
 #### ping
 
@@ -524,12 +523,10 @@ Riak CS version 1.5 offers support for supercluster operations. The
 `supercluster` command interface enables you to interact with that system.
 More information can be found in [Riak CS Supercluster Support](/riak/cs/2.0.1/cookbooks/supercluster).
 
-<div class="note">
-<div class="title">Note: technical preview</div>
+{{% note title="Note: technical preview" %}}
 Riak CS supercluster support is available only as a technical preview for
-users of Riak CS installations with support for Multi-Datacenter
-Replication.
-</div>
+users of Riak CS installations with support for Multi-Datacenter Replication.
+{{% /note %}}
 
 #### list-members
 

--- a/content/riak/cs/2.0.1/cookbooks/configuration/dragondisk.md
+++ b/content/riak/cs/2.0.1/cookbooks/configuration/dragondisk.md
@@ -59,12 +59,10 @@ save an account. The following describes the process for doing so.
 * Enter the Riak CS public interface HTTP port into the **HTTP Port**
   field.
 
-<div class="note">
-<div class="title">Note on HTTPS</div>
-If you'll be using HTTPS, be sure to enter the correct public HTTPS port
-into the **HTTPS Port** field and click the **Connect
-using SSL/HTTS** check box.
-</div>
+{{% note title="Note on HTTPS" %}}
+If you'll be using HTTPS, be sure to enter the correct public HTTPS port into
+the **HTTPS Port** field and click the **Connect using SSL/HTTS** check box.
+{{% /note %}}
 
 * Click **OK** to save the account configuration.
 
@@ -163,12 +161,10 @@ save an account. The following describes the process for doing so.
 * Enter the Riak CS public interface HTTP port into the **HTTP Port**
   field.
 
-<div class="note">
-<div class="title">Note on HTTPS</div>
-If you'll be using HTTPS, be sure to enter the correct public HTTPS port
-into the **HTTPS Port** field and click the **Connect using SSL/HTTS**
-check box.
-</div>
+{{% note title="Note on HTTPS" %}}
+If you'll be using HTTPS, be sure to enter the correct public HTTPS port into
+the **HTTPS Port** field and click the **Connect using SSL/HTTS** check box.
+{{% /note %}}
 
 * Click **OK** to save the account configuration.
 
@@ -268,12 +264,10 @@ save an account. The following describes the process for doing so.
 * Enter the Riak CS public interface HTTP port into the **HTTP Port**
   field.
 
-<div class="note">
-<div class="title">Note on HTTPS</div>
-If you'll be using HTTPS, be sure to enter the correct public HTTPS port
-into the **HTTPS Port** field and click the **Connect using SSL/HTTS**
-check box.
-</div>
+{{% note title="Note on HTTPS" %}}
+If you'll be using HTTPS, be sure to enter the correct public HTTPS port into
+the **HTTPS Port** field and click the **Connect using SSL/HTTS** check box.
+{{% /note %}}
 
 * Click **OK** to save the account configuration.
 

--- a/content/riak/cs/2.0.1/cookbooks/configuration/multi-datacenter.md
+++ b/content/riak/cs/2.0.1/cookbooks/configuration/multi-datacenter.md
@@ -14,12 +14,10 @@ aliases:
   - /riak/cs/2.0.1/cookbooks/configuration/Configuring-MDC/
 ---
 
-<div class="note">
-<div class="title">Riak CS Enterprise requires a separate download</div>
-Please note that Riak CS Enterprise requires a download separate from
-the open-source Riak CS, which will not work in conjunction with Riak
-Enterprise.
-</div>
+{{% note title="Riak CS Enterprise requires a separate download" %}}
+Please note that Riak CS Enterprise requires a download separate from the
+open-source Riak CS, which will not work in conjunction with Riak Enterprise.
+{{% /note %}}
 
 Configuring Multi-Datacenter Replication in Riak CS requires the
 addition of a new group of settings to the `app.config` configuration

--- a/content/riak/cs/2.0.1/cookbooks/configuration/reference.md
+++ b/content/riak/cs/2.0.1/cookbooks/configuration/reference.md
@@ -92,23 +92,25 @@ Most of the settings you will need to manipulate have been ported into the newer
 such as setting up customized `lager` streams -- that will need to be configured
 in `advanced.config`.
 
-<div class="note"><div class="title">A Note About Time Values</div>
+{{% note title="A Note About Time Values" %}}
 In the `app.config` configuration files, time periods were generally written
 as either seconds or milliseconds, with no real indication of which was being
 used. With the update to `riak-cs.conf`, all values that describe a period of
-time are written as an integer and a character, describing the unit of time and
-the number of times that unit should be repeated for the period. For example
-`31d` represents 31 days, `6h` represents six hours, `6000ms` represents 6,000
-milliseconds.</br>
-The full list of valid time units are as follows:</br>
-`f` -- Fortnights</br>
-`w` -- Weeks</br>
-`d` -- Days</br>
-`h` -- Hours</br>
-`m` -- Minutes</br>
-`s` -- Seconds</br>
-`ms` -- Milliseconds</br>
-</div>
+time are written as an integer and a character, describing the unit of time
+and the number of times that unit should be repeated for the period. For
+example `31d` represents 31 days, `6h` represents six hours, `6000ms`
+represents 6,000 milliseconds.
+
+The full list of valid time units are as follows:
+
+`f` -- Fortnights
+`w` -- Weeks
+`d` -- Days
+`h` -- Hours
+`m` -- Minutes
+`s` -- Seconds
+`ms` -- Milliseconds
+{{% /note %}}
 
 The tables below will show settings for both `riak-cs.conf` and
 `advanced.config`/`app.config` where applicable, organized by functionality.

--- a/content/riak/cs/2.0.1/cookbooks/configuration/riak-cs.md
+++ b/content/riak/cs/2.0.1/cookbooks/configuration/riak-cs.md
@@ -73,13 +73,12 @@ You will also need to set the host listener for Riak CS:
    port number does not conflict with the `riak_host` port number of the Riak
    node and the Riak CS node that are running on the same machine.
 
-<div class="note">
-<div class="title">Note on IP addresses</div>
-The IP address you enter here must match the IP address specified for
-the Protocol Buffers interface in the Riak <code>riak.conf</code> file
-unless Riak CS is running on a completely different network, in which
-case address translation is required.
-</div>
+{{% note title="Note on IP addresses" %}}
+The IP address you enter here must match the IP address specified for the
+Protocol Buffers interface in the Riak `riak.conf` file unless Riak CS is
+running on a completely different network, in which case address translation
+is required.
+{{% /note %}}
 
 After making any changes to the `riak-cs.conf` file in Riak CS,
 [restart](/riak/cs/2.0.1/cookbooks/command-line-tools/#riak-cs) the node if it is already running.
@@ -144,13 +143,12 @@ The admin user is authorized to perform actions such as creating users or
 obtaining billing statistics. An admin user account is no different from any
 other user account. **You must create an admin user to use Riak CS**.
 
-<div class="note">
-<div class="title">Note on anonymous user creation</div>
-Before creating an admin user, you must first set `anonymous_user_creation = on`
-in the Riak CS `riak-cs.conf` (or set `{anonymous_user_creation, true}` in the
-old-style `advanced.config`/`app.config`). You may disable this again once the
-admin user has been created.
-</div>
+{{% note title="Note on anonymous user creation" %}}
+Before creating an admin user, you must first set `anonymous_user_creation =
+on` in the Riak CS `riak-cs.conf` (or set `{anonymous_user_creation, true}` in
+the old-style `advanced.config`/`app.config`). You may disable this again once
+the admin user has been created.
+{{% /note %}}
 
 To create an account for the admin user, use an HTTP `POST` request with the
 username you want to use for the admin account. The following is an
@@ -413,11 +411,11 @@ settings are available through the `riak-cs.conf` configuration file.**
 * `gc_batch_size` --- This option represents the size used for paginating the
   results of the secondary index query. The default value is 1000.
 
-<div class="note"><div class="title">Deprecated Configurations</div>
+{{% note title="Deprecated Configurations" %}}
 While Riak CS 2.0.0 still allows the configuration of `gc_paginated_indexes`,
 it is strongly recommended that these settings not be used. This setting has
-been deprecated, and <em>will be removed</em> in the next major release.
-</div>
+been deprecated, and _will be removed_ in the next major release.
+{{% /note %}}
 
 ## Other Riak CS Settings
 

--- a/content/riak/cs/2.0.1/cookbooks/configuration/riak-for-cs.md
+++ b/content/riak/cs/2.0.1/cookbooks/configuration/riak-for-cs.md
@@ -155,12 +155,11 @@ buckets.default.allow_mult = true
 This will enable Riak to create [siblings](/riak/kv/2.1.3/learn/concepts/causal-context/#siblings), which is necessary for Riak CS to function. If you are connecting to Riak CS from a [client library](/riak/kv/2.1.3/developing/client-libraries), don't worry: you will not have to manage [conflict resolution](/riak/kv/2.1.3/developing/usage/conflict-resolution), as all Riak CS
 operations are strongly consistent by definition.
 
-<div class="note">
-<div class="title">Note on <code>allow_mult</code></div>
+{{% note title="Note on `allow_mult`" %}}
 Any Riak node that also supports Riak CS should have `allow_mult` set to
-`true` at all times. Riak CS will refuse to start if `allow_mult` is
-set to `false`.
-</div>
+`true` at all times. Riak CS will refuse to start if `allow_mult` is set to
+`false`.
+{{% /note %}}
 
 ## Specifying the Nodename and IP Address
 
@@ -248,12 +247,11 @@ the `pb` value in `advanced.config`/`app.config`) file must match the values for
 `riak_host` in the Riak CS `riak-cs.config` and Stanchion `stanchion.conf` (or
 `riak_host` the relative `advanced.config`/`app.config`) files.
 
-<div class="note">
-<div class="title">Note on port numbers</div>
-A different port number might be required if the port number conflicts
-with ports used by another application or if you use a load balancer or
-proxy server.
-</div>
+{{% note title="Note on port numbers" %}}
+A different port number might be required if the port number conflicts with
+ports used by another application or if you use a load balancer or proxy
+server.
+{{% /note %}}
 
 It is also recommended that users insure that the size of Riak's
 `protobuf.backlog` (or in the `advanced.config`/`app.config` files, the

--- a/content/riak/cs/2.0.1/cookbooks/configuration/stanchion.md
+++ b/content/riak/cs/2.0.1/cookbooks/configuration/stanchion.md
@@ -60,11 +60,11 @@ listener = 127.0.0.1:8080
             ]}
 ```
 
-<div class="note"><div class="title">Note on matching IP addresses</div>
+{{% note title="Note on matching IP addresses" %}}
 The IP address you enter here must match the IP address specified for the
-<code>stanchion_host</code> variable in the Riak <code>riak.conf</code> file and
-the Riak CS <code>riak-cs.conf</code> file.
-</div>
+`stanchion_host` variable in the Riak `riak.conf` file and the Riak CS
+`riak-cs.conf` file.
+{{% /note %}}
 
 If you want to use SSL, make sure the `ssl.certfile` and `ssl.keyfile` settings
 are not commented out, and have been set correctly.

--- a/content/riak/cs/2.0.1/cookbooks/configuration/transmit.md
+++ b/content/riak/cs/2.0.1/cookbooks/configuration/transmit.md
@@ -17,7 +17,10 @@ aliases:
 [Transmit](https://www.panic.com/transmit/) is an S3-compatible client with a
 graphical user interface for Mac OS X. The following guide describes configuration of Transmit for use with Riak CS.
 
-<div class="info"><div class="title">Note</div>S3 support was added in Transmit version 4.4, so ensure that you're following along with a version that supports S3 before continuing.</div>
+{{% note title="Note" %}}
+S3 support was added in Transmit version 4.4, so ensure that you're following
+along with a version that supports S3 before continuing.
+{{% /note %}}
 
 ## Define a Connection
 

--- a/content/riak/cs/2.0.1/cookbooks/designate-admin-user.md
+++ b/content/riak/cs/2.0.1/cookbooks/designate-admin-user.md
@@ -13,9 +13,8 @@ editing and replacing the `admin_key` and `admin_secret` in `app.config`
 with the user's credentials. Once this is done, do not forget to update
 the same credentials in the Stanchion `app.config` as well.
 
-<div class="note">
-<div class="title">Note on the admin role</div>
-This is a powerful role and gives the designee administrative
-capabilities within the system. As such, caution should be used to
-protect the access credentials of the admin user.
-</div>
+{{% note title="Note on the admin role" %}}
+This is a powerful role and gives the designee administrative capabilities
+within the system. As such, caution should be used to protect the access
+credentials of the admin user.
+{{% /note %}}

--- a/content/riak/cs/2.0.1/cookbooks/garbage-collection.md
+++ b/content/riak/cs/2.0.1/cookbooks/garbage-collection.md
@@ -42,14 +42,13 @@ that can be divided into two essential phases:
 
 These two phases are described in more detail in the following sections.
 
-<div class="note">
-<div class="title">Note on manifest pruning</div>
+{{% note title="Note on manifest pruning" %}}
 A Riak CS object's manifest is updated any time a write, i.e. a `PUT` or
 `DELETE` request, is issued, which means that manifest sizes can grow
 significantly over time. This can lead to latency problems. Riak CS's GC
-subsystem will prune these manifests. If you're experiencing
-manifest-related issues, we would recommend using GC.
-</div>
+subsystem will prune these manifests. If you're experiencing manifest-related
+issues, we would recommend using GC.
+{{% /note %}}
 
 ## Synchronous GC Actions
 

--- a/content/riak/cs/2.0.1/cookbooks/monitoring-and-metrics.md
+++ b/content/riak/cs/2.0.1/cookbooks/monitoring-and-metrics.md
@@ -225,10 +225,9 @@ dtrace -qn 'erlang*:::user_trace* /arg2 == 703/ {printf("pid %s: mod %s op %s: u
 dtrace -qn 'erlang*:::user_trace* /arg2 == 705/ {printf("pid %s: %s:%s\n", copyinstr(arg0), copyinstr(arg6), copyinstr(arg7));}'
 ```
 
-<div class="info">
-<div class="title">Note on DTrace Support</div>
-Work on packaging of Riak CS for SmartOS and other operating systems
-with DTrace support is ongoing with the goal of providing enhanced
-ability to diagnose low-level issues in instances of Riak CS running on
-such operating systems.
-</div>
+{{% note title="Note on DTrace Support" %}}
+Work on packaging of Riak CS for SmartOS and other operating systems with
+DTrace support is ongoing with the goal of providing enhanced ability to
+diagnose low-level issues in instances of Riak CS running on such operating
+systems.
+{{% /note %}}

--- a/content/riak/cs/2.0.1/cookbooks/multi-datacenter-overview.md
+++ b/content/riak/cs/2.0.1/cookbooks/multi-datacenter-overview.md
@@ -26,12 +26,10 @@ synchronization.
 
 If you are interested, sign up for a [developer trial](http://info.basho.com/RiakCS1.1_DeveloperTrialRequest.html) of Riak CS Enterprise or [contact us](http://basho.com/contact/) for more information.
 
-<div class="note">
-<div class="title">Riak CS Enterprise requires a separate download</div>
-Please note that Riak CS Enterprise requires a download separate from
-the open-source Riak CS, which will not work in conjunction with Riak
-Enterprise.
-</div>
+{{% note title="Riak CS Enterprise requires a separate download" %}}
+Please note that Riak CS Enterprise requires a download separate from the
+open-source Riak CS, which will not work in conjunction with Riak Enterprise.
+{{% /note %}}
 
 ## Multi-Datacenter Replication
 

--- a/content/riak/cs/2.0.1/cookbooks/multipart-upload-overview.md
+++ b/content/riak/cs/2.0.1/cookbooks/multipart-upload-overview.md
@@ -26,10 +26,9 @@ may be uploaded in parallel. In Riak CS they are designed to both behave
 like Amazon S3 multipart uploads and to utilize the same user-facing
 API.
 
-<div class="note">
-<div class="title">Note on file size limit</div>
+{{% note title="Note on file size limit" %}}
 The size limit on individual parts of a multipart upload is 5 gigabytes.
-</div>
+{{% /note %}}
 
 There are three phases to a multipart upload: **initiation**, **parts
 upload**, and **completion**. Each phase is described in more detail

--- a/content/riak/cs/2.0.1/cookbooks/querying-access-statistics.md
+++ b/content/riak/cs/2.0.1/cookbooks/querying-access-statistics.md
@@ -17,12 +17,11 @@ Access statistics are tracked on a per-user basis as rollups for slices
 of time. Querying these statistics is done via the
 `/riak-cs/usage/$USER_KEY_ID` resource.
 
-<div class="note">
-<div class="title">Note on terminology</div>
-In this and other documents in the Riak CS documentation, the terms
-"storage" and "billing" are used interchangeably. The same goes for the
-terms "usage" and access.
-</div>
+{{% note title="Note on terminology" %}}
+In this and other documents in the Riak CS documentation, the terms "storage"
+and "billing" are used interchangeably. The same goes for the terms "usage"
+and access.
+{{% /note %}}
 
 For information about how access statistics are logged, please read
 [Usage and Billing Data](/riak/cs/2.0.1/cookbooks/usage-and-billing-data).

--- a/content/riak/cs/2.0.1/cookbooks/querying-storage-statistics.md
+++ b/content/riak/cs/2.0.1/cookbooks/querying-storage-statistics.md
@@ -17,12 +17,11 @@ Storage statistics are tracked on a per-user basis, as rollups for
 slices of time. Querying these statistics is done via the
 `/riak-cs/usage/$USER_KEY_ID` resource.
 
-<div class="note">
-<div class="title">Note on terminology</div>
-In this and other documents in the Riak CS documentation, the terms
-"storage" and "billing" are used interchangeably. The same goes for the
-terms "usage" and access.
-</div>
+{{% note title="Note on terminology" %}}
+In this and other documents in the Riak CS documentation, the terms "storage"
+and "billing" are used interchangeably. The same goes for the terms "usage"
+and access.
+{{% /note %}}
 
 
 > **Note**:

--- a/content/riak/cs/2.0.1/cookbooks/rolling-upgrades.md
+++ b/content/riak/cs/2.0.1/cookbooks/rolling-upgrades.md
@@ -23,30 +23,35 @@ Be sure to check the Riak CS [Version Compatibility](/riak/cs/2.0.1/cookbooks/ve
 As Riak CS 2.0.0 only works with Riak 2.0.5, the underlying Riak installation
 *must* be upgraded to Riak 2.0.5.
 
-<div class="note"><div class="title">Note on upgrading from Riak CS < 1.5.4</div>
+{{% note title="Note on upgrading from Riak CS < 1.5.4" %}}
 <a href="https://github.com/basho/riak_cs/blob/release/1.5/RELEASE-NOTES.md#notes-on-upgrading">
 Some key objects changed names</a> after the upgrade. Applications may need to
-change their behaviour due to this bugfix.</div>
+change their behaviour due to this bugfix.
+{{% /note %}}
 
-<div class="note"><div class="title">Note on upgrading from Riak CS < 1.5.1</div>
+{{% note title="Note on upgrading from Riak CS < 1.5.1" %}}
 <a href="https://github.com/basho/riak_cs/blob/release/1.5/RELEASE-NOTES.md#notes-on-upgrading-1">
 Bucket number limitation per user</a> have been introduced in 1.5.1. Users who
 have more than 100 buckets cannot create any bucket after the upgrade unless
-the limit is extended in the system configuration.</div>
+the limit is extended in the system configuration.
+{{% /note %}}
 
-<div class="note"><div class="title">Note on upgrading From Riak CS 1.4.x</div>
+{{% note title="Note on upgrading From Riak CS 1.4.x" %}}
 An operational procedure
 <a href="https://github.com/basho/riak_cs/blob/release/1.5/RELEASE-NOTES.md#incomplete-multipart-uploads">
-to clean up incomplete multipart under deleted buckets</a> is needed. Otherwise
-new buckets with names that used to exist in the past can't be created. The
-operation will fail with a `409 Conflict` error.<br/><br/>
+to clean up incomplete multipart under deleted buckets</a> is needed.
+Otherwise new buckets with names that used to exist in the past can't be
+created. The operation will fail with a `409 Conflict` error.
+
+
 
 Leeway seconds and disk space should also be carefully watched during the
 upgrade, because timestamp management of garbage collection has changed since
 the 1.5.0 release. Consult the
- <a href="https://github.com/basho/riak_cs/blob/release/1.5/RELEASE-NOTES.md#leeway-seconds-and-disk-space">
-Leeway seconds and disk space</a> section of the 1.5 release notes
-for a more detailed description.</div>
+<a href="https://github.com/basho/riak_cs/blob/release/1.5/RELEASE-NOTES.md#leeway-seconds-and-disk-space">
+Leeway seconds and disk space</a> section of the 1.5 release notes for a more
+detailed description.
+{{% /note %}}
 
 1. Stop Riak, Riak CS, and Stanchion:
 

--- a/content/riak/cs/2.0.1/cookbooks/supercluster.md
+++ b/content/riak/cs/2.0.1/cookbooks/supercluster.md
@@ -13,12 +13,11 @@ aliases:
   - /riakcs/2.0.1/cookbooks/supercluster/
 ---
 
-<div class="note">
-<div class="title">Technical Preview</div>
-Riak CS Supercluster is currently in technical preview mode and is
-available only to <a href="http://basho.com/riak-enterprise/">Riak
-Enterprise</a> customers. It is not yet suitable for production use.
-</div>
+{{% note title="Technical Preview" %}}
+Riak CS Supercluster is currently in technical preview mode and is available
+only to <a href="http://basho.com/riak-enterprise/">Riak Enterprise</a>
+customers. It is not yet suitable for production use.
+{{% /note %}}
 
 While [Riak CS Enterprise](http://basho.com/riak-enterprise) enables
 you to distribute Riak CS objects across multiple data centers in a

--- a/content/riak/cs/2.0.1/cookbooks/usage-and-billing-data.md
+++ b/content/riak/cs/2.0.1/cookbooks/usage-and-billing-data.md
@@ -17,12 +17,11 @@ Like many other object storage systems, Riak CS gathers a variety of
 usage statistics and makes them available through its administrative
 API.
 
-<div class="note">
-<div class="title">Note on terminology</div>
-In this and other documents in the Riak CS documentation, the terms
-"storage" and "billing" are used interchangeably. The same goes for the
-terms "usage" and access.
-</div>
+{{% note title="Note on terminology" %}}
+In this and other documents in the Riak CS documentation, the terms "storage"
+and "billing" are used interchangeably. The same goes for the terms "usage"
+and access.
+{{% /note %}}
 
 ## Access Statistics
 
@@ -252,17 +251,15 @@ stats.storage.schedule.2 = 1800
 {storage_schedule, ["0600", "1800"]}
 ```
 
-<div class="note">
-<div class="title">Note on archive periods</div>
-When using multiple times in a storage schedule, they must be scheduled
-for different archive periods (see details for `storage_archive_period`
-in the **Archival** section below). Extra scheduled times in the same
-archive period are skipped. This is intended to allow more than one Riak
-CS node to calculate storage statistics concurrently, as they will take
-notice of users already calculated by other nodes and skip them (see
-details in the Manual Triggering section about overriding this
-behavior).
-</div>
+{{% note title="Note on archive periods" %}}
+When using multiple times in a storage schedule, they must be scheduled for
+different archive periods (see details for `storage_archive_period` in the
+**Archival** section below). Extra scheduled times in the same archive period
+are skipped. This is intended to allow more than one Riak CS node to calculate
+storage statistics concurrently, as they will take notice of users already
+calculated by other nodes and skip them (see details in the Manual Triggering
+section about overriding this behavior).
+{{% /note %}}
 
 By default, no schedule is specified, so the storage calculation is
 never done automatically.

--- a/content/riak/cs/2.0.1/references/apis/storage/openstack/delete-container.md
+++ b/content/riak/cs/2.0.1/references/apis/storage/openstack/delete-container.md
@@ -10,7 +10,7 @@ aliases:
 
 Deletes a container.
 
-<div class="note"><div clas="title">Note</div>All objects in the container must be deleted before you can delete the container.</div>
+<div class="note"><div class="title">Note</div>All objects in the container must be deleted before you can delete the container.</div>
 
 ## Requests
 

--- a/content/riak/cs/2.0.1/references/apis/storage/openstack/delete-container.md
+++ b/content/riak/cs/2.0.1/references/apis/storage/openstack/delete-container.md
@@ -10,7 +10,10 @@ aliases:
 
 Deletes a container.
 
-<div class="note"><div class="title">Note</div>All objects in the container must be deleted before you can delete the container.</div>
+{{% note title="Note" %}}
+All objects in the container must be deleted before you can delete the
+container.
+{{% /note %}}
 
 ## Requests
 

--- a/content/riak/cs/2.0.1/references/apis/storage/s3/delete-bucket.md
+++ b/content/riak/cs/2.0.1/references/apis/storage/s3/delete-bucket.md
@@ -11,7 +11,9 @@ aliases:
 
 The `DELETE Bucket` operation deletes the bucket specified in the URI.
 
-<div class="note"><div class="title">Note</div>All objects in the bucket must be deleted before you can delete the bucket.</div>
+{{% note title="Note" %}}
+All objects in the bucket must be deleted before you can delete the bucket.
+{{% /note %}}
 
 ## Requests
 

--- a/content/riak/cs/2.0.1/references/apis/storage/s3/delete-bucket.md
+++ b/content/riak/cs/2.0.1/references/apis/storage/s3/delete-bucket.md
@@ -11,7 +11,7 @@ aliases:
 
 The `DELETE Bucket` operation deletes the bucket specified in the URI.
 
-<div class="note"><div clas="title">Note</div>All objects in the bucket must be deleted before you can delete the bucket.</div>
+<div class="note"><div class="title">Note</div>All objects in the bucket must be deleted before you can delete the bucket.</div>
 
 ## Requests
 

--- a/content/riak/cs/2.0.1/references/apis/storage/s3/put-bucket-policy.md
+++ b/content/riak/cs/2.0.1/references/apis/storage/s3/put-bucket-policy.md
@@ -11,7 +11,10 @@ aliases:
 
 The `PUT Bucket policy` operation uses the `policy` subresource to add or replace the policy on an existing bucket. If the bucket already has a policy, the one in this request completely replaces it. To perform this operation, you must be the bucket owner.
 
-<div class="note"><div class="title">Note</div>Currently only the `aws:SourceIp` and `aws:SecureTransport` policy conditions are supported.</div>
+{{% note title="Note" %}}
+Currently only the `aws:SourceIp` and `aws:SecureTransport` policy conditions
+are supported.
+{{% /note %}}
 
 ## Requests
 

--- a/content/riak/cs/2.0.1/references/apis/storage/s3/put-bucket.md
+++ b/content/riak/cs/2.0.1/references/apis/storage/s3/put-bucket.md
@@ -48,7 +48,10 @@ Authorization: signature_value
     <LocationConstraint>BucketRegion</LocationConstraint>
   </CreateBucketConfiguration>
 ```
-<div class="note"><div class="title">Note</div>This example includes some request headers. The Request Headers section contains the complete list of headers.</div>
+{{% note title="Note" %}}
+This example includes some request headers. The Request Headers section
+contains the complete list of headers.
+{{% /note %}}
 
 ### Request Parameters
 

--- a/content/riak/cs/2.0.1/references/apis/storage/s3/put-object-copy.md
+++ b/content/riak/cs/2.0.1/references/apis/storage/s3/put-object-copy.md
@@ -18,10 +18,10 @@ PUT Object (Copy) offers the option to specify the permissions you want to grant
 * Specify a predefined ACL using the `x-amz-acl` request header. More information about predefined ACLs is available [here](http://docs.amazonwebservices.com/AmazonS3/latest/dev/ACLOverview.html#CannedACL).
 * Specify access permissions explicitly using the `x-amz-grant-read`, `x-amz-grant-write`, `x-amz-grant-read-acp`, `x-amz-grant-write-acp`, `x-amz-grant-full-control` headers, which map to the set of ACL permissions supported by Amazon S3.
 
-<div class="note">
-<div class="title">Note</div>
-You can use either a predefined ACL or specify access permissions explicitly, not both.
-</div>
+{{% note title="Note" %}}
+You can use either a predefined ACL or specify access permissions explicitly,
+not both.
+{{% /note %}}
 
 *Note*: You can configure an application to use the `100-continue` HTTP status code, which sends the Request Headers prior to sending the request body. Doing so prevents sending the message body when the message is rejected based on the headers, for example, due to authentication failure or redirect).
 

--- a/content/riak/cs/2.0.1/references/apis/storage/s3/put-object.md
+++ b/content/riak/cs/2.0.1/references/apis/storage/s3/put-object.md
@@ -25,10 +25,10 @@ PUT Object offers the option to specify the permissions you want to grant to spe
 * Specify a predefined ACL using the x-amz-acl request header. More information about predefined ACLs is available [here](http://docs.amazonwebservices.com/AmazonS3/latest/dev/ACLOverview.html#CannedACL).
 * Specify access permissions explicitly using the x-amz-grant-read, x-amz-grant-write, x-amz-grant-read-acp, x-amz-grant-write-acp, x-amz-grant-full-control headers, which map to the set of ACL permissions supported by Amazon S3.
 
-<div class="note">
-<div class="title">Note</div>
-You can use either a predefined ACL or specify access permissions explicitly, not both.
-</div>
+{{% note title="Note" %}}
+You can use either a predefined ACL or specify access permissions explicitly,
+not both.
+{{% /note %}}
 
 ## Requests
 

--- a/content/riak/cs/2.0.1/tutorials/fast-track/local-testing-environment.md
+++ b/content/riak/cs/2.0.1/tutorials/fast-track/local-testing-environment.md
@@ -201,10 +201,10 @@ to use the custom backend provided by Riak CS. You'll have to use the old-style
 ].
 ```
 
-<div class="note"><div class="title">Note on OS-specific paths</div>
+{{% note title="Note on OS-specific paths" %}}
 The path for `add_paths` may be `/usr/lib/riak-cs` or `/usr/lib64/riak-cs`
 depending on your operating system.
-</div>
+{{% /note %}}
 
 Next, set your interface IP addresses in the `riak.conf` file. In a
 production environment, you'd likely have multiple NICs, but for this
@@ -393,9 +393,9 @@ You can use this same process to create additional Riak CS users. To
 make this user the admin user, we set these keys in the Riak CS
 `riak-cs.conf` and `stanchion.conf` files.
 
-<div class="note"><div class="title">Note on admin keys</div>
+{{% note title="Note on admin keys" %}}
 The same admin keys will need to be set on all nodes of the cluster.
-</div>
+{{% /note %}}
 
 Change the following lines in `/etc/riak-cs/riak-cs.conf` on all Riak CS
 machines:

--- a/content/riak/cs/2.1.0/cookbooks/account-management.md
+++ b/content/riak/cs/2.1.0/cookbooks/account-management.md
@@ -24,12 +24,11 @@ curl -X POST http://localhost:8080/riak-cs/user \
   --data '{"email":"foobar@example.com", "name":"foo bar"}' \
 ```
 
-<div class="note">
-<div class="title">Note on admin users</div>
-By default, only the admin user may create new user accounts. If you
-need to create a user account without authenticating yourself, you must
-set `{anonymous_user_creation, true}` in the Riak CS `app.config`.
-</div>
+{{% note title="Note on admin users" %}}
+By default, only the admin user may create new user accounts. If you need to
+create a user account without authenticating yourself, you must set
+`{anonymous_user_creation, true}` in the Riak CS `app.config`.
+{{% /note %}}
 
 The submitted user document may be either JSON or XML, but the type
 should match the value of the `Content-Type` header used. Here are some
@@ -187,13 +186,12 @@ The documents should resemble the following examples.
 </UserUpdate>
 ```
 
-<div class="note">
-<div class="title">Note on update fields</div>
-The `new_key_secret` field (or `NewKeySecret` in XML) may be combined
-with other user update fields in the same request.  Currently, the only
-other supported field is status, but more may be added in the future.
-Unsupported fields are ignored.
-</div>
+{{% note title="Note on update fields" %}}
+The `new_key_secret` field (or `NewKeySecret` in XML) may be combined with
+other user update fields in the same request.  Currently, the only other
+supported field is status, but more may be added in the future. Unsupported
+fields are ignored.
+{{% /note %}}
 
 ## Retrieving a List of All Users
 
@@ -204,12 +202,11 @@ is rejected and a `403 Forbidden` error is returned. This request does
 not properly work with s3cmd, but can be performed using a less dogmatic
 tool such as [s3-curl](http://aws.amazon.com/code/128).
 
-<div class="info">
-<div class="title">Note on hostname</div>
-You must modify the `@endpoints` variable in the `s3curl.pl` script to
-include your Riak CS hostname so that the following example will return
-the list of users.
-</div>
+{{% note title="Note on hostname" %}}
+You must modify the `@endpoints` variable in the `s3curl.pl` script to include
+your Riak CS hostname so that the following example will return the list of
+users.
+{{% /note %}}
 
 A sample URL for a user listing request looks like this:
 

--- a/content/riak/cs/2.1.0/cookbooks/command-line-tools.md
+++ b/content/riak/cs/2.1.0/cookbooks/command-line-tools.md
@@ -84,11 +84,10 @@ Stops all applications and starts without restarting the Erlang VM.
 riak-cs reboot
 ```
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The <code>riak-cs reboot</code> command has been deprecated. We
-recommend using the <code>riak-cs restart</code> command instead.
-</div>
+{{% note title="Deprecation notice" %}}
+The `riak-cs reboot` command has been deprecated. We recommend using the
+`riak-cs restart` command instead.
+{{% /note %}}
 
 #### ping
 
@@ -524,12 +523,10 @@ Riak CS version 1.5 offers support for supercluster operations. The
 `supercluster` command interface enables you to interact with that system.
 More information can be found in [Riak CS Supercluster Support](/riak/cs/2.1.0/cookbooks/supercluster).
 
-<div class="note">
-<div class="title">Note: technical preview</div>
+{{% note title="Note: technical preview" %}}
 Riak CS supercluster support is available only as a technical preview for
-users of Riak CS installations with support for Multi-Datacenter
-Replication.
-</div>
+users of Riak CS installations with support for Multi-Datacenter Replication.
+{{% /note %}}
 
 #### list-members
 

--- a/content/riak/cs/2.1.0/cookbooks/configuration/dragondisk.md
+++ b/content/riak/cs/2.1.0/cookbooks/configuration/dragondisk.md
@@ -59,12 +59,10 @@ save an account. The following describes the process for doing so.
 * Enter the Riak CS public interface HTTP port into the **HTTP Port**
   field.
 
-<div class="note">
-<div class="title">Note on HTTPS</div>
-If you'll be using HTTPS, be sure to enter the correct public HTTPS port
-into the **HTTPS Port** field and click the **Connect
-using SSL/HTTS** check box.
-</div>
+{{% note title="Note on HTTPS" %}}
+If you'll be using HTTPS, be sure to enter the correct public HTTPS port into
+the **HTTPS Port** field and click the **Connect using SSL/HTTS** check box.
+{{% /note %}}
 
 * Click **OK** to save the account configuration.
 
@@ -163,12 +161,10 @@ save an account. The following describes the process for doing so.
 * Enter the Riak CS public interface HTTP port into the **HTTP Port**
   field.
 
-<div class="note">
-<div class="title">Note on HTTPS</div>
-If you'll be using HTTPS, be sure to enter the correct public HTTPS port
-into the **HTTPS Port** field and click the **Connect using SSL/HTTS**
-check box.
-</div>
+{{% note title="Note on HTTPS" %}}
+If you'll be using HTTPS, be sure to enter the correct public HTTPS port into
+the **HTTPS Port** field and click the **Connect using SSL/HTTS** check box.
+{{% /note %}}
 
 * Click **OK** to save the account configuration.
 
@@ -268,12 +264,10 @@ save an account. The following describes the process for doing so.
 * Enter the Riak CS public interface HTTP port into the **HTTP Port**
   field.
 
-<div class="note">
-<div class="title">Note on HTTPS</div>
-If you'll be using HTTPS, be sure to enter the correct public HTTPS port
-into the **HTTPS Port** field and click the **Connect using SSL/HTTS**
-check box.
-</div>
+{{% note title="Note on HTTPS" %}}
+If you'll be using HTTPS, be sure to enter the correct public HTTPS port into
+the **HTTPS Port** field and click the **Connect using SSL/HTTS** check box.
+{{% /note %}}
 
 * Click **OK** to save the account configuration.
 

--- a/content/riak/cs/2.1.0/cookbooks/configuration/multi-datacenter.md
+++ b/content/riak/cs/2.1.0/cookbooks/configuration/multi-datacenter.md
@@ -14,12 +14,10 @@ aliases:
   - /riak/cs/2.1.0/cookbooks/configuration/Configuring-MDC/
 ---
 
-<div class="note">
-<div class="title">Riak CS Enterprise requires a separate download</div>
-Please note that Riak CS Enterprise requires a download separate from
-the open-source Riak CS, which will not work in conjunction with Riak
-Enterprise.
-</div>
+{{% note title="Riak CS Enterprise requires a separate download" %}}
+Please note that Riak CS Enterprise requires a download separate from the
+open-source Riak CS, which will not work in conjunction with Riak Enterprise.
+{{% /note %}}
 
 Configuring Multi-Datacenter Replication in Riak CS requires the
 addition of a new group of settings to the `app.config` configuration

--- a/content/riak/cs/2.1.0/cookbooks/configuration/reference.md
+++ b/content/riak/cs/2.1.0/cookbooks/configuration/reference.md
@@ -92,23 +92,25 @@ Most of the settings you will need to manipulate have been ported into the newer
 such as setting up customized `lager` streams -- that will need to be configured
 in `advanced.config`.
 
-<div class="note"><div class="title">A Note About Time Values</div>
+{{% note title="A Note About Time Values" %}}
 In the `app.config` configuration files, time periods were generally written
 as either seconds or milliseconds, with no real indication of which was being
 used. With the update to `riak-cs.conf`, all values that describe a period of
-time are written as an integer and a character, describing the unit of time and
-the number of times that unit should be repeated for the period. For example
-`31d` represents 31 days, `6h` represents six hours, `6000ms` represents 6,000
-milliseconds.</br>
-The full list of valid time units are as follows:</br>
-`f` -- Fortnights</br>
-`w` -- Weeks</br>
-`d` -- Days</br>
-`h` -- Hours</br>
-`m` -- Minutes</br>
-`s` -- Seconds</br>
-`ms` -- Milliseconds</br>
-</div>
+time are written as an integer and a character, describing the unit of time
+and the number of times that unit should be repeated for the period. For
+example `31d` represents 31 days, `6h` represents six hours, `6000ms`
+represents 6,000 milliseconds.
+
+The full list of valid time units are as follows:
+
+`f` -- Fortnights
+`w` -- Weeks
+`d` -- Days
+`h` -- Hours
+`m` -- Minutes
+`s` -- Seconds
+`ms` -- Milliseconds
+{{% /note %}}
 
 The tables below will show settings for both `riak-cs.conf` and
 `advanced.config`/`app.config` where applicable, organized by functionality.

--- a/content/riak/cs/2.1.0/cookbooks/configuration/riak-cs.md
+++ b/content/riak/cs/2.1.0/cookbooks/configuration/riak-cs.md
@@ -73,13 +73,12 @@ You will also need to set the host listener for Riak CS:
    port number does not conflict with the `riak_host` port number of the Riak
    node and the Riak CS node that are running on the same machine.
 
-<div class="note">
-<div class="title">Note on IP addresses</div>
-The IP address you enter here must match the IP address specified for
-the Protocol Buffers interface in the Riak <code>riak.conf</code> file
-unless Riak CS is running on a completely different network, in which
-case address translation is required.
-</div>
+{{% note title="Note on IP addresses" %}}
+The IP address you enter here must match the IP address specified for the
+Protocol Buffers interface in the Riak `riak.conf` file unless Riak CS is
+running on a completely different network, in which case address translation
+is required.
+{{% /note %}}
 
 After making any changes to the `riak-cs.conf` file in Riak CS,
 [restart](/riak/cs/2.1.0/cookbooks/command-line-tools/#riak-cs) the node if it is already running.
@@ -144,13 +143,12 @@ The admin user is authorized to perform actions such as creating users or
 obtaining billing statistics. An admin user account is no different from any
 other user account. **You must create an admin user to use Riak CS**.
 
-<div class="note">
-<div class="title">Note on anonymous user creation</div>
-Before creating an admin user, you must first set `anonymous_user_creation = on`
-in the Riak CS `riak-cs.conf` (or set `{anonymous_user_creation, true}` in the
-old-style `advanced.config`/`app.config`). You may disable this again once the
-admin user has been created.
-</div>
+{{% note title="Note on anonymous user creation" %}}
+Before creating an admin user, you must first set `anonymous_user_creation =
+on` in the Riak CS `riak-cs.conf` (or set `{anonymous_user_creation, true}` in
+the old-style `advanced.config`/`app.config`). You may disable this again once
+the admin user has been created.
+{{% /note %}}
 
 To create an account for the admin user, use an HTTP `POST` request with the
 username you want to use for the admin account. The following is an
@@ -413,11 +411,11 @@ settings are available through the `riak-cs.conf` configuration file.**
 * `gc_batch_size` --- This option represents the size used for paginating the
   results of the secondary index query. The default value is 1000.
 
-<div class="note"><div class="title">Deprecated Configurations</div>
+{{% note title="Deprecated Configurations" %}}
 While Riak CS 2.0.0 still allows the configuration of `gc_paginated_indexes`,
 it is strongly recommended that these settings not be used. This setting has
-been deprecated, and <em>will be removed</em> in the next major release.
-</div>
+been deprecated, and _will be removed_ in the next major release.
+{{% /note %}}
 
 ## Other Riak CS Settings
 

--- a/content/riak/cs/2.1.0/cookbooks/configuration/riak-for-cs.md
+++ b/content/riak/cs/2.1.0/cookbooks/configuration/riak-for-cs.md
@@ -155,12 +155,11 @@ buckets.default.allow_mult = true
 This will enable Riak to create [siblings](/riak/kv/2.1.3/learn/concepts/causal-context/#siblings), which is necessary for Riak CS to function. If you are connecting to Riak CS from a [client library](/riak/kv/2.1.3/developing/client-libraries), don't worry: you will not have to manage [conflict resolution](/riak/kv/2.1.3/developing/usage/conflict-resolution), as all Riak CS
 operations are strongly consistent by definition.
 
-<div class="note">
-<div class="title">Note on <code>allow_mult</code></div>
+{{% note title="Note on `allow_mult`" %}}
 Any Riak node that also supports Riak CS should have `allow_mult` set to
-`true` at all times. Riak CS will refuse to start if `allow_mult` is
-set to `false`.
-</div>
+`true` at all times. Riak CS will refuse to start if `allow_mult` is set to
+`false`.
+{{% /note %}}
 
 ## Specifying the Nodename and IP Address
 
@@ -248,12 +247,11 @@ the `pb` value in `advanced.config`/`app.config`) file must match the values for
 `riak_host` in the Riak CS `riak-cs.config` and Stanchion `stanchion.conf` (or
 `riak_host` the relative `advanced.config`/`app.config`) files.
 
-<div class="note">
-<div class="title">Note on port numbers</div>
-A different port number might be required if the port number conflicts
-with ports used by another application or if you use a load balancer or
-proxy server.
-</div>
+{{% note title="Note on port numbers" %}}
+A different port number might be required if the port number conflicts with
+ports used by another application or if you use a load balancer or proxy
+server.
+{{% /note %}}
 
 It is also recommended that users insure that the size of Riak's
 `protobuf.backlog` (or in the `advanced.config`/`app.config` files, the

--- a/content/riak/cs/2.1.0/cookbooks/configuration/stanchion.md
+++ b/content/riak/cs/2.1.0/cookbooks/configuration/stanchion.md
@@ -60,11 +60,11 @@ listener = 127.0.0.1:8080
             ]}
 ```
 
-<div class="note"><div class="title">Note on matching IP addresses</div>
+{{% note title="Note on matching IP addresses" %}}
 The IP address you enter here must match the IP address specified for the
-<code>stanchion_host</code> variable in the Riak <code>riak.conf</code> file and
-the Riak CS <code>riak-cs.conf</code> file.
-</div>
+`stanchion_host` variable in the Riak `riak.conf` file and the Riak CS
+`riak-cs.conf` file.
+{{% /note %}}
 
 If you want to use SSL, make sure the `ssl.certfile` and `ssl.keyfile` settings
 are not commented out, and have been set correctly.

--- a/content/riak/cs/2.1.0/cookbooks/configuration/transmit.md
+++ b/content/riak/cs/2.1.0/cookbooks/configuration/transmit.md
@@ -17,7 +17,10 @@ aliases:
 [Transmit](https://www.panic.com/transmit/) is an S3-compatible client with a
 graphical user interface for Mac OS X. The following guide describes configuration of Transmit for use with Riak CS.
 
-<div class="info"><div class="title">Note</div>S3 support was added in Transmit version 4.4, so ensure that you're following along with a version that supports S3 before continuing.</div>
+{{% note title="Note" %}}
+S3 support was added in Transmit version 4.4, so ensure that you're following
+along with a version that supports S3 before continuing.
+{{% /note %}}
 
 ## Define a Connection
 

--- a/content/riak/cs/2.1.0/cookbooks/designate-admin-user.md
+++ b/content/riak/cs/2.1.0/cookbooks/designate-admin-user.md
@@ -13,9 +13,8 @@ editing and replacing the `admin_key` and `admin_secret` in `app.config`
 with the user's credentials. Once this is done, do not forget to update
 the same credentials in the Stanchion `app.config` as well.
 
-<div class="note">
-<div class="title">Note on the admin role</div>
-This is a powerful role and gives the designee administrative
-capabilities within the system. As such, caution should be used to
-protect the access credentials of the admin user.
-</div>
+{{% note title="Note on the admin role" %}}
+This is a powerful role and gives the designee administrative capabilities
+within the system. As such, caution should be used to protect the access
+credentials of the admin user.
+{{% /note %}}

--- a/content/riak/cs/2.1.0/cookbooks/garbage-collection.md
+++ b/content/riak/cs/2.1.0/cookbooks/garbage-collection.md
@@ -42,14 +42,13 @@ that can be divided into two essential phases:
 
 These two phases are described in more detail in the following sections.
 
-<div class="note">
-<div class="title">Note on manifest pruning</div>
+{{% note title="Note on manifest pruning" %}}
 A Riak CS object's manifest is updated any time a write, i.e. a `PUT` or
 `DELETE` request, is issued, which means that manifest sizes can grow
 significantly over time. This can lead to latency problems. Riak CS's GC
-subsystem will prune these manifests. If you're experiencing
-manifest-related issues, we would recommend using GC.
-</div>
+subsystem will prune these manifests. If you're experiencing manifest-related
+issues, we would recommend using GC.
+{{% /note %}}
 
 ## Synchronous GC Actions
 

--- a/content/riak/cs/2.1.0/cookbooks/monitoring-and-metrics.md
+++ b/content/riak/cs/2.1.0/cookbooks/monitoring-and-metrics.md
@@ -225,10 +225,9 @@ dtrace -qn 'erlang*:::user_trace* /arg2 == 703/ {printf("pid %s: mod %s op %s: u
 dtrace -qn 'erlang*:::user_trace* /arg2 == 705/ {printf("pid %s: %s:%s\n", copyinstr(arg0), copyinstr(arg6), copyinstr(arg7));}'
 ```
 
-<div class="info">
-<div class="title">Note on DTrace Support</div>
-Work on packaging of Riak CS for SmartOS and other operating systems
-with DTrace support is ongoing with the goal of providing enhanced
-ability to diagnose low-level issues in instances of Riak CS running on
-such operating systems.
-</div>
+{{% note title="Note on DTrace Support" %}}
+Work on packaging of Riak CS for SmartOS and other operating systems with
+DTrace support is ongoing with the goal of providing enhanced ability to
+diagnose low-level issues in instances of Riak CS running on such operating
+systems.
+{{% /note %}}

--- a/content/riak/cs/2.1.0/cookbooks/multi-datacenter-overview.md
+++ b/content/riak/cs/2.1.0/cookbooks/multi-datacenter-overview.md
@@ -26,12 +26,10 @@ synchronization.
 
 If you are interested, sign up for a [developer trial](http://info.basho.com/RiakCS1.1_DeveloperTrialRequest.html) of Riak CS Enterprise or [contact us](http://basho.com/contact/) for more information.
 
-<div class="note">
-<div class="title">Riak CS Enterprise requires a separate download</div>
-Please note that Riak CS Enterprise requires a download separate from
-the open-source Riak CS, which will not work in conjunction with Riak
-Enterprise.
-</div>
+{{% note title="Riak CS Enterprise requires a separate download" %}}
+Please note that Riak CS Enterprise requires a download separate from the
+open-source Riak CS, which will not work in conjunction with Riak Enterprise.
+{{% /note %}}
 
 ## Multi-Datacenter Replication
 

--- a/content/riak/cs/2.1.0/cookbooks/multipart-upload-overview.md
+++ b/content/riak/cs/2.1.0/cookbooks/multipart-upload-overview.md
@@ -26,10 +26,9 @@ may be uploaded in parallel. In Riak CS they are designed to both behave
 like Amazon S3 multipart uploads and to utilize the same user-facing
 API.
 
-<div class="note">
-<div class="title">Note on file size limit</div>
+{{% note title="Note on file size limit" %}}
 The size limit on individual parts of a multipart upload is 5 gigabytes.
-</div>
+{{% /note %}}
 
 There are three phases to a multipart upload: **initiation**, **parts
 upload**, and **completion**. Each phase is described in more detail

--- a/content/riak/cs/2.1.0/cookbooks/querying-access-statistics.md
+++ b/content/riak/cs/2.1.0/cookbooks/querying-access-statistics.md
@@ -17,12 +17,11 @@ Access statistics are tracked on a per-user basis as rollups for slices
 of time. Querying these statistics is done via the
 `/riak-cs/usage/$USER_KEY_ID` resource.
 
-<div class="note">
-<div class="title">Note on terminology</div>
-In this and other documents in the Riak CS documentation, the terms
-"storage" and "billing" are used interchangeably. The same goes for the
-terms "usage" and access.
-</div>
+{{% note title="Note on terminology" %}}
+In this and other documents in the Riak CS documentation, the terms "storage"
+and "billing" are used interchangeably. The same goes for the terms "usage"
+and access.
+{{% /note %}}
 
 For information about how access statistics are logged, please read
 [Usage and Billing Data](/riak/cs/2.1.0/cookbooks/usage-and-billing-data).

--- a/content/riak/cs/2.1.0/cookbooks/querying-storage-statistics.md
+++ b/content/riak/cs/2.1.0/cookbooks/querying-storage-statistics.md
@@ -17,12 +17,11 @@ Storage statistics are tracked on a per-user basis, as rollups for
 slices of time. Querying these statistics is done via the
 `/riak-cs/usage/$USER_KEY_ID` resource.
 
-<div class="note">
-<div class="title">Note on terminology</div>
-In this and other documents in the Riak CS documentation, the terms
-"storage" and "billing" are used interchangeably. The same goes for the
-terms "usage" and access.
-</div>
+{{% note title="Note on terminology" %}}
+In this and other documents in the Riak CS documentation, the terms "storage"
+and "billing" are used interchangeably. The same goes for the terms "usage"
+and access.
+{{% /note %}}
 
 
 > **Note**:

--- a/content/riak/cs/2.1.0/cookbooks/rolling-upgrades.md
+++ b/content/riak/cs/2.1.0/cookbooks/rolling-upgrades.md
@@ -23,30 +23,35 @@ Be sure to check the Riak CS [Version Compatibility](/riak/cs/2.1.0/cookbooks/ve
 As Riak CS 2.0.0 only works with Riak 2.0.5, the underlying Riak installation
 *must* be upgraded to Riak 2.0.5.
 
-<div class="note"><div class="title">Note on upgrading from Riak CS < 1.5.4</div>
+{{% note title="Note on upgrading from Riak CS < 1.5.4" %}}
 <a href="https://github.com/basho/riak_cs/blob/release/1.5/RELEASE-NOTES.md#notes-on-upgrading">
 Some key objects changed names</a> after the upgrade. Applications may need to
-change their behaviour due to this bugfix.</div>
+change their behaviour due to this bugfix.
+{{% /note %}}
 
-<div class="note"><div class="title">Note on upgrading from Riak CS < 1.5.1</div>
+{{% note title="Note on upgrading from Riak CS < 1.5.1" %}}
 <a href="https://github.com/basho/riak_cs/blob/release/1.5/RELEASE-NOTES.md#notes-on-upgrading-1">
 Bucket number limitation per user</a> have been introduced in 1.5.1. Users who
 have more than 100 buckets cannot create any bucket after the upgrade unless
-the limit is extended in the system configuration.</div>
+the limit is extended in the system configuration.
+{{% /note %}}
 
-<div class="note"><div class="title">Note on upgrading From Riak CS 1.4.x</div>
+{{% note title="Note on upgrading From Riak CS 1.4.x" %}}
 An operational procedure
 <a href="https://github.com/basho/riak_cs/blob/release/1.5/RELEASE-NOTES.md#incomplete-multipart-uploads">
-to clean up incomplete multipart under deleted buckets</a> is needed. Otherwise
-new buckets with names that used to exist in the past can't be created. The
-operation will fail with a `409 Conflict` error.<br/><br/>
+to clean up incomplete multipart under deleted buckets</a> is needed.
+Otherwise new buckets with names that used to exist in the past can't be
+created. The operation will fail with a `409 Conflict` error.
+
+
 
 Leeway seconds and disk space should also be carefully watched during the
 upgrade, because timestamp management of garbage collection has changed since
 the 1.5.0 release. Consult the
- <a href="https://github.com/basho/riak_cs/blob/release/1.5/RELEASE-NOTES.md#leeway-seconds-and-disk-space">
-Leeway seconds and disk space</a> section of the 1.5 release notes
-for a more detailed description.</div>
+<a href="https://github.com/basho/riak_cs/blob/release/1.5/RELEASE-NOTES.md#leeway-seconds-and-disk-space">
+Leeway seconds and disk space</a> section of the 1.5 release notes for a more
+detailed description.
+{{% /note %}}
 
 1. Stop Riak, Riak CS, and Stanchion:
 

--- a/content/riak/cs/2.1.0/cookbooks/supercluster.md
+++ b/content/riak/cs/2.1.0/cookbooks/supercluster.md
@@ -13,12 +13,11 @@ aliases:
   - /riakcs/2.1.0/cookbooks/supercluster/
 ---
 
-<div class="note">
-<div class="title">Technical Preview</div>
-Riak CS Supercluster is currently in technical preview mode and is
-available only to <a href="http://basho.com/riak-enterprise/">Riak
-Enterprise</a> customers. It is not yet suitable for production use.
-</div>
+{{% note title="Technical Preview" %}}
+Riak CS Supercluster is currently in technical preview mode and is available
+only to <a href="http://basho.com/riak-enterprise/">Riak Enterprise</a>
+customers. It is not yet suitable for production use.
+{{% /note %}}
 
 While [Riak CS Enterprise](http://basho.com/riak-enterprise) enables
 you to distribute Riak CS objects across multiple data centers in a

--- a/content/riak/cs/2.1.0/cookbooks/usage-and-billing-data.md
+++ b/content/riak/cs/2.1.0/cookbooks/usage-and-billing-data.md
@@ -17,12 +17,11 @@ Like many other object storage systems, Riak CS gathers a variety of
 usage statistics and makes them available through its administrative
 API.
 
-<div class="note">
-<div class="title">Note on terminology</div>
-In this and other documents in the Riak CS documentation, the terms
-"storage" and "billing" are used interchangeably. The same goes for the
-terms "usage" and access.
-</div>
+{{% note title="Note on terminology" %}}
+In this and other documents in the Riak CS documentation, the terms "storage"
+and "billing" are used interchangeably. The same goes for the terms "usage"
+and access.
+{{% /note %}}
 
 ## Access Statistics
 
@@ -252,17 +251,15 @@ stats.storage.schedule.2 = 1800
 {storage_schedule, ["0600", "1800"]}
 ```
 
-<div class="note">
-<div class="title">Note on archive periods</div>
-When using multiple times in a storage schedule, they must be scheduled
-for different archive periods (see details for `storage_archive_period`
-in the **Archival** section below). Extra scheduled times in the same
-archive period are skipped. This is intended to allow more than one Riak
-CS node to calculate storage statistics concurrently, as they will take
-notice of users already calculated by other nodes and skip them (see
-details in the Manual Triggering section about overriding this
-behavior).
-</div>
+{{% note title="Note on archive periods" %}}
+When using multiple times in a storage schedule, they must be scheduled for
+different archive periods (see details for `storage_archive_period` in the
+**Archival** section below). Extra scheduled times in the same archive period
+are skipped. This is intended to allow more than one Riak CS node to calculate
+storage statistics concurrently, as they will take notice of users already
+calculated by other nodes and skip them (see details in the Manual Triggering
+section about overriding this behavior).
+{{% /note %}}
 
 By default, no schedule is specified, so the storage calculation is
 never done automatically.

--- a/content/riak/cs/2.1.0/references/apis/storage/openstack/delete-container.md
+++ b/content/riak/cs/2.1.0/references/apis/storage/openstack/delete-container.md
@@ -10,7 +10,7 @@ aliases:
 
 Deletes a container.
 
-<div class="note"><div clas="title">Note</div>All objects in the container must be deleted before you can delete the container.</div>
+<div class="note"><div class="title">Note</div>All objects in the container must be deleted before you can delete the container.</div>
 
 ## Requests
 

--- a/content/riak/cs/2.1.0/references/apis/storage/openstack/delete-container.md
+++ b/content/riak/cs/2.1.0/references/apis/storage/openstack/delete-container.md
@@ -10,7 +10,10 @@ aliases:
 
 Deletes a container.
 
-<div class="note"><div class="title">Note</div>All objects in the container must be deleted before you can delete the container.</div>
+{{% note title="Note" %}}
+All objects in the container must be deleted before you can delete the
+container.
+{{% /note %}}
 
 ## Requests
 

--- a/content/riak/cs/2.1.0/references/apis/storage/s3/delete-bucket.md
+++ b/content/riak/cs/2.1.0/references/apis/storage/s3/delete-bucket.md
@@ -11,7 +11,9 @@ aliases:
 
 The `DELETE Bucket` operation deletes the bucket specified in the URI.
 
-<div class="note"><div class="title">Note</div>All objects in the bucket must be deleted before you can delete the bucket.</div>
+{{% note title="Note" %}}
+All objects in the bucket must be deleted before you can delete the bucket.
+{{% /note %}}
 
 ## Requests
 

--- a/content/riak/cs/2.1.0/references/apis/storage/s3/delete-bucket.md
+++ b/content/riak/cs/2.1.0/references/apis/storage/s3/delete-bucket.md
@@ -11,7 +11,7 @@ aliases:
 
 The `DELETE Bucket` operation deletes the bucket specified in the URI.
 
-<div class="note"><div clas="title">Note</div>All objects in the bucket must be deleted before you can delete the bucket.</div>
+<div class="note"><div class="title">Note</div>All objects in the bucket must be deleted before you can delete the bucket.</div>
 
 ## Requests
 

--- a/content/riak/cs/2.1.0/references/apis/storage/s3/put-bucket-policy.md
+++ b/content/riak/cs/2.1.0/references/apis/storage/s3/put-bucket-policy.md
@@ -11,7 +11,10 @@ aliases:
 
 The `PUT Bucket policy` operation uses the `policy` subresource to add or replace the policy on an existing bucket. If the bucket already has a policy, the one in this request completely replaces it. To perform this operation, you must be the bucket owner.
 
-<div class="note"><div class="title">Note</div>Currently only the `aws:SourceIp` and `aws:SecureTransport` policy conditions are supported.</div>
+{{% note title="Note" %}}
+Currently only the `aws:SourceIp` and `aws:SecureTransport` policy conditions
+are supported.
+{{% /note %}}
 
 ## Requests
 

--- a/content/riak/cs/2.1.0/references/apis/storage/s3/put-bucket.md
+++ b/content/riak/cs/2.1.0/references/apis/storage/s3/put-bucket.md
@@ -48,7 +48,10 @@ Authorization: signature_value
     <LocationConstraint>BucketRegion</LocationConstraint>
   </CreateBucketConfiguration>
 ```
-<div class="note"><div class="title">Note</div>This example includes some request headers. The Request Headers section contains the complete list of headers.</div>
+{{% note title="Note" %}}
+This example includes some request headers. The Request Headers section
+contains the complete list of headers.
+{{% /note %}}
 
 ### Request Parameters
 

--- a/content/riak/cs/2.1.0/references/apis/storage/s3/put-object-copy.md
+++ b/content/riak/cs/2.1.0/references/apis/storage/s3/put-object-copy.md
@@ -18,10 +18,10 @@ PUT Object (Copy) offers the option to specify the permissions you want to grant
 * Specify a predefined ACL using the `x-amz-acl` request header. More information about predefined ACLs is available [here](http://docs.amazonwebservices.com/AmazonS3/latest/dev/ACLOverview.html#CannedACL).
 * Specify access permissions explicitly using the `x-amz-grant-read`, `x-amz-grant-write`, `x-amz-grant-read-acp`, `x-amz-grant-write-acp`, `x-amz-grant-full-control` headers, which map to the set of ACL permissions supported by Amazon S3.
 
-<div class="note">
-<div class="title">Note</div>
-You can use either a predefined ACL or specify access permissions explicitly, not both.
-</div>
+{{% note title="Note" %}}
+You can use either a predefined ACL or specify access permissions explicitly,
+not both.
+{{% /note %}}
 
 *Note*: You can configure an application to use the `100-continue` HTTP status code, which sends the Request Headers prior to sending the request body. Doing so prevents sending the message body when the message is rejected based on the headers, for example, due to authentication failure or redirect).
 

--- a/content/riak/cs/2.1.0/references/apis/storage/s3/put-object.md
+++ b/content/riak/cs/2.1.0/references/apis/storage/s3/put-object.md
@@ -25,10 +25,10 @@ PUT Object offers the option to specify the permissions you want to grant to spe
 * Specify a predefined ACL using the x-amz-acl request header. More information about predefined ACLs is available [here](http://docs.amazonwebservices.com/AmazonS3/latest/dev/ACLOverview.html#CannedACL).
 * Specify access permissions explicitly using the x-amz-grant-read, x-amz-grant-write, x-amz-grant-read-acp, x-amz-grant-write-acp, x-amz-grant-full-control headers, which map to the set of ACL permissions supported by Amazon S3.
 
-<div class="note">
-<div class="title">Note</div>
-You can use either a predefined ACL or specify access permissions explicitly, not both.
-</div>
+{{% note title="Note" %}}
+You can use either a predefined ACL or specify access permissions explicitly,
+not both.
+{{% /note %}}
 
 ## Requests
 

--- a/content/riak/cs/2.1.0/tutorials/fast-track/local-testing-environment.md
+++ b/content/riak/cs/2.1.0/tutorials/fast-track/local-testing-environment.md
@@ -201,10 +201,10 @@ to use the custom backend provided by Riak CS. You'll have to use the old-style
 ].
 ```
 
-<div class="note"><div class="title">Note on OS-specific paths</div>
+{{% note title="Note on OS-specific paths" %}}
 The path for `add_paths` may be `/usr/lib/riak-cs` or `/usr/lib64/riak-cs`
 depending on your operating system.
-</div>
+{{% /note %}}
 
 Next, set your interface IP addresses in the `riak.conf` file. In a
 production environment, you'd likely have multiple NICs, but for this
@@ -393,9 +393,9 @@ You can use this same process to create additional Riak CS users. To
 make this user the admin user, we set these keys in the Riak CS
 `riak-cs.conf` and `stanchion.conf` files.
 
-<div class="note"><div class="title">Note on admin keys</div>
+{{% note title="Note on admin keys" %}}
 The same admin keys will need to be set on all nodes of the cluster.
-</div>
+{{% /note %}}
 
 Change the following lines in `/etc/riak-cs/riak-cs.conf` on all Riak CS
 machines:

--- a/content/riak/cs/2.1.1/cookbooks/account-management.md
+++ b/content/riak/cs/2.1.1/cookbooks/account-management.md
@@ -24,12 +24,11 @@ curl -X POST http://localhost:8080/riak-cs/user \
   --data '{"email":"foobar@example.com", "name":"foo bar"}' \
 ```
 
-<div class="note">
-<div class="title">Note on admin users</div>
-By default, only the admin user may create new user accounts. If you
-need to create a user account without authenticating yourself, you must
-set `{anonymous_user_creation, true}` in the Riak CS `app.config`.
-</div>
+{{% note title="Note on admin users" %}}
+By default, only the admin user may create new user accounts. If you need to
+create a user account without authenticating yourself, you must set
+`{anonymous_user_creation, true}` in the Riak CS `app.config`.
+{{% /note %}}
 
 The submitted user document may be either JSON or XML, but the type
 should match the value of the `Content-Type` header used. Here are some
@@ -187,13 +186,12 @@ The documents should resemble the following examples.
 </UserUpdate>
 ```
 
-<div class="note">
-<div class="title">Note on update fields</div>
-The `new_key_secret` field (or `NewKeySecret` in XML) may be combined
-with other user update fields in the same request.  Currently, the only
-other supported field is status, but more may be added in the future.
-Unsupported fields are ignored.
-</div>
+{{% note title="Note on update fields" %}}
+The `new_key_secret` field (or `NewKeySecret` in XML) may be combined with
+other user update fields in the same request.  Currently, the only other
+supported field is status, but more may be added in the future. Unsupported
+fields are ignored.
+{{% /note %}}
 
 ## Retrieving a List of All Users
 
@@ -204,12 +202,11 @@ is rejected and a `403 Forbidden` error is returned. This request does
 not properly work with s3cmd, but can be performed using a less dogmatic
 tool such as [s3-curl](http://aws.amazon.com/code/128).
 
-<div class="info">
-<div class="title">Note on hostname</div>
-You must modify the `@endpoints` variable in the `s3curl.pl` script to
-include your Riak CS hostname so that the following example will return
-the list of users.
-</div>
+{{% note title="Note on hostname" %}}
+You must modify the `@endpoints` variable in the `s3curl.pl` script to include
+your Riak CS hostname so that the following example will return the list of
+users.
+{{% /note %}}
 
 A sample URL for a user listing request looks like this:
 

--- a/content/riak/cs/2.1.1/cookbooks/command-line-tools.md
+++ b/content/riak/cs/2.1.1/cookbooks/command-line-tools.md
@@ -84,11 +84,10 @@ Stops all applications and starts without restarting the Erlang VM.
 riak-cs reboot
 ```
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The <code>riak-cs reboot</code> command has been deprecated. We
-recommend using the <code>riak-cs restart</code> command instead.
-</div>
+{{% note title="Deprecation notice" %}}
+The `riak-cs reboot` command has been deprecated. We recommend using the
+`riak-cs restart` command instead.
+{{% /note %}}
 
 #### ping
 
@@ -523,12 +522,10 @@ Riak CS version 1.5 offers support for supercluster operations. The
 `supercluster` command interface enables you to interact with that system.
 More information can be found in [Riak CS Supercluster Support](/riak/cs/2.1.1/cookbooks/supercluster).
 
-<div class="note">
-<div class="title">Note: technical preview</div>
+{{% note title="Note: technical preview" %}}
 Riak CS supercluster support is available only as a technical preview for
-users of Riak CS installations with support for Multi-Datacenter
-Replication.
-</div>
+users of Riak CS installations with support for Multi-Datacenter Replication.
+{{% /note %}}
 
 #### list-members
 

--- a/content/riak/cs/2.1.1/cookbooks/configuration/dragondisk.md
+++ b/content/riak/cs/2.1.1/cookbooks/configuration/dragondisk.md
@@ -59,12 +59,10 @@ save an account. The following describes the process for doing so.
 * Enter the Riak CS public interface HTTP port into the **HTTP Port**
   field.
 
-<div class="note">
-<div class="title">Note on HTTPS</div>
-If you'll be using HTTPS, be sure to enter the correct public HTTPS port
-into the **HTTPS Port** field and click the **Connect
-using SSL/HTTS** check box.
-</div>
+{{% note title="Note on HTTPS" %}}
+If you'll be using HTTPS, be sure to enter the correct public HTTPS port into
+the **HTTPS Port** field and click the **Connect using SSL/HTTS** check box.
+{{% /note %}}
 
 * Click **OK** to save the account configuration.
 
@@ -163,12 +161,10 @@ save an account. The following describes the process for doing so.
 * Enter the Riak CS public interface HTTP port into the **HTTP Port**
   field.
 
-<div class="note">
-<div class="title">Note on HTTPS</div>
-If you'll be using HTTPS, be sure to enter the correct public HTTPS port
-into the **HTTPS Port** field and click the **Connect using SSL/HTTS**
-check box.
-</div>
+{{% note title="Note on HTTPS" %}}
+If you'll be using HTTPS, be sure to enter the correct public HTTPS port into
+the **HTTPS Port** field and click the **Connect using SSL/HTTS** check box.
+{{% /note %}}
 
 * Click **OK** to save the account configuration.
 
@@ -268,12 +264,10 @@ save an account. The following describes the process for doing so.
 * Enter the Riak CS public interface HTTP port into the **HTTP Port**
   field.
 
-<div class="note">
-<div class="title">Note on HTTPS</div>
-If you'll be using HTTPS, be sure to enter the correct public HTTPS port
-into the **HTTPS Port** field and click the **Connect using SSL/HTTS**
-check box.
-</div>
+{{% note title="Note on HTTPS" %}}
+If you'll be using HTTPS, be sure to enter the correct public HTTPS port into
+the **HTTPS Port** field and click the **Connect using SSL/HTTS** check box.
+{{% /note %}}
 
 * Click **OK** to save the account configuration.
 

--- a/content/riak/cs/2.1.1/cookbooks/configuration/multi-datacenter.md
+++ b/content/riak/cs/2.1.1/cookbooks/configuration/multi-datacenter.md
@@ -14,12 +14,10 @@ aliases:
   - /riak/cs/2.1.1/cookbooks/configuration/Configuring-MDC/
 ---
 
-<div class="note">
-<div class="title">Riak CS Enterprise requires a separate download</div>
-Please note that Riak CS Enterprise requires a download separate from
-the open-source Riak CS, which will not work in conjunction with Riak
-Enterprise.
-</div>
+{{% note title="Riak CS Enterprise requires a separate download" %}}
+Please note that Riak CS Enterprise requires a download separate from the
+open-source Riak CS, which will not work in conjunction with Riak Enterprise.
+{{% /note %}}
 
 Configuring Multi-Datacenter Replication in Riak CS requires the
 addition of a new group of settings to the `app.config` configuration

--- a/content/riak/cs/2.1.1/cookbooks/configuration/reference.md
+++ b/content/riak/cs/2.1.1/cookbooks/configuration/reference.md
@@ -92,23 +92,25 @@ Most of the settings you will need to manipulate have been ported into the newer
 such as setting up customized `lager` streams -- that will need to be configured
 in `advanced.config`.
 
-<div class="note"><div class="title">A Note About Time Values</div>
+{{% note title="A Note About Time Values" %}}
 In the `app.config` configuration files, time periods were generally written
 as either seconds or milliseconds, with no real indication of which was being
 used. With the update to `riak-cs.conf`, all values that describe a period of
-time are written as an integer and a character, describing the unit of time and
-the number of times that unit should be repeated for the period. For example
-`31d` represents 31 days, `6h` represents six hours, `6000ms` represents 6,000
-milliseconds.</br>
-The full list of valid time units are as follows:</br>
-`f` -- Fortnights</br>
-`w` -- Weeks</br>
-`d` -- Days</br>
-`h` -- Hours</br>
-`m` -- Minutes</br>
-`s` -- Seconds</br>
-`ms` -- Milliseconds</br>
-</div>
+time are written as an integer and a character, describing the unit of time
+and the number of times that unit should be repeated for the period. For
+example `31d` represents 31 days, `6h` represents six hours, `6000ms`
+represents 6,000 milliseconds.
+
+The full list of valid time units are as follows:
+
+`f` -- Fortnights
+`w` -- Weeks
+`d` -- Days
+`h` -- Hours
+`m` -- Minutes
+`s` -- Seconds
+`ms` -- Milliseconds
+{{% /note %}}
 
 The tables below will show settings for both `riak-cs.conf` and
 `advanced.config`/`app.config` where applicable, organized by functionality.

--- a/content/riak/cs/2.1.1/cookbooks/configuration/riak-cs.md
+++ b/content/riak/cs/2.1.1/cookbooks/configuration/riak-cs.md
@@ -73,13 +73,12 @@ You will also need to set the host listener for Riak CS:
    port number does not conflict with the `riak_host` port number of the Riak
    node and the Riak CS node that are running on the same machine.
 
-<div class="note">
-<div class="title">Note on IP addresses</div>
-The IP address you enter here must match the IP address specified for
-the Protocol Buffers interface in the Riak <code>riak.conf</code> file
-unless Riak CS is running on a completely different network, in which
-case address translation is required.
-</div>
+{{% note title="Note on IP addresses" %}}
+The IP address you enter here must match the IP address specified for the
+Protocol Buffers interface in the Riak `riak.conf` file unless Riak CS is
+running on a completely different network, in which case address translation
+is required.
+{{% /note %}}
 
 After making any changes to the `riak-cs.conf` file in Riak CS,
 [restart](/riak/cs/2.1.1/cookbooks/command-line-tools/#riak-cs) the node if it is already running.
@@ -144,13 +143,12 @@ The admin user is authorized to perform actions such as creating users or
 obtaining billing statistics. An admin user account is no different from any
 other user account. **You must create an admin user to use Riak CS**.
 
-<div class="note">
-<div class="title">Note on anonymous user creation</div>
-Before creating an admin user, you must first set `anonymous_user_creation = on`
-in the Riak CS `riak-cs.conf` (or set `{anonymous_user_creation, true}` in the
-old-style `advanced.config`/`app.config`). You may disable this again once the
-admin user has been created.
-</div>
+{{% note title="Note on anonymous user creation" %}}
+Before creating an admin user, you must first set `anonymous_user_creation =
+on` in the Riak CS `riak-cs.conf` (or set `{anonymous_user_creation, true}` in
+the old-style `advanced.config`/`app.config`). You may disable this again once
+the admin user has been created.
+{{% /note %}}
 
 To create an account for the admin user, use an HTTP `POST` request with the
 username you want to use for the admin account. The following is an
@@ -413,11 +411,11 @@ settings are available through the `riak-cs.conf` configuration file.**
 * `gc_batch_size` --- This option represents the size used for paginating the
   results of the secondary index query. The default value is 1000.
 
-<div class="note"><div class="title">Deprecated Configurations</div>
+{{% note title="Deprecated Configurations" %}}
 While Riak CS 2.0.0 still allows the configuration of `gc_paginated_indexes`,
 it is strongly recommended that these settings not be used. This setting has
-been deprecated, and <em>will be removed</em> in the next major release.
-</div>
+been deprecated, and _will be removed_ in the next major release.
+{{% /note %}}
 
 ## Other Riak CS Settings
 

--- a/content/riak/cs/2.1.1/cookbooks/configuration/riak-for-cs.md
+++ b/content/riak/cs/2.1.1/cookbooks/configuration/riak-for-cs.md
@@ -155,12 +155,11 @@ buckets.default.allow_mult = true
 This will enable Riak to create [siblings](/riak/kv/2.1.3/learn/concepts/causal-context/#siblings), which is necessary for Riak CS to function. If you are connecting to Riak CS from a [client library](/riak/kv/2.1.3/developing/client-libraries), don't worry: you will not have to manage [conflict resolution](/riak/kv/2.1.3/developing/usage/conflict-resolution), as all Riak CS
 operations are strongly consistent by definition.
 
-<div class="note">
-<div class="title">Note on <code>allow_mult</code></div>
+{{% note title="Note on `allow_mult`" %}}
 Any Riak node that also supports Riak CS should have `allow_mult` set to
-`true` at all times. Riak CS will refuse to start if `allow_mult` is
-set to `false`.
-</div>
+`true` at all times. Riak CS will refuse to start if `allow_mult` is set to
+`false`.
+{{% /note %}}
 
 ## Specifying the Nodename and IP Address
 
@@ -248,12 +247,11 @@ the `pb` value in `advanced.config`/`app.config`) file must match the values for
 `riak_host` in the Riak CS `riak-cs.config` and Stanchion `stanchion.conf` (or
 `riak_host` the relative `advanced.config`/`app.config`) files.
 
-<div class="note">
-<div class="title">Note on port numbers</div>
-A different port number might be required if the port number conflicts
-with ports used by another application or if you use a load balancer or
-proxy server.
-</div>
+{{% note title="Note on port numbers" %}}
+A different port number might be required if the port number conflicts with
+ports used by another application or if you use a load balancer or proxy
+server.
+{{% /note %}}
 
 It is also recommended that users insure that the size of Riak's
 `protobuf.backlog` (or in the `advanced.config`/`app.config` files, the

--- a/content/riak/cs/2.1.1/cookbooks/configuration/stanchion.md
+++ b/content/riak/cs/2.1.1/cookbooks/configuration/stanchion.md
@@ -60,11 +60,11 @@ listener = 127.0.0.1:8080
             ]}
 ```
 
-<div class="note"><div class="title">Note on matching IP addresses</div>
+{{% note title="Note on matching IP addresses" %}}
 The IP address you enter here must match the IP address specified for the
-<code>stanchion_host</code> variable in the Riak <code>riak.conf</code> file and
-the Riak CS <code>riak-cs.conf</code> file.
-</div>
+`stanchion_host` variable in the Riak `riak.conf` file and the Riak CS
+`riak-cs.conf` file.
+{{% /note %}}
 
 If you want to use SSL, make sure the `ssl.certfile` and `ssl.keyfile` settings
 are not commented out, and have been set correctly.

--- a/content/riak/cs/2.1.1/cookbooks/configuration/transmit.md
+++ b/content/riak/cs/2.1.1/cookbooks/configuration/transmit.md
@@ -17,7 +17,10 @@ aliases:
 [Transmit](https://www.panic.com/transmit/) is an S3-compatible client with a
 graphical user interface for Mac OS X. The following guide describes configuration of Transmit for use with Riak CS.
 
-<div class="info"><div class="title">Note</div>S3 support was added in Transmit version 4.4, so ensure that you're following along with a version that supports S3 before continuing.</div>
+{{% note title="Note" %}}
+S3 support was added in Transmit version 4.4, so ensure that you're following
+along with a version that supports S3 before continuing.
+{{% /note %}}
 
 ## Define a Connection
 

--- a/content/riak/cs/2.1.1/cookbooks/designate-admin-user.md
+++ b/content/riak/cs/2.1.1/cookbooks/designate-admin-user.md
@@ -13,9 +13,8 @@ editing and replacing the `admin_key` and `admin_secret` in `app.config`
 with the user's credentials. Once this is done, do not forget to update
 the same credentials in the Stanchion `app.config` as well.
 
-<div class="note">
-<div class="title">Note on the admin role</div>
-This is a powerful role and gives the designee administrative
-capabilities within the system. As such, caution should be used to
-protect the access credentials of the admin user.
-</div>
+{{% note title="Note on the admin role" %}}
+This is a powerful role and gives the designee administrative capabilities
+within the system. As such, caution should be used to protect the access
+credentials of the admin user.
+{{% /note %}}

--- a/content/riak/cs/2.1.1/cookbooks/garbage-collection.md
+++ b/content/riak/cs/2.1.1/cookbooks/garbage-collection.md
@@ -42,14 +42,13 @@ that can be divided into two essential phases:
 
 These two phases are described in more detail in the following sections.
 
-<div class="note">
-<div class="title">Note on manifest pruning</div>
+{{% note title="Note on manifest pruning" %}}
 A Riak CS object's manifest is updated any time a write, i.e. a `PUT` or
 `DELETE` request, is issued, which means that manifest sizes can grow
 significantly over time. This can lead to latency problems. Riak CS's GC
-subsystem will prune these manifests. If you're experiencing
-manifest-related issues, we would recommend using GC.
-</div>
+subsystem will prune these manifests. If you're experiencing manifest-related
+issues, we would recommend using GC.
+{{% /note %}}
 
 ## Synchronous GC Actions
 

--- a/content/riak/cs/2.1.1/cookbooks/monitoring-and-metrics.md
+++ b/content/riak/cs/2.1.1/cookbooks/monitoring-and-metrics.md
@@ -225,10 +225,9 @@ dtrace -qn 'erlang*:::user_trace* /arg2 == 703/ {printf("pid %s: mod %s op %s: u
 dtrace -qn 'erlang*:::user_trace* /arg2 == 705/ {printf("pid %s: %s:%s\n", copyinstr(arg0), copyinstr(arg6), copyinstr(arg7));}'
 ```
 
-<div class="info">
-<div class="title">Note on DTrace Support</div>
-Work on packaging of Riak CS for SmartOS and other operating systems
-with DTrace support is ongoing with the goal of providing enhanced
-ability to diagnose low-level issues in instances of Riak CS running on
-such operating systems.
-</div>
+{{% note title="Note on DTrace Support" %}}
+Work on packaging of Riak CS for SmartOS and other operating systems with
+DTrace support is ongoing with the goal of providing enhanced ability to
+diagnose low-level issues in instances of Riak CS running on such operating
+systems.
+{{% /note %}}

--- a/content/riak/cs/2.1.1/cookbooks/multi-datacenter-overview.md
+++ b/content/riak/cs/2.1.1/cookbooks/multi-datacenter-overview.md
@@ -25,12 +25,10 @@ synchronization.
 
 If you are interested, sign up for a [developer trial](http://info.basho.com/RiakCS1.1_DeveloperTrialRequest.html) of Riak CS Enterprise or [contact us](http://basho.com/contact/) for more information.
 
-<div class="note">
-<div class="title">Riak CS Enterprise requires a separate download</div>
-Please note that Riak CS Enterprise requires a download separate from
-the open-source Riak CS, which will not work in conjunction with Riak
-Enterprise.
-</div>
+{{% note title="Riak CS Enterprise requires a separate download" %}}
+Please note that Riak CS Enterprise requires a download separate from the
+open-source Riak CS, which will not work in conjunction with Riak Enterprise.
+{{% /note %}}
 
 ## Multi-Datacenter Replication
 

--- a/content/riak/cs/2.1.1/cookbooks/multipart-upload-overview.md
+++ b/content/riak/cs/2.1.1/cookbooks/multipart-upload-overview.md
@@ -26,10 +26,9 @@ may be uploaded in parallel. In Riak CS they are designed to both behave
 like Amazon S3 multipart uploads and to utilize the same user-facing
 API.
 
-<div class="note">
-<div class="title">Note on file size limit</div>
+{{% note title="Note on file size limit" %}}
 The size limit on individual parts of a multipart upload is 5 gigabytes.
-</div>
+{{% /note %}}
 
 There are three phases to a multipart upload: **initiation**, **parts
 upload**, and **completion**. Each phase is described in more detail

--- a/content/riak/cs/2.1.1/cookbooks/querying-access-statistics.md
+++ b/content/riak/cs/2.1.1/cookbooks/querying-access-statistics.md
@@ -17,12 +17,11 @@ Access statistics are tracked on a per-user basis as rollups for slices
 of time. Querying these statistics is done via the
 `/riak-cs/usage/$USER_KEY_ID` resource.
 
-<div class="note">
-<div class="title">Note on terminology</div>
-In this and other documents in the Riak CS documentation, the terms
-"storage" and "billing" are used interchangeably. The same goes for the
-terms "usage" and access.
-</div>
+{{% note title="Note on terminology" %}}
+In this and other documents in the Riak CS documentation, the terms "storage"
+and "billing" are used interchangeably. The same goes for the terms "usage"
+and access.
+{{% /note %}}
 
 For information about how access statistics are logged, please read
 [Usage and Billing Data](/riak/cs/2.1.1/cookbooks/usage-and-billing-data).

--- a/content/riak/cs/2.1.1/cookbooks/querying-storage-statistics.md
+++ b/content/riak/cs/2.1.1/cookbooks/querying-storage-statistics.md
@@ -17,12 +17,11 @@ Storage statistics are tracked on a per-user basis, as rollups for
 slices of time. Querying these statistics is done via the
 `/riak-cs/usage/$USER_KEY_ID` resource.
 
-<div class="note">
-<div class="title">Note on terminology</div>
-In this and other documents in the Riak CS documentation, the terms
-"storage" and "billing" are used interchangeably. The same goes for the
-terms "usage" and access.
-</div>
+{{% note title="Note on terminology" %}}
+In this and other documents in the Riak CS documentation, the terms "storage"
+and "billing" are used interchangeably. The same goes for the terms "usage"
+and access.
+{{% /note %}}
 
 
 > **Note**:

--- a/content/riak/cs/2.1.1/cookbooks/supercluster.md
+++ b/content/riak/cs/2.1.1/cookbooks/supercluster.md
@@ -13,12 +13,11 @@ aliases:
   - /riakcs/2.1.1/cookbooks/supercluster/
 ---
 
-<div class="note">
-<div class="title">Technical Preview</div>
-Riak CS Supercluster is currently in technical preview mode and is
-available only to <a href="http://basho.com/riak-enterprise/">Riak
-Enterprise</a> customers. It is not yet suitable for production use.
-</div>
+{{% note title="Technical Preview" %}}
+Riak CS Supercluster is currently in technical preview mode and is available
+only to <a href="http://basho.com/riak-enterprise/">Riak Enterprise</a>
+customers. It is not yet suitable for production use.
+{{% /note %}}
 
 While [Riak CS Enterprise](http://basho.com/riak-enterprise) enables
 you to distribute Riak CS objects across multiple data centers in a

--- a/content/riak/cs/2.1.1/cookbooks/usage-and-billing-data.md
+++ b/content/riak/cs/2.1.1/cookbooks/usage-and-billing-data.md
@@ -17,12 +17,11 @@ Like many other object storage systems, Riak CS gathers a variety of
 usage statistics and makes them available through its administrative
 API.
 
-<div class="note">
-<div class="title">Note on terminology</div>
-In this and other documents in the Riak CS documentation, the terms
-"storage" and "billing" are used interchangeably. The same goes for the
-terms "usage" and access.
-</div>
+{{% note title="Note on terminology" %}}
+In this and other documents in the Riak CS documentation, the terms "storage"
+and "billing" are used interchangeably. The same goes for the terms "usage"
+and access.
+{{% /note %}}
 
 ## Access Statistics
 
@@ -252,17 +251,15 @@ stats.storage.schedule.2 = 1800
 {storage_schedule, ["0600", "1800"]}
 ```
 
-<div class="note">
-<div class="title">Note on archive periods</div>
-When using multiple times in a storage schedule, they must be scheduled
-for different archive periods (see details for `storage_archive_period`
-in the **Archival** section below). Extra scheduled times in the same
-archive period are skipped. This is intended to allow more than one Riak
-CS node to calculate storage statistics concurrently, as they will take
-notice of users already calculated by other nodes and skip them (see
-details in the Manual Triggering section about overriding this
-behavior).
-</div>
+{{% note title="Note on archive periods" %}}
+When using multiple times in a storage schedule, they must be scheduled for
+different archive periods (see details for `storage_archive_period` in the
+**Archival** section below). Extra scheduled times in the same archive period
+are skipped. This is intended to allow more than one Riak CS node to calculate
+storage statistics concurrently, as they will take notice of users already
+calculated by other nodes and skip them (see details in the Manual Triggering
+section about overriding this behavior).
+{{% /note %}}
 
 By default, no schedule is specified, so the storage calculation is
 never done automatically.

--- a/content/riak/cs/2.1.1/references/apis/storage/openstack/delete-container.md
+++ b/content/riak/cs/2.1.1/references/apis/storage/openstack/delete-container.md
@@ -10,7 +10,7 @@ aliases:
 
 Deletes a container.
 
-<div class="note"><div clas="title">Note</div>All objects in the container must be deleted before you can delete the container.</div>
+<div class="note"><div class="title">Note</div>All objects in the container must be deleted before you can delete the container.</div>
 
 ## Requests
 

--- a/content/riak/cs/2.1.1/references/apis/storage/openstack/delete-container.md
+++ b/content/riak/cs/2.1.1/references/apis/storage/openstack/delete-container.md
@@ -10,7 +10,10 @@ aliases:
 
 Deletes a container.
 
-<div class="note"><div class="title">Note</div>All objects in the container must be deleted before you can delete the container.</div>
+{{% note title="Note" %}}
+All objects in the container must be deleted before you can delete the
+container.
+{{% /note %}}
 
 ## Requests
 

--- a/content/riak/cs/2.1.1/references/apis/storage/s3/delete-bucket.md
+++ b/content/riak/cs/2.1.1/references/apis/storage/s3/delete-bucket.md
@@ -11,7 +11,9 @@ aliases:
 
 The `DELETE Bucket` operation deletes the bucket specified in the URI.
 
-<div class="note"><div class="title">Note</div>All objects in the bucket must be deleted before you can delete the bucket.</div>
+{{% note title="Note" %}}
+All objects in the bucket must be deleted before you can delete the bucket.
+{{% /note %}}
 
 ## Requests
 

--- a/content/riak/cs/2.1.1/references/apis/storage/s3/delete-bucket.md
+++ b/content/riak/cs/2.1.1/references/apis/storage/s3/delete-bucket.md
@@ -11,7 +11,7 @@ aliases:
 
 The `DELETE Bucket` operation deletes the bucket specified in the URI.
 
-<div class="note"><div clas="title">Note</div>All objects in the bucket must be deleted before you can delete the bucket.</div>
+<div class="note"><div class="title">Note</div>All objects in the bucket must be deleted before you can delete the bucket.</div>
 
 ## Requests
 

--- a/content/riak/cs/2.1.1/references/apis/storage/s3/put-bucket-policy.md
+++ b/content/riak/cs/2.1.1/references/apis/storage/s3/put-bucket-policy.md
@@ -11,7 +11,10 @@ aliases:
 
 The `PUT Bucket policy` operation uses the `policy` subresource to add or replace the policy on an existing bucket. If the bucket already has a policy, the one in this request completely replaces it. To perform this operation, you must be the bucket owner.
 
-<div class="note"><div class="title">Note</div>Currently only the `aws:SourceIp` and `aws:SecureTransport` policy conditions are supported.</div>
+{{% note title="Note" %}}
+Currently only the `aws:SourceIp` and `aws:SecureTransport` policy conditions
+are supported.
+{{% /note %}}
 
 ## Requests
 

--- a/content/riak/cs/2.1.1/references/apis/storage/s3/put-bucket.md
+++ b/content/riak/cs/2.1.1/references/apis/storage/s3/put-bucket.md
@@ -48,7 +48,10 @@ Authorization: signature_value
     <LocationConstraint>BucketRegion</LocationConstraint>
   </CreateBucketConfiguration>
 ```
-<div class="note"><div class="title">Note</div>This example includes some request headers. The Request Headers section contains the complete list of headers.</div>
+{{% note title="Note" %}}
+This example includes some request headers. The Request Headers section
+contains the complete list of headers.
+{{% /note %}}
 
 ### Request Parameters
 

--- a/content/riak/cs/2.1.1/references/apis/storage/s3/put-object-copy.md
+++ b/content/riak/cs/2.1.1/references/apis/storage/s3/put-object-copy.md
@@ -18,10 +18,10 @@ PUT Object (Copy) offers the option to specify the permissions you want to grant
 * Specify a predefined ACL using the `x-amz-acl` request header. More information about predefined ACLs is available [here](http://docs.amazonwebservices.com/AmazonS3/latest/dev/ACLOverview.html#CannedACL).
 * Specify access permissions explicitly using the `x-amz-grant-read`, `x-amz-grant-write`, `x-amz-grant-read-acp`, `x-amz-grant-write-acp`, `x-amz-grant-full-control` headers, which map to the set of ACL permissions supported by Amazon S3.
 
-<div class="note">
-<div class="title">Note</div>
-You can use either a predefined ACL or specify access permissions explicitly, not both.
-</div>
+{{% note title="Note" %}}
+You can use either a predefined ACL or specify access permissions explicitly,
+not both.
+{{% /note %}}
 
 *Note*: You can configure an application to use the `100-continue` HTTP status code, which sends the Request Headers prior to sending the request body. Doing so prevents sending the message body when the message is rejected based on the headers, for example, due to authentication failure or redirect).
 

--- a/content/riak/cs/2.1.1/references/apis/storage/s3/put-object.md
+++ b/content/riak/cs/2.1.1/references/apis/storage/s3/put-object.md
@@ -25,10 +25,10 @@ PUT Object offers the option to specify the permissions you want to grant to spe
 * Specify a predefined ACL using the x-amz-acl request header. More information about predefined ACLs is available [here](http://docs.amazonwebservices.com/AmazonS3/latest/dev/ACLOverview.html#CannedACL).
 * Specify access permissions explicitly using the x-amz-grant-read, x-amz-grant-write, x-amz-grant-read-acp, x-amz-grant-write-acp, x-amz-grant-full-control headers, which map to the set of ACL permissions supported by Amazon S3.
 
-<div class="note">
-<div class="title">Note</div>
-You can use either a predefined ACL or specify access permissions explicitly, not both.
-</div>
+{{% note title="Note" %}}
+You can use either a predefined ACL or specify access permissions explicitly,
+not both.
+{{% /note %}}
 
 ## Requests
 

--- a/content/riak/cs/2.1.1/tutorials/fast-track/local-testing-environment.md
+++ b/content/riak/cs/2.1.1/tutorials/fast-track/local-testing-environment.md
@@ -201,10 +201,10 @@ to use the custom backend provided by Riak CS. You'll have to use the old-style
 ].
 ```
 
-<div class="note"><div class="title">Note on OS-specific paths</div>
+{{% note title="Note on OS-specific paths" %}}
 The path for `add_paths` may be `/usr/lib/riak-cs` or `/usr/lib64/riak-cs`
 depending on your operating system.
-</div>
+{{% /note %}}
 
 Next, set your interface IP addresses in the `riak.conf` file. In a
 production environment, you'd likely have multiple NICs, but for this
@@ -393,9 +393,9 @@ You can use this same process to create additional Riak CS users. To
 make this user the admin user, we set these keys in the Riak CS
 `riak-cs.conf` and `stanchion.conf` files.
 
-<div class="note"><div class="title">Note on admin keys</div>
+{{% note title="Note on admin keys" %}}
 The same admin keys will need to be set on all nodes of the cluster.
-</div>
+{{% /note %}}
 
 Change the following lines in `/etc/riak-cs/riak-cs.conf` on all Riak CS
 machines:

--- a/content/riak/kv/2.0.0/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.0.0/configuring/load-balancing-proxy.md
@@ -184,15 +184,13 @@ act as a front-end proxy to a 5-node Riak cluster.
 This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
-<div class="note">
-<div class="title">Nginx version notes</div>
-This example configuration was verified on <strong>Nginx version
-1.2.3</strong>. Please be aware that earlier versions of Nginx did not
-support any HTTP 1.1 semantics for upstream communication to backends.
-You should carefully examine this configuration and make changes
-appropriate to your specific environment before attempting to use
-it
-</div>
+{{% note title="Nginx version notes" %}}
+This example configuration was verified on **Nginx version 1.2.3**. Please be
+aware that earlier versions of Nginx did not support any HTTP 1.1 semantics
+for upstream communication to backends. You should carefully examine this
+configuration and make changes appropriate to your specific environment before
+attempting to use it
+{{% /note %}}
 
 Here is an example `nginx.conf` file:
 
@@ -250,13 +248,12 @@ server {
 }
 ```
 
-<div class="note">
-<div class="title">Note on access controls</div>
-Even when filtering and limiting requests to GETs only as done in the
-example, you should strongly consider additional access controls beyond
-what Nginx can provide directly, such as specific firewall rules to
-limit inbound connections to trusted sources.
-</div>
+{{% note title="Note on access controls" %}}
+Even when filtering and limiting requests to GETs only as done in the example,
+you should strongly consider additional access controls beyond what Nginx can
+provide directly, such as specific firewall rules to limit inbound connections
+to trusted sources.
+{{% /note %}}
 
 ### Querying Secondary Indexes Over HTTP
 

--- a/content/riak/kv/2.0.0/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.0.0/configuring/load-balancing-proxy.md
@@ -185,7 +185,7 @@ This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
 <div class="note">
-<div class="title">Nginx version notes</div
+<div class="title">Nginx version notes</div>
 This example configuration was verified on <strong>Nginx version
 1.2.3</strong>. Please be aware that earlier versions of Nginx did not
 support any HTTP 1.1 semantics for upstream communication to backends.

--- a/content/riak/kv/2.0.0/configuring/v2-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.0.0/configuring/v2-multi-datacenter/ssl.md
@@ -64,8 +64,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -73,7 +72,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.0.0/configuring/v3-multi-datacenter/quick-start.md
+++ b/content/riak/kv/2.0.0/configuring/v3-multi-datacenter/quick-start.md
@@ -137,13 +137,11 @@ Sink             Cluster Name         <Ctrl-Pid>      [Members]
 Cluster1          Cluster1            <0.4456.0>      ["10.60.67.149:9080"] (via 10.60.67.149:9080)
 ```
 
-<div class="note">
-<div class="title">Note on connections</div>
-At this point, if you do not have connections, replication will not
-work. Check your IP bindings by running <code>netstat -a</code> on all
-nodes. You should see <code>*:9080 LISTENING</code>. If not, you have
-configuration problems.
-</div>
+{{% note title="Note on connections" %}}
+At this point, if you do not have connections, replication will not work.
+Check your IP bindings by running `netstat -a` on all nodes. You should see
+`*:9080 LISTENING`. If not, you have configuration problems.
+{{% /note %}}
 
 ### Enable Realtime Replication
 

--- a/content/riak/kv/2.0.0/configuring/v3-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.0.0/configuring/v3-multi-datacenter/ssl.md
@@ -54,12 +54,11 @@ the `riak-core` section of [`advanced.confg`][config reference#advanced.config]:
 The `cacertsdir` is a directory containing all the CA certificates
 needed to verify the CA chain back to the root.
 
-<div class="note">
-<div class="title">Note on configuration</div>
+{{% note title="Note on configuration" %}}
 In Version 3 replication, the SSL settings need to be placed in the
-<code>riak-core</code> section of <code>advanced.config</code> as opposed to
-the <code>riak-repl</code> section used by Version 2 replication.
-</div>
+`riak-core` section of `advanced.config` as opposed to the `riak-repl` section
+used by Version 2 replication.
+{{% /note %}}
 
 ## Verifying Peer Certificates
 
@@ -80,8 +79,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -89,7 +87,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.0.0/developing/api/http/fetch-object.md
+++ b/content/riak/kv/2.0.0/developing/api/http/fetch-object.md
@@ -79,22 +79,23 @@ datetime format
 The body of the response will be the contents of the object except when siblings
 are present.
 
-<div class="note"><div class="title">Siblings</div>
-<p>When `allow_mult` is set to true in the bucket properties, concurrent updates
-are allowed to create "sibling" objects, meaning that the object has any number
-of different values that are related to one another by the vector clock.  This
-allows your application to use its own conflict resolution technique.</p>
+{{% note title="Siblings" %}}
+When `allow_mult` is set to true in the bucket properties, concurrent updates
+are allowed to create "sibling" objects, meaning that the object has any
+number of different values that are related to one another by the vector
+clock.  This allows your application to use its own conflict resolution
+technique.
 
-<p>An object with multiple sibling values will result in a `300 Multiple
-Choices` response.  If the `Accept` header prefers `multipart/mixed`, all
-siblings will be returned in a single request as sections of the
-`multipart/mixed` response body.  Otherwise, a list of "vtags" will be given in
-a simple text format. You can request individual siblings by adding the `vtag`
-query parameter. Scroll down to the 'manually requesting siblings' example below for more information.</p>
+An object with multiple sibling values will result in a `300 Multiple Choices`
+response.  If the `Accept` header prefers `multipart/mixed`, all siblings will
+be returned in a single request as sections of the `multipart/mixed` response
+body.  Otherwise, a list of "vtags" will be given in a simple text format. You
+can request individual siblings by adding the `vtag` query parameter. Scroll
+down to the 'manually requesting siblings' example below for more information.
 
-<p>To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
-given in the response.</p>
-</div>
+To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
+given in the response.
+{{% /note %}}
 
 ## Simple Example
 

--- a/content/riak/kv/2.0.0/developing/api/http/link-walking.md
+++ b/content/riak/kv/2.0.0/developing/api/http/link-walking.md
@@ -26,22 +26,19 @@ is a special case of [MapReduce](/riak/kv/2.0.0/developing/usage/mapreduce), and
 GET /buckets/bucket/keys/key/[bucket],[tag],[keep]
 ```
 
-<div class="info"><div class="title">Link filters</div>
-<p>A link filter within the request URL is made of three parts, separated by
-commas:</p>
+{{% note title="Link filters" %}}
+A link filter within the request URL is made of three parts, separated by
+commas:
 
-<ul>
-<li>Bucket - a bucket name to limit the links to</li>
-<li>Tag - a "riaktag" to limit the links to</li>
-<li>Keep - 0 or 1, whether to return results from this phase</li>
-</ul>
+* Bucket - a bucket name to limit the links to
+* Tag - a "riaktag" to limit the links to
+* Keep - 0 or 1, whether to return results from this phase
 
-<p>Any of the three parts may be replaced with <code>_</code> (underscore),
-signifying that any value is valid. Multiple phases of links can be followed by
-adding additional path segments to the URL, separating the link filters by
-slashes. The final phase in the link-walking query implicitly returns its
-results.</p>
-</div>
+Any of the three parts may be replaced with `_` (underscore), signifying that
+any value is valid. Multiple phases of links can be followed by adding
+additional path segments to the URL, separating the link filters by slashes.
+The final phase in the link-walking query implicitly returns its results.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.0.0/developing/api/http/list-buckets.md
+++ b/content/riak/kv/2.0.0/developing/api/http/list-buckets.md
@@ -17,10 +17,10 @@ aliases:
 
 Lists all known buckets (ones that have keys stored in them).
 
-<div class="note"><div class="title">Not for production use</div>
+{{% note title="Not for production use" %}}
 Similar to the list keys operation, this requires traversing all keys stored
 in the cluster and should not be used in production.
-</div>
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.0/developing/api/http/list-keys.md
+++ b/content/riak/kv/2.0.0/developing/api/http/list-keys.md
@@ -17,12 +17,10 @@ aliases:
 
 Lists keys in a bucket.
 
-<div class="note">
-<div class="title">Not for production use</div>
-
-This operation requires traversing all keys stored in the cluster and should not be used in production.
-
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.0/developing/api/http/set-bucket-props.md
+++ b/content/riak/kv/2.0.0/developing/api/http/set-bucket-props.md
@@ -50,14 +50,12 @@ the bucket
 
 Other properties do exist but are not commonly modified.
 
-<div class="note">
-<div class="title">Property types</div>
-<p>Make sure you use the proper types for attributes like <strong>n_val</strong>
-and <strong>allow_mult</strong>. If you use strings instead of integers and
-booleans respectively, you may see some odd errors in your logs, saying
-something like
-<code>"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"</code>.</p>
-</div>
+{{% note title="Property types" %}}
+Make sure you use the proper types for attributes like **n_val** and
+**allow_mult**. If you use strings instead of integers and booleans
+respectively, you may see some odd errors in your logs, saying something like
+`"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"`.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.0.0/developing/api/protocol-buffers.md
+++ b/content/riak/kv/2.0.0/developing/api/protocol-buffers.md
@@ -106,12 +106,11 @@ Code | Message |
 254 | `RpbAuthResp` |
 255 | `RpbStartTls` |
 
-<div class="info">
-<div class="title">Message Definitions</div>
-All Protocol Buffers messages are defined in the <code>riak.proto</code>
-and other <code>.proto</code> files in the <code>/src</code> directory
-of the <a href="https://github.com/basho/riak_pb">RiakPB</a> project.
-</div>
+{{% note title="Message Definitions" %}}
+All Protocol Buffers messages are defined in the `riak.proto` and other
+`.proto` files in the `/src` directory of the
+<a href="https://github.com/basho/riak_pb">RiakPB</a> project.
+{{% /note %}}
 
 ### Error Response
 

--- a/content/riak/kv/2.0.0/developing/api/protocol-buffers/fetch-object.md
+++ b/content/riak/kv/2.0.0/developing/api/protocol-buffers/fetch-object.md
@@ -137,14 +137,12 @@ of the following optional parameters:
 * `deleted` --- Whether the object has been deleted (i.e. whether a
   tombstone for the object has been found under the specified key)
 
-<div class="note">
-<div class="title">Note on missing keys</div>
-Remember: if a key is not stored in Riak, an <code>RpbGetResp</code>
-response without the <code>content</code> and <code>vclock</code> fields
-will be returned. This should be mapped to whatever convention the
-client language uses to return not found. The Erlang client, for
-example, returns the atom <code>{error, notfound}</code>.
-</div>
+{{% note title="Note on missing keys" %}}
+Remember: if a key is not stored in Riak, an `RpbGetResp` response without the
+`content` and `vclock` fields will be returned. This should be mapped to
+whatever convention the client language uses to return not found. The Erlang
+client, for example, returns the atom `{error, notfound}`.
+{{% /note %}}
 
 ## Example
 

--- a/content/riak/kv/2.0.0/developing/api/protocol-buffers/get-client-id.md
+++ b/content/riak/kv/2.0.0/developing/api/protocol-buffers/get-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.0.0/dev/references/protocol-buffers/get-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Get the client id used for this connection. Client ids are used for
 conflict resolution and each unique actor in the system should be

--- a/content/riak/kv/2.0.0/developing/api/protocol-buffers/list-buckets.md
+++ b/content/riak/kv/2.0.0/developing/api/protocol-buffers/list-buckets.md
@@ -17,12 +17,10 @@ aliases:
 
 List all of the bucket names available.
 
-<div class="note">
-<div class="title">Caution</div>
-
-This call can be expensive for the server. Do not use in
-performance-sensitive code.
-</div>
+{{% note title="Caution" %}}
+This call can be expensive for the server. Do not use in performance-sensitive
+code.
+{{% /note %}}
 
 
 ## Request

--- a/content/riak/kv/2.0.0/developing/api/protocol-buffers/list-keys.md
+++ b/content/riak/kv/2.0.0/developing/api/protocol-buffers/list-keys.md
@@ -18,11 +18,10 @@ aliases:
 List all of the keys in a bucket. This is a streaming call, with
 multiple response messages sent for each request.
 
-<div class="note">
-<div class="title">Not for production use</div>
-This operation requires traversing all keys stored in the cluster and
-should not be used in production.
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.0/developing/api/protocol-buffers/set-client-id.md
+++ b/content/riak/kv/2.0.0/developing/api/protocol-buffers/set-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.0.0/dev/references/protocol-buffers/set-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Set the client ID for this connection. A library may want to set the
 client ID if it has a good way to uniquely identify actors across

--- a/content/riak/kv/2.0.0/developing/app-guide/advanced-mapreduce.md
+++ b/content/riak/kv/2.0.0/developing/app-guide/advanced-mapreduce.md
@@ -253,10 +253,10 @@ curl -XPOST localhost:8098/mapred \
 
 The result should be a JSON map of bucket and key names expressed as key/value pairs.
 
-<div class="info">
-Be sure to install the MapReduce function as described above on all of
-the nodes in your cluster to ensure proper operation.
-</div>
+{{% note %}}
+Be sure to install the MapReduce function as described above on all of the
+nodes in your cluster to ensure proper operation.
+{{% /note %}}
 
 
 ## Phase functions
@@ -481,27 +481,25 @@ takes any of the following forms:
 * `{jsanon, {Bucket, Key}}` where the object at `{Bucket, Key}` contains
   the source for an anonymous Javascript function
 
-<div class="info">
-<div class="title">qfun Note</div>
-Using `qfun` in compiled applications can be a fragile
-operation. Please keep the following points in mind.
+{{% note title="qfun Note" %}}
+Using `qfun` in compiled applications can be a fragile operation. Please keep
+the following points in mind.
 
-1. The module in which the function is defined must be present and
-**exactly the same version** on both the client and Riak nodes.
+1. The module in which the function is defined must be present and **exactly
+   the same version** on both the client and Riak nodes.
 
-2. Any modules and functions used by this function (or any function in
-the resulting call stack) must also be present on the Riak nodes.
+2. Any modules and functions used by this function (or any function in the
+   resulting call stack) must also be present on the Riak nodes.
 
-Errors about failures to ensure both 1 and 2 are often surprising,
-usually seen as opaque **missing-function** or **function-clause**
-errors. Especially in the case of differing module versions, this can be
-difficult to diagnose without expecting the issue and knowing of
-`Module:info/0`.
+Errors about failures to ensure both 1 and 2 are often surprising, usually
+seen as opaque **missing-function** or **function-clause** errors. Especially
+in the case of differing module versions, this can be difficult to diagnose
+without expecting the issue and knowing of `Module:info/0`.
 
-When using the Erlang shell, anonymous MapReduce functions can be
-defined and sent to Riak instead of deploying them to all servers in
-advance, but condition #2 above still holds.
-</div>
+When using the Erlang shell, anonymous MapReduce functions can be defined and
+sent to Riak instead of deploying them to all servers in advance, but
+condition #2 above still holds.
+{{% /note %}}
 
 Link phases are expressed in the following form:
 

--- a/content/riak/kv/2.0.0/developing/app-guide/replication-properties.md
+++ b/content/riak/kv/2.0.0/developing/app-guide/replication-properties.md
@@ -154,15 +154,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -330,15 +328,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -355,14 +352,12 @@ documentation on [Bitcask](/riak/kv/2.0.0/setup/planning/backend/bitcask), [Leve
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.0.0/developing/client-libraries.md
+++ b/content/riak/kv/2.0.0/developing/client-libraries.md
@@ -49,12 +49,11 @@ developing something that you wish to see added to this list, please
 fork the [Riak Docs repo on GitHub](https://github.com/basho/basho_docs)
 and send us a pull request.
 
-<div class="note">
-<div class="title">Note on community-produced libraries</div>
-All of these projects and libraries are at various stages of
-completeness and may not suit your application's needs based on their
-level of maturity and activity.
-</div>
+{{% note title="Note on community-produced libraries" %}}
+All of these projects and libraries are at various stages of completeness and
+may not suit your application's needs based on their level of maturity and
+activity.
+{{% /note %}}
 
 ### Client Libraries and Frameworks
 

--- a/content/riak/kv/2.0.0/developing/getting-started/csharp.md
+++ b/content/riak/kv/2.0.0/developing/getting-started/csharp.md
@@ -25,10 +25,12 @@ To try this flavor of Riak, a working installation of the .NET Framework or Mono
 
 Install [the Riak .NET Client](https://github.com/basho/riak-dotnet-client/wiki/Installation) through [NuGet](http://nuget.org/packages/RiakClient) or the Visual Studio NuGet package manager.
 
-<div class="note">
-<div class="title">Configuring for a remote cluster</div>
-By default, the Riak .NET Client will add a section to your `app.config` file for a four node local cluster. If you are using a remote cluster, open up `app.config` and change the `hostAddress` values to point to nodes in your remote cluster.
-</div>
+{{% note title="Configuring for a remote cluster" %}}
+By default, the Riak .NET Client will add a section to your `app.config` file
+for a four node local cluster. If you are using a remote cluster, open up
+`app.config` and change the `hostAddress` values to point to nodes in your
+remote cluster.
+{{% /note %}}
 
 ### Connecting to Riak
 

--- a/content/riak/kv/2.0.0/developing/getting-started/csharp/object-modeling.md
+++ b/content/riak/kv/2.0.0/developing/getting-started/csharp/object-modeling.md
@@ -64,12 +64,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially when many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially when many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.0/developing/getting-started/erlang/object-modeling.md
+++ b/content/riak/kv/2.0.0/developing/getting-started/erlang/object-modeling.md
@@ -18,14 +18,13 @@ aliases:
 
 To get started, let's create the records that we'll be using.
 
-<div class="note">
-<div class="title">Code Download</div>
+{{% note title="Code Download" %}}
 You can also download the code for this chapter at
 [Github](https://github.com/basho/taste-of-riak/tree/am-dem-erlang-modules/erlang/Ch03-Msgy-Schema).
 
-The Github version includes Erlang type specifications which have been
-omitted here for brevity.
-</div>
+The Github version includes Erlang type specifications which have been omitted
+here for brevity.
+{{% /note %}}
 
 
 ```erlang
@@ -91,13 +90,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.0/developing/getting-started/golang/object-modeling.md
+++ b/content/riak/kv/2.0.0/developing/getting-started/golang/object-modeling.md
@@ -182,13 +182,11 @@ users and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.0/developing/getting-started/java.md
+++ b/content/riak/kv/2.0.0/developing/getting-started/java.md
@@ -40,13 +40,11 @@ Next, download
 [`TasteOfRiak.java`](https://github.com/basho/basho_docs/raw/master/extras/code-examples/TasteOfRiak.java)
 source code for this tutorial, and save it to your working directory.
 
-<div class="note">
-<div class="title">Configuring for a local cluster</div>
-The `TasteOfRiak.java` file that you downloaded is set up to communicate
-with a 1-node Riak cluster listening on `localhost` port 10017. We
-recommend modifying the connection info directly within the
-`setUpCluster()` method.
-</div>
+{{% note title="Configuring for a local cluster" %}}
+The `TasteOfRiak.java` file that you downloaded is set up to communicate with
+a 1-node Riak cluster listening on `localhost` port 10017. We recommend
+modifying the connection info directly within the `setUpCluster()` method.
+{{% /note %}}
 
 If you execute the `TasteOfRiak.java` file within your IDE, you should
 see the following:

--- a/content/riak/kv/2.0.0/developing/getting-started/java/object-modeling.md
+++ b/content/riak/kv/2.0.0/developing/getting-started/java/object-modeling.md
@@ -157,12 +157,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.0/developing/getting-started/nodejs/object-modeling.md
+++ b/content/riak/kv/2.0.0/developing/getting-started/nodejs/object-modeling.md
@@ -73,12 +73,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_SENT_2014-03-06` or `marketing_group_INBOX_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.0/developing/getting-started/python/object-modeling.md
+++ b/content/riak/kv/2.0.0/developing/getting-started/python/object-modeling.md
@@ -83,13 +83,11 @@ users, and `<groupname>_<type>_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-06`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.0/developing/getting-started/ruby/object-modeling.md
+++ b/content/riak/kv/2.0.0/developing/getting-started/ruby/object-modeling.md
@@ -94,13 +94,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.0/developing/usage/conflict-resolution.md
+++ b/content/riak/kv/2.0.0/developing/usage/conflict-resolution.md
@@ -25,16 +25,15 @@ If you are using Riak in an [eventually consistent](/riak/kv/2.0.0/learn/concept
 unavoidable. Often, Riak can resolve these conflicts on its own
 internally if you use causal context, i.e. [vector clocks](/riak/kv/2.0.0/learn/concepts/causal-context#vector-clocks) or [dotted version vectors](/riak/kv/2.0.0/learn/concepts/causal-context#dotted-version-vectors), when updating objects. Instructions on this can be found in the section [below](#siblings).
 
-<div class="note">
-<div class="title">Important note on terminology</div>
-In versions of Riak prior to 2.0, vector clocks were the only causal
-context mechanism available in Riak, which changed with the introduction
-of dotted version vectors in 2.0. Please note that you may frequent find
-terminology in client library APIs, internal Basho documentation, and
-more that uses the term "vector clock" interchangeably with causal
-context in general. Riak's HTTP API still uses a `X-Riak-Vclock` header,
-for example, even if you are using dotted version vectors.
-</div>
+{{% note title="Important note on terminology" %}}
+In versions of Riak prior to 2.0, vector clocks were the only causal context
+mechanism available in Riak, which changed with the introduction of dotted
+version vectors in 2.0. Please note that you may frequent find terminology in
+client library APIs, internal Basho documentation, and more that uses the term
+"vector clock" interchangeably with causal context in general. Riak's HTTP API
+still uses a `X-Riak-Vclock` header, for example, even if you are using dotted
+version vectors.
+{{% /note %}}
 
 But even when you use causal context, Riak cannot always decide which
 value is most causally recent, especially in cases involving concurrent
@@ -118,12 +117,10 @@ will be no concurrent updates. If you are storing immutable data in
 which each object is guaranteed to have its own key or engaging in
 operations related to bulk loading, you should consider LWW.
 
-<div class="note">
-<div class="title">Undefined behavior warning</div>
-Setting both <code>allow_mult</code> and <code>last_write_wins</code> to
-<code>true</code> necessarily leads to unpredictable behavior and should
-always be avoided.
-</div>
+{{% note title="Undefined behavior warning" %}}
+Setting both `allow_mult` and `last_write_wins` to `true` necessarily leads to
+unpredictable behavior and should always be avoided.
+{{% /note %}}
 
 ### Resolve Conflicts on the Application Side
 
@@ -602,13 +599,12 @@ X-Riak-Vclock: a85hYGBgzGDKBVIcR4M2cgczH7HPYEpkzGNlsP/VfYYvCwA=
 # accompany the write for Riak to be able to use the vector clock
 ```
 
-<div class="note">
-<div class="title">Concurrent conflict resolution</div>
+{{% note title="Concurrent conflict resolution" %}}
 It should be noted that it is possible to have two clients that are
 simultaneously engaging in conflict resolution. To avoid a pathological
-divergence, you should be sure to limit the number of reconciliations
-and fail once that limit has been exceeded.
-</div>
+divergence, you should be sure to limit the number of reconciliations and fail
+once that limit has been exceeded.
+{{% /note %}}
 
 ### Sibling Explosion
 
@@ -650,13 +646,10 @@ better performance. Some use cases where you might want to use
 `last_write_wins` include caching, session storage, and insert-only
 (no updates).
 
-<div class="note">
-<div class="title">Note on combining <code>allow_mult</code> and
-<code>last_write_wins</code></div>
-The combination of setting both the <code>allow_mult</code> and
-<code>last_write_wins</code> properties to <code>true</code> leads to
-undefined behavior and should not be used.
-</div>
+{{% note title="Note on combining `allow_mult` and `last_write_wins`" %}}
+The combination of setting both the `allow_mult` and `last_write_wins`
+properties to `true` leads to undefined behavior and should not be used.
+{{% /note %}}
 
 ## Vector Clock Pruning
 

--- a/content/riak/kv/2.0.0/developing/usage/mapreduce.md
+++ b/content/riak/kv/2.0.0/developing/usage/mapreduce.md
@@ -15,16 +15,14 @@ aliases:
   - /riak/kv/2.0.0/dev/using/mapreduce
 ---
 
-<div class="note">
-<div class="title">Use MapReduce sparingly</div>
-In Riak, MapReduce is the primary method for non-primary-key-based
-querying. Although useful for a limited range of purposes, such as batch
-processing jobs, MapReduce operations can be very computationally
-expensive, sometimes to the extent that they can degrade performance in
-production clusters operating under load. Thus, we recommend running
-MapReduce operations in a controlled, rate-limited fashion and never for
-realtime querying purposes.
-</div>
+{{% note title="Use MapReduce sparingly" %}}
+In Riak, MapReduce is the primary method for non-primary-key-based querying.
+Although useful for a limited range of purposes, such as batch processing
+jobs, MapReduce operations can be very computationally expensive, sometimes to
+the extent that they can degrade performance in production clusters operating
+under load. Thus, we recommend running MapReduce operations in a controlled,
+rate-limited fashion and never for realtime querying purposes.
+{{% /note %}}
 
 MapReduce (M/R) is a technique for dividing data processing work across
 a distributed system. It takes advantage of the parallel processing

--- a/content/riak/kv/2.0.0/developing/usage/reading-objects.md
+++ b/content/riak/kv/2.0.0/developing/usage/reading-objects.md
@@ -197,12 +197,10 @@ The most common error code:
 
 * `404 Not Found`
 
-<div class="note">
-<div class="title">Note</div>
-If you're using a Riak client instead of HTTP, these responses will vary
-a great deal, so make sure to check the documentation for your specific
-client.
-</div>
+{{% note title="Note" %}}
+If you're using a Riak client instead of HTTP, these responses will vary a
+great deal, so make sure to check the documentation for your specific client.
+{{% /note %}}
 
 ## No Object Stored
 

--- a/content/riak/kv/2.0.0/developing/usage/replication.md
+++ b/content/riak/kv/2.0.0/developing/usage/replication.md
@@ -45,18 +45,17 @@ is one of the features that differentiates Riak from other databases.
 At the bottom of the page, you'll find a [screencast](/riak/kv/2.0.0/developing/app-guide/replication-properties#screencast) that briefly explains how to adjust your
 replication levels to match your application and business needs.
 
-<div class="note">
-<div class="title">Note on strong consistency</div>
+{{% note title="Note on strong consistency" %}}
 An option introduced in Riak version 2.0 is to use Riak as a
-<a href="/riak/kv/2.0.0/using/reference/strong-consistency/">strongly consistent</a>
-system for data in specified buckets. Using Riak in this way is
-fundamentally different from adjusting replication properties and
-fine-tuning the availability/consistency trade-off, as it sacrifices
-<em>all</em> availability guarantees when necessary. Therefore, you
-should consult the <a href="/riak/kv/2.0.0/developing/app-guide/strong-consistency">Using
-Strong Consistency</a> documentation, as this option will not be covered
-in this tutorial.
-</div>
+<a href="/riak/kv/2.0.0/using/reference/strong-consistency/">strongly
+consistent</a> system for data in specified buckets. Using Riak in this way is
+fundamentally different from adjusting replication properties and fine-tuning
+the availability/consistency trade-off, as it sacrifices _all_ availability
+guarantees when necessary. Therefore, you should consult the
+<a href="/riak/kv/2.0.0/developing/app-guide/strong-consistency">Using Strong
+Consistency</a> documentation, as this option will not be covered in this
+tutorial.
+{{% /note %}}
 
 ## How Replication Properties Work
 
@@ -163,15 +162,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -339,15 +336,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -364,14 +360,12 @@ documentation on [Bitcask][plan backend bitcask], [LevelDB][plan backend leveldb
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.0.0/developing/usage/security/erlang.md
+++ b/content/riak/kv/2.0.0/developing/usage/security/erlang.md
@@ -24,13 +24,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.0.0/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Erlang Client Basics
 

--- a/content/riak/kv/2.0.0/developing/usage/security/java.md
+++ b/content/riak/kv/2.0.0/developing/usage/security/java.md
@@ -23,13 +23,11 @@ If you are using [trust-](/riak/kv/2.0.0/using/security/managing-sources/#trust-
 security setup described [below](#java-client-basics). [Certificate](/riak/kv/2.0.0/using/security/managing-sources/#certificate-based-authentication)-based authentication is not
 yet supported in the Java client.
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Java Client Basics
 

--- a/content/riak/kv/2.0.0/developing/usage/security/python.md
+++ b/content/riak/kv/2.0.0/developing/usage/security/python.md
@@ -25,13 +25,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.0.0/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## OpenSSL Versions
 

--- a/content/riak/kv/2.0.0/developing/usage/security/ruby.md
+++ b/content/riak/kv/2.0.0/developing/usage/security/ruby.md
@@ -25,13 +25,11 @@ can use the security setup described in the [Ruby Client Basics](#ruby-client-ba
 in a [later section](#password-based-authentication), while [certificate](/riak/kv/2.0.0/using/security/managing-sources/#certificate-based-authentication)-based authentication
 is covered [further down](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Ruby Client Basics
 

--- a/content/riak/kv/2.0.0/introduction.md
+++ b/content/riak/kv/2.0.0/introduction.md
@@ -185,14 +185,12 @@ Based on Basho's [Cuttlefish](https://github.com/basho/cuttlefish)
 project, the new system is much simpler, leaving behind the Erlang
 syntax required in `app.config`.
 
-<div class="note">
-<div class="title">Note on upgrading</div>
-Version 2.0 will support both the old and the new configuration system,
-in case you're upgrading. Please note, however, that if you use both
-systems side by side, all settings from the older,
-`app.config`/`vm.args`-based system will override any settings from the
-new system.
-</div>
+{{% note title="Note on upgrading" %}}
+Version 2.0 will support both the old and the new configuration system, in
+case you're upgrading. Please note, however, that if you use both systems side
+by side, all settings from the older, `app.config`/`vm.args`-based system will
+override any settings from the new system.
+{{% /note %}}
 
 #### Relevant Docs
 

--- a/content/riak/kv/2.0.0/learn/concepts/strong-consistency.md
+++ b/content/riak/kv/2.0.0/learn/concepts/strong-consistency.md
@@ -18,10 +18,14 @@ aliases:
 [usage bucket types]: /riak/kv/2.0.0/developing/usage/bucket-types
 [concept eventual consistency]: /riak/kv/2.0.0/learn/concepts/eventual-consistency
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 Riak was originally designed as an [eventually consistent](/riak/kv/2.0.0/learn/concepts/eventual-consistency) system, fundamentally geared toward providing partition
 (i.e. fault) tolerance and high read and write availability.

--- a/content/riak/kv/2.0.0/setup/downgrade.md
+++ b/content/riak/kv/2.0.0/setup/downgrade.md
@@ -37,13 +37,13 @@ additional steps to be performed before, during, and after the upgrade
 on on each node.  These steps are related to changes or new features
 that are not present in the downgraded version.
 
-<div class="note">
-<div class="title">A Note About the Following Instructions</div>
-The below instructions describe the procedures required for a single
-feature release version downgrade. In a downgrade between two feature
-release versions, the steps for the in-between version must also be
-performed. For example, a downgrade from 1.4 to 1.2 requires that the
-downgrade steps for both 1.4 and 1.3 are performed.  </div>
+{{% note title="A Note About the Following Instructions" %}}
+The below instructions describe the procedures required for a single feature
+release version downgrade. In a downgrade between two feature release
+versions, the steps for the in-between version must also be performed. For
+example, a downgrade from 1.4 to 1.2 requires that the downgrade steps for
+both 1.4 and 1.3 are performed.
+{{% /note %}}
 
 ## General Guidelines
 

--- a/content/riak/kv/2.0.0/setup/installing/amazon-web-services.md
+++ b/content/riak/kv/2.0.0/setup/installing/amazon-web-services.md
@@ -62,10 +62,10 @@ You will need need to launch at least 3 instances to form a Riak cluster.  When 
 
 You can find more information on connecting to an instance on the official [Amazon EC2 instance guide](http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/AccessingInstances.html).
 
-<div class="note">
-<div class="title">Note</div>
-The following clustering setup will <em>not</em> be resilient to instance restarts unless deployed in Amazon VPC.
-</div>
+{{% note title="Note" %}}
+The following clustering setup will _not_ be resilient to instance restarts
+unless deployed in Amazon VPC.
+{{% /note %}}
 
 1. On the first node, obtain the internal IP address:
 

--- a/content/riak/kv/2.0.0/setup/installing/mac-osx.md
+++ b/content/riak/kv/2.0.0/setup/installing/mac-osx.md
@@ -52,13 +52,12 @@ directory and execute `bin/riak start` to start the Riak node.
 
 ## Homebrew
 
-<div class="note">
-<div class="title">Warning: Homebrew not always up to date</div>
-Homebrew's Riak recipe is community supported, and thus is not always up
-to date with the latest Riak package. Please ensure that the current
-recipe is using the latest supported code (and don't be afraid to update
-it if it's not).
-</div>
+{{% note title="Warning: Homebrew not always up to date" %}}
+Homebrew's Riak recipe is community supported, and thus is not always up to
+date with the latest Riak package. Please ensure that the current recipe is
+using the latest supported code (and don't be afraid to update it if it's
+not).
+{{% /note %}}
 
 Installing Riak 2.0 with [Homebrew](http://brew.sh/) is easy:
 
@@ -92,11 +91,10 @@ the Riak installation directory via environment variables.
 You must have Xcode tools installed from [Apple's Developer
 website](http://developer.apple.com/).
 
-<div class="note">
-<div class="title">Note on Clang</div>
-Riak will not compile with Clang. Please make sure that your default
-C/C++ compiler is [GCC](https://gcc.gnu.org/).
-</div>
+{{% note title="Note on Clang" %}}
+Riak will not compile with Clang. Please make sure that your default C/C++
+compiler is [GCC](https://gcc.gnu.org/).
+{{% /note %}}
 
 Riak requires [Erlang](http://www.erlang.org/) R16B02+
 

--- a/content/riak/kv/2.0.0/using/admin/riak-admin.md
+++ b/content/riak/kv/2.0.0/using/admin/riak-admin.md
@@ -185,11 +185,10 @@ rename the nodes of a cluster. For more information, visit the
 riak-admin reip <old nodename> <new nodename>
 ```
 
-<div class="note">
-<div class="title">Note about reip prior to Riak 2.0</title></div>
-Several bugs have been fixed related to reip in Riak 2.0. We recommend
-against using reip prior to 2.0, if possible.
-</div>
+{{% note title="Note about reip prior to Riak 2.0" %}}
+Several bugs have been fixed related to reip in Riak 2.0. We recommend against
+using reip prior to 2.0, if possible.
+{{% /note %}}
 
 
 ## js-reload
@@ -389,12 +388,10 @@ entropy tree building, and key repairs which were triggered by AAE.
  * The *Max* column shows the maximum number of keys repaired during all
    key exchanges since the last node restart.
 
-<div class="note">
-<div class="title">Note in AAE status information</div>
-All AAE status information is in-memory and is reset across a node
-restart. Only tree build times are persistent (since trees themselves
-are persistent)
-</div>
+{{% note title="Note in AAE status information" %}}
+All AAE status information is in-memory and is reset across a node restart.
+Only tree build times are persistent (since trees themselves are persistent)
+{{% /note %}}
 
 More details on the `aae-status` command are available in the [Riak
 version 1.3 release notes](https://github.com/basho/riak/blob/1.3/RELEASE-NOTES.md#active-anti-entropy).
@@ -628,11 +625,10 @@ repaired for a given exchange round since the node has started.
 
 ### switch-to-new-search
 
-<div class="info">
-<div class="title">Only For Legacy Migration</div>
-This is only needed when migrating from legacy riak search to the new
-Search (Yokozuna).
-</div>
+{{% note title="Only For Legacy Migration" %}}
+This is only needed when migrating from legacy riak search to the new Search
+(Yokozuna).
+{{% /note %}}
 
 ```bash
 riak-admin search switch-to-new-search

--- a/content/riak/kv/2.0.0/using/admin/riak-control.md
+++ b/content/riak/kv/2.0.0/using/admin/riak-control.md
@@ -57,12 +57,11 @@ listener.https.<name> = 127.0.0.1:8096
 %%     the `riak_api` tuple's value list.
 ```
 
-<div class="note">
-<div class="title">Note on SSL</div>
-We strongly recommend that you enable SSL for Riak Control. It is
-disabled by default, and if you wish to enable it you must do so
-explicitly. More information can be found in the document below.
-</div>
+{{% note title="Note on SSL" %}}
+We strongly recommend that you enable SSL for Riak Control. It is disabled by
+default, and if you wish to enable it you must do so explicitly. More
+information can be found in the document below.
+{{% /note %}}
 
 ## Enabling and Disabling Riak Control
 
@@ -168,16 +167,15 @@ be because you are using self-signed certificates. If you have
 authentication enabled in your configuration, you will next be asked to
 authenticate. Enter an appropriate username and password now.
 
-<div class="note">
-<div class="title">Note on browser TLS</div>
-Your browser needs to be support TLS v1.2 to use Riak Control over
-HTTPS. A list of browsers that support TLS v1.2 can be found
+{{% note title="Note on browser TLS" %}}
+Your browser needs to be support TLS v1.2 to use Riak Control over HTTPS. A
+list of browsers that support TLS v1.2 can be found
 [here](https://en.wikipedia.org/wiki/Transport_Layer_Security#Web_browsers).
-TLS v1.2 may be disabled by default on your browser, for example if you
-are using Firefox versions earlier than 27, Safari versions earlier than
-7, Chrome versions earlier than 30, or Internet Explorer versions
-earlier than 11.  To enable it, follow browser-specific instructions.
-</div>
+TLS v1.2 may be disabled by default on your browser, for example if you are
+using Firefox versions earlier than 27, Safari versions earlier than 7, Chrome
+versions earlier than 30, or Internet Explorer versions earlier than 11.  To
+enable it, follow browser-specific instructions.
+{{% /note %}}
 
 ### Snapshot View
 

--- a/content/riak/kv/2.0.0/using/cluster-operations/adding-removing-nodes.md
+++ b/content/riak/kv/2.0.0/using/cluster-operations/adding-removing-nodes.md
@@ -136,15 +136,14 @@ Transfers resulting from cluster changes: 51
 If the plan is to your liking, submit the changes by running `riak-admin
 cluster commit`.
 
-<div class="note">
-<div class="title">Note on ring changes</div>
-The algorithm that distributes partitions across the cluster
-during membership changes is non-deterministic. As a result, there is no
-optimal ring. In the event that a plan results in a slightly uneven
-distribution of partitions, the plan can be cleared. Clearing a cluster
-plan with `riak-admin cluster clear` and running `riak-admin cluster
-plan` again will produce a slightly different ring.
-</div>
+{{% note title="Note on ring changes" %}}
+The algorithm that distributes partitions across the cluster during membership
+changes is non-deterministic. As a result, there is no optimal ring. In the
+event that a plan results in a slightly uneven distribution of partitions, the
+plan can be cleared. Clearing a cluster plan with `riak-admin cluster clear`
+and running `riak-admin cluster plan` again will produce a slightly different
+ring.
+{{% /note %}}
 
 ## Removing a Node From a Cluster
 

--- a/content/riak/kv/2.0.0/using/cluster-operations/bucket-types.md
+++ b/content/riak/kv/2.0.0/using/cluster-operations/bucket-types.md
@@ -16,14 +16,13 @@ Buckets are essentially a flat namespace in Riak. They allow the same
 key name to exist in multiple buckets and enable you to apply
 configurations across keys.
 
-<div class="info">
-<div class="title">How Many Buckets Can I Have?</div>
-Buckets come with virtually no cost <em>except for when you modify the
-default bucket properties</em>. Modified bucket properties are gossiped
-around the cluster and therefore add to the amount of data sent around
-the network. In other words, buckets using the <tt>default</tt> bucket
-type are free. More on that in the next section.
-</div>
+{{% note title="How Many Buckets Can I Have?" %}}
+Buckets come with virtually no cost _except for when you modify the default
+bucket properties_. Modified bucket properties are gossiped around the cluster
+and therefore add to the amount of data sent around the network. In other
+words, buckets using the `default` bucket type are free. More on that in the
+next section.
+{{% /note %}}
 
 In Riak versions 2.0 and later, Basho suggests that you [use bucket types](/riak/kv/2.0.0/developing/usage/bucket-types) to namespace and configure all buckets you use. Bucket types have a lower overhead within the cluster than the
 default bucket namespace but require an additional setup step on the

--- a/content/riak/kv/2.0.0/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.0.0/using/cluster-operations/changing-cluster-info.md
@@ -302,9 +302,12 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
-<div class="note"><div class="title">Note</div>
-When using the `riak-admin cluster force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
-</div>
+{{% note title="Note" %}}
+When using the `riak-admin cluster force-replace` command, you will always get
+a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be
+lost`. Since we didn't delete any data files and we are replacing the node
+with itself under a new name, we will not lose any replicas.
+{{% /note %}}
 
 <a id="repeat"></a>
 #### Repeat previous steps on each node

--- a/content/riak/kv/2.0.0/using/cluster-operations/replacing-node.md
+++ b/content/riak/kv/2.0.0/using/cluster-operations/replacing-node.md
@@ -86,12 +86,10 @@ with the [`riak-admin ringready`](/riak/kv/2.0.0/using/admin/riak-admin/#ringrea
 and [`riak-admin member-status`](/riak/kv/2.0.0/using/admin/riak-admin/#member-status)
 commands.
 
-<div class="info">
-<div class="title">Ring Settling</div>
-You'll need to make sure that no other ring changes occur between the
-time when you start the new node and the ring settles with the new IP
-info.
+{{% note title="Ring Settling" %}}
+You'll need to make sure that no other ring changes occur between the time
+when you start the new node and the ring settles with the new IP info.
 
-The ring is considered settled when the new node reports `true` when you
-run the `riak-admin ringready` command.
-</div>
+The ring is considered settled when the new node reports `true` when you run
+the `riak-admin ringready` command.
+{{% /note %}}

--- a/content/riak/kv/2.0.0/using/cluster-operations/strong-consistency.md
+++ b/content/riak/kv/2.0.0/using/cluster-operations/strong-consistency.md
@@ -12,10 +12,14 @@ menu:
 toc: true
 ---
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 ## Monitoring Strong Consistency
 

--- a/content/riak/kv/2.0.0/using/performance.md
+++ b/content/riak/kv/2.0.0/using/performance.md
@@ -26,13 +26,12 @@ changes.
 For performance and tuning recommendations specific to running Riak
 clusters on the Amazon Web Services EC2 environment, see [AWS Performance Tuning](/riak/kv/2.0.0/using/performance/amazon-web-services).
 
-<div class="note">
-<div class="title">Note on other operating systems</div>
+{{% note title="Note on other operating systems" %}}
 Unless otherwise specified, the tunings recommended below are for Linux
-distributions. Users implementing Riak on BSD and Solaris distributions
-can use these tuning recommendations to make analogous changes in those
-operating systems.
-</div>
+distributions. Users implementing Riak on BSD and Solaris distributions can
+use these tuning recommendations to make analogous changes in those operating
+systems.
+{{% /note %}}
 
 ## Storage and File System Tuning
 
@@ -171,12 +170,11 @@ net.ipv4.tcp_tw_reuse = 1
 net.ipv4.tcp_moderate_rcvbuf = 1
 ```
 
-<div class="note">
-<div class="title">Note on system default</div>
+{{% note title="Note on system default" %}}
 In general, these recommended values should be compared with the system
-defaults and only changed if benchmarks or other performance metrics
-indicate that networking is the bottleneck.
-</div>
+defaults and only changed if benchmarks or other performance metrics indicate
+that networking is the bottleneck.
+{{% /note %}}
 
 The following settings are optional, but may improve performance on a
 10Gb network:
@@ -211,11 +209,10 @@ ethtool -K eth0 tso off
 `ethtool` settings can be persisted across reboots by adding the above
 command to the `/etc/rc.local` script.
 
-<div class="info">
-<div class="title">Pro tip</div>
-Tuning these values will be required if they are changed, as they affect
-all network operations.
-</div>
+{{% note title="Pro tip" %}}
+Tuning these values will be required if they are changed, as they affect all
+network operations.
+{{% /note %}}
 
 ## Optional I/O Settings
 

--- a/content/riak/kv/2.0.0/using/performance/amazon-web-services.md
+++ b/content/riak/kv/2.0.0/using/performance/amazon-web-services.md
@@ -54,14 +54,13 @@ indexes are not needed for the application.
 In any case, proper benchmarking and tuning are needed to achieve the
 desired performance.
 
-<div class="info">
-<div class="title">Tip</div>
-Most successful AWS cluster deployments use more EC2 instances than they
-would the same number of physical nodes to compensate for the
-performance variability caused by shared, virtualized resources. Plan to
-have more EC2 instance based nodes than physical server nodes when
-estimating cluster size with respect to node count.
-</div>
+{{% note title="Tip" %}}
+Most successful AWS cluster deployments use more EC2 instances than they would
+the same number of physical nodes to compensate for the performance
+variability caused by shared, virtualized resources. Plan to have more EC2
+instance based nodes than physical server nodes when estimating cluster size
+with respect to node count.
+{{% /note %}}
 
 ## Operating System
 

--- a/content/riak/kv/2.0.0/using/performance/erlang.md
+++ b/content/riak/kv/2.0.0/using/performance/erlang.md
@@ -44,16 +44,15 @@ Erlang parameter | Riak parameter
 [`-env ERL_MAX_ETS_TABLES`](http://learnyousomeerlang.com/ets) | `erlang.max_ets_tables`
 `-name` | `nodename`
 
-<div class="note">
-<div class="title">Note on upgrading to 2.0</div>
-In versions of Riak prior to 2.0, Erlang VM-related parameters were
-specified in a `vm.args` configuration file; in versions 2.0 and later,
-all Erlang-VM-specific parameters are set in the `riak.conf` file. If
-you're upgrading to 2.0 from an earlier version, you can still use your
-old `vm.args` if you wish.  Please note, however, that if you set one or
-more parameters in both `vm.args` and in `riak.conf`, the settings in
-`vm.args` will override those in `riak.conf`.
-</div>
+{{% note title="Note on upgrading to 2.0" %}}
+In versions of Riak prior to 2.0, Erlang VM-related parameters were specified
+in a `vm.args` configuration file; in versions 2.0 and later, all
+Erlang-VM-specific parameters are set in the `riak.conf` file. If you're
+upgrading to 2.0 from an earlier version, you can still use your old `vm.args`
+if you wish.  Please note, however, that if you set one or more parameters in
+both `vm.args` and in `riak.conf`, the settings in `vm.args` will override
+those in `riak.conf`.
+{{% /note %}}
 
 ## SMP
 

--- a/content/riak/kv/2.0.0/using/reference/bucket-types.md
+++ b/content/riak/kv/2.0.0/using/reference/bucket-types.md
@@ -16,14 +16,12 @@ Bucket types allow groups of buckets to share configuration details and
 for Riak users to manage bucket properties more efficiently than in the
 older configuration system based on [bucket properties](/riak/kv/2.0.0/developing/usage/bucket-types/#bucket-properties-and-operations).
 
-<div class="note">
-<div class="title">Important note on cluster downgrades</div>
-If you upgrade a Riak to version 2.0 or later, you can still downgrade
-the cluster to a pre-2.0 version <em>as long as you have not created and
-activated a bucket type in the cluster</em>. Once any bucket type has
-been created and activated, you can no longer downgrade the cluster to a
-pre-2.0 version.
-</div>
+{{% note title="Important note on cluster downgrades" %}}
+If you upgrade a Riak to version 2.0 or later, you can still downgrade the
+cluster to a pre-2.0 version _as long as you have not created and activated a
+bucket type in the cluster_. Once any bucket type has been created and
+activated, you can no longer downgrade the cluster to a pre-2.0 version.
+{{% /note %}}
 
 ## How Bucket Types Work
 
@@ -129,11 +127,11 @@ If creation is successful, you should see the following output:
 type_using_defaults created
 ```
 
-<div class="note">
+{{% note %}}
 The `create` command can be run multiple times prior to a bucket type being
 activated. Riak will persist only those properties contained in the final call
 of the command.
-</div>
+{{% /note %}}
 
 Creating bucket types that assign properties _always_ involves passing
 stringified JSON to the `create` command. One way to do that is to pass
@@ -243,11 +241,22 @@ of the type:
 riak-admin bucket-type update type_to_update '{"props":{ ... }}'
 ```
 
-> **Note**
->
-> Any bucket properties associated with a type can be modified after a bucket is created, with two important exceptions: `consistent` and `datatype`. If a bucket type entails strong consistency (requiring that `consistent` be set to `true`) or is set up as a `map`, `set`, or `counter`, then this will be true of the bucket type once and for all.
->
-> If you need to change one of these properties, it is recommended that you simply create and activate a new bucket type.
+{{% note title="Immutable Configurations" %}}
+Any bucket properties associated with a type can be modified after a bucket is
+created, with three important exceptions:
+
+* `consistent`
+* `datatype`
+* `write_once`
+
+If a bucket type entails strong consistency (requiring that `consistent` be
+set to `true`), is set up as a `map`, `set`, or `counter`, or is defined as a
+write-once  bucket (requiring `write_once` be set to `true`), then this will
+be true of the bucket types.
+
+If you need to change one of these properties, we recommend that you simply
+create and activate a new bucket type.
+{{% /note %}}
 
 ## Buckets as Namespaces
 
@@ -375,12 +384,11 @@ curl http://localhost:8098/types/type1/buckets/my_bucket/keys/my_key
 curl http://localhost:8098/types/type2/buckets/my_bucket/keys/my_key
 ```
 
-<div class="note">
-<div class="title">Note on object location</div>
-In Riak 2.x, <em>all requests</em> must be made to a location specified
-by a bucket type, bucket, and key rather than to a bucket/key pair, as
-in previous versions.
-</div>
+{{% note title="Note on object location" %}}
+In Riak 2.x, _all requests_ must be made to a location specified by a bucket
+type, bucket, and key rather than to a bucket/key pair, as in previous
+versions.
+{{% /note %}}
 
 If requests are made to a bucket/key pair without a specified bucket
 type, `default` will be used in place of a bucket type. The following

--- a/content/riak/kv/2.0.0/using/reference/custom-code.md
+++ b/content/riak/kv/2.0.0/using/reference/custom-code.md
@@ -31,13 +31,13 @@ name must have the same name the module. So if you are given a file named
 If you have been given Erlang code and are expected to compile it for
 your developers, keep the following notes in mind.
 
-<div class="info"><div class="title">Note on the Erlang Compiler</div> You
-must use the Erlang compiler (<tt>erlc</tt>) associated with the Riak
+{{% note title="Note on the Erlang Compiler" %}}
+You must use the Erlang compiler (`erlc`) associated with the Riak
 installation or the version of Erlang used when compiling Riak from source.
-For packaged Riak installations, you can consult Table 1 below for the
-default location of Riak's <tt>erlc</tt> for each supported platform.
-If you compiled from source, use the <tt>erlc</tt> from the Erlang version
-you used to compile Riak.</div>
+For packaged Riak installations, you can consult Table 1 below for the default
+location of Riak's `erlc` for each supported platform. If you compiled from
+source, use the `erlc` from the Erlang version you used to compile Riak.
+{{% /note %}}
 
 <table style="width: 100%; border-spacing: 0px;">
 <tbody>
@@ -88,8 +88,9 @@ and loaded. For our example, we'll use a temporary directory `/tmp/beams`,
 but you should choose a directory for production functions based on your
 own requirements such that they will be available where and when needed.
 
-<div class="info">Ensure that the directory chosen above can be read by
-the <tt>riak</tt> user.</div>
+{{% note %}}
+Ensure that the directory chosen above can be read by the `riak` user.
+{{% /note %}}
 
 Successful compilation will result in a new `.beam` file,
 `validate_json.beam`.
@@ -124,5 +125,7 @@ value store has fully initialized and become available for use.
 This is done with the `riak-admin wait-for-service` command as detailed
 in the [Commands documentation](/riak/kv/2.0.0/using/admin/riak-admin/#wait-for-service).
 
-<div class="note">It is important that you ensure riak_kv is
-active before restarting the next node.</div>
+{{% note %}}
+It is important that you ensure riak_kv is active before restarting the next
+node.
+{{% /note %}}

--- a/content/riak/kv/2.0.0/using/reference/multi-datacenter/comparison.md
+++ b/content/riak/kv/2.0.0/using/reference/multi-datacenter/comparison.md
@@ -18,13 +18,12 @@ aliases:
 This document is a systematic comparison of [Version 2](/riak/kv/2.0.0/using/reference/v2-multi-datacenter) and [Version 3](/riak/kv/2.0.0/using/reference/v3-multi-datacenter) of Riak Enterprise's Multi-Datacenter
 Replication capabilities.
 
-<div class="note">
-<div class="title">Important note on mixing versions</div>
+{{% note title="Important note on mixing versions" %}}
 If you are installing Riak Enterprise anew, you should use version 3
-replication. Under no circumstances should you mix version 2 and version
-3 replication. This comparison is meant only to list improvements
-introduced in version 3.
-</div>
+replication. Under no circumstances should you mix version 2 and version 3
+replication. This comparison is meant only to list improvements introduced in
+version 3.
+{{% /note %}}
 
 ## Version 2
 

--- a/content/riak/kv/2.0.0/using/reference/multi-datacenter/monitoring.md
+++ b/content/riak/kv/2.0.0/using/reference/multi-datacenter/monitoring.md
@@ -34,14 +34,12 @@ replication:
 * Use canary (test) objects to test replication and establish trip times
   from source to sink clusters
 
-<div class="note">
-<div class="title">Note on querying and time windows</div>
-Riak's statistics are calculated over a sliding 60-second window. Each
-time you query the stats interface, each sliding statistic shown is a
-sum or histogram value calculated from the previous 60 seconds of data.
-Because of this, the stats interface should not be queried more than
-once per minute.
-</div>
+{{% note title="Note on querying and time windows" %}}
+Riak's statistics are calculated over a sliding 60-second window. Each time
+you query the stats interface, each sliding statistic shown is a sum or
+histogram value calculated from the previous 60 seconds of data. Because of
+this, the stats interface should not be queried more than once per minute.
+{{% /note %}}
 
 ## Statistics
 

--- a/content/riak/kv/2.0.0/using/reference/statistics-monitoring.md
+++ b/content/riak/kv/2.0.0/using/reference/statistics-monitoring.md
@@ -92,15 +92,13 @@ As with the throughput metrics, keeping an eye on average (and max)
 latency times will help detect usage patterns, and provide advanced
 warnings for potential problems.
 
-<div class="note">
-<div class="title">Note on FSM Time Stats</div>
-FSM Time Stats represent the amount of time in microseconds required
-to traverse the GET or PUT Finite State Machine code, offering a
-picture of general node health. From your application's perspective,
-FSM Time effectively represents experienced latency. Mean, Median, and
-95th-, 99th-, and 100th-percentile (Max) counters are displayed. These
-are one-minute stats.
-</div>
+{{% note title="Note on FSM Time Stats" %}}
+FSM Time Stats represent the amount of time in microseconds required to
+traverse the GET or PUT Finite State Machine code, offering a picture of
+general node health. From your application's perspective, FSM Time effectively
+represents experienced latency. Mean, Median, and 95th-, 99th-, and
+100th-percentile (Max) counters are displayed. These are one-minute stats.
+{{% /note %}}
 
 Metric | Also | Relevance | Latency (in microseconds)
 :------|:-----|:----------|:-------------------------
@@ -191,19 +189,21 @@ reported success with when used for monitoring the operational status of
 their Riak clusters. Community and open source projects are presented
 along with commercial and hosted services.
 
-<div class="note">
-<div class="title">Note on Riak 2.x Statistics Support</div>
-Many of the below tools were either created by third-parties or Basho engineers
-for general usage, and have been passed to the community for further updates. As
-such, many of the below only aggregate the statistics and messages that were
-output by Riak 1.4.x.</br>
+{{% note title="Note on Riak 2.x Statistics Support" %}}
+Many of the below tools were either created by third-parties or Basho
+engineers for general usage, and have been passed to the community for further
+updates. As such, many of the below only aggregate the statistics and messages
+that were output by Riak 1.4.x.
+
 Like all code under [Basho Labs](https://github.com/basho-labs/), the below
-tools are "best effort" and have no dedicated Basho support. We both appreciate
-and need your contribution to keep these tools stable and up to date. Please
-open up a GitHub issue on the repository if you'd like to be a maintainer.</br>
-Look for banners calling out the tools we've verified that support the latest Riak 2.x
-statistics!
-</div>
+tools are "best effort" and have no dedicated Basho support. We both
+appreciate and need your contribution to keep these tools stable and up to
+date. Please open up a GitHub issue on the repository if you'd like to be a
+maintainer.
+
+Look for banners calling out the tools we've verified that support the latest
+Riak 2.x statistics!
+{{% /note %}}
 
 ### Self-Hosted Monitoring Tools
 
@@ -250,9 +250,9 @@ the Riak HTTP [`/stats`](/riak/kv/2.0.0/developing/api/http/status) endpoint is 
 
 #### Nagios
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x.**
+{{% /note %}}
 
 [Nagios](http://www.nagios.org) is a monitoring and alerting solution
 that can provide information on the status of Riak cluster nodes, in
@@ -286,9 +286,9 @@ module specifically designed to read Riak statistics.
 
 #### Zabbix
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [Zabbix](http://www.zabbix.com) is an open-source performance monitoring,
 alerting, and graphing solution that can provide information on the state of
@@ -312,9 +312,9 @@ capacity planning in a Riak cluster environment.
 
 #### New Relic
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [New Relic](http://newrelic.com) is a data analytics and visualization platform
 that can provide information on the current and past states of Riak nodes and

--- a/content/riak/kv/2.0.0/using/reference/v3-multi-datacenter/cascading-writes.md
+++ b/content/riak/kv/2.0.0/using/reference/v3-multi-datacenter/cascading-writes.md
@@ -28,13 +28,11 @@ Riak Enterprise. It will need to be manually enabled on new clusters.
 Cascading realtime requires the `{riak_repl, rtq_meta}` capability to
 function.
 
-<div class="note">
-<div class="title">Note on cascading tracking</div>
-Cascading tracking is a simple list of where an object has been written.
-This works well for most common configurations. Larger installations,
-however, may have writes cascade to clusters to which other clusters
-have already written.
-</div>
+{{% note title="Note on cascading tracking" %}}
+Cascading tracking is a simple list of where an object has been written. This
+works well for most common configurations. Larger installations, however, may
+have writes cascade to clusters to which other clusters have already written.
+{{% /note %}}
 
 
 ```

--- a/content/riak/kv/2.0.0/using/repair-recovery/errors.md
+++ b/content/riak/kv/2.0.0/using/repair-recovery/errors.md
@@ -135,11 +135,10 @@ Riak to explain the correct course of action. For example, the
 `map/reduce` `parse_input` phase will respond like this when it
 encounters an invalid input:
 
-<div class="note">
-<div class="title">Note on inputs</div>
-Inputs must be a binary bucket, a tuple of bucket and key-filters, a
-list of target tuples, a search index, or modfun tuple: `INPUT`.
-</div>
+{{% note title="Note on inputs" %}}
+Inputs must be a binary bucket, a tuple of bucket and key-filters, a list of
+target tuples, a search index, or modfun tuple: `INPUT`.
+{{% /note %}}
 
 For the remaining common error codes, they are often marked by Erlang
 atoms (and quite often wrapped within an `{error,{badmatch,{...` tuple,

--- a/content/riak/kv/2.0.0/using/repair-recovery/failure-recovery.md
+++ b/content/riak/kv/2.0.0/using/repair-recovery/failure-recovery.md
@@ -117,6 +117,8 @@ spreading load and increasing available CPU and IOPS.
 
 See [Changing Cluster Information](/riak/kv/2.1.4/using/cluster-operations/changing-cluster-info/#clusters-from-backups) for instructions on cluster recovery.
 
-<div class="info">
-<div class="title">Tip</div> If you are a licensed Riak Enterprise or CS customer and require assistance or further advice with a cluster recovery, please file a ticket with the <a href="https://help.basho.com">Basho Helpdesk</a>.
-</div>
+{{% note title="Tip" %}}
+If you are a licensed Riak Enterprise or CS customer and require assistance or
+further advice with a cluster recovery, please file a ticket with the
+<a href="https://help.basho.com">Basho Helpdesk</a>.
+{{% /note %}}

--- a/content/riak/kv/2.0.0/using/repair-recovery/repairs.md
+++ b/content/riak/kv/2.0.0/using/repair-recovery/repairs.md
@@ -169,10 +169,11 @@ If there are compaction errors in any of your vnodes, those will be listed in th
 ./442446784738847563128068650529343492278651453440/LOG 
 ```
 
-<div class="note">
-<div class="title">Note</div>
-While corruption on one vnode is not uncommon, corruption in several vnodes very likely means that there is a deeper problem that needs to be address, perhaps on the OS or hardware level.
-</div>
+{{% note title="Note" %}}
+While corruption on one vnode is not uncommon, corruption in several vnodes
+very likely means that there is a deeper problem that needs to be address,
+perhaps on the OS or hardware level.
+{{% /note %}}
 
 ## Healing Corrupted LevelDBs
 

--- a/content/riak/kv/2.0.0/using/running-a-cluster.md
+++ b/content/riak/kv/2.0.0/using/running-a-cluster.md
@@ -171,14 +171,13 @@ the node's ring file.
 riak-admin cluster replace riak@127.0.0.1 riak@192.168.1.10
 ```
 
-<div class="note">
-<div class="title">Note on single nodes</div>
-If a node is started singly using default settings, as you might do when
-you are building your first test environment, you will need to remove
-the ring files from the data directory after you edit your configuration
-files. `riak-admin cluster replace` will not work since the node has not
-been joined to a cluster.
-</div>
+{{% note title="Note on single nodes" %}}
+If a node is started singly using default settings, as you might do when you
+are building your first test environment, you will need to remove the ring
+files from the data directory after you edit your configuration files.
+`riak-admin cluster replace` will not work since the node has not been joined
+to a cluster.
+{{% /note %}}
 
 As with all cluster changes, you need to view the planned changes by
 running `riak-admin cluster plan` and then running `riak-admin cluster

--- a/content/riak/kv/2.0.0/using/security/basics.md
+++ b/content/riak/kv/2.0.0/using/security/basics.md
@@ -444,13 +444,11 @@ Permission | Operation |
 `riak_kv.list_keys` | List all of the keys in a bucket
 `riak_kv.list_buckets` | List all buckets
 
-<div class="note">
-<div class="title">Note on Listing Keys and Buckets</div>
-<code>riak_kv.list_keys</code> and <code>riak_kv.list_buckets</code> are
-both very expensive operations that should be performed very rarely and
-never in production. Access to this functionality should be granted very
-carefully.
-</div>
+{{% note title="Note on Listing Keys and Buckets" %}}
+`riak_kv.list_keys` and `riak_kv.list_buckets` are both very expensive
+operations that should be performed very rarely and never in production.
+Access to this functionality should be granted very carefully.
+{{% /note %}}
 
 If you'd like to create, for example, a `client` account that is
 allowed only to run `GET` and `PUT` requests on all buckets:
@@ -631,23 +629,20 @@ The following command would remove the source for `riakuser` on
 riak-admin security del-source riakuser 127.0.0.1/32
 ```
 
-<div class="note">
-<div class="title">Note on Removing Sources</div>
-If you apply a security source both to <code>all</code> and to specific
-users and then wish to remove that source, you will need to do so in
-separate steps. The <code>riak-admin security del-source all ...</code>
-command by itself is not sufficient.
+{{% note title="Note on Removing Sources" %}}
+If you apply a security source both to `all` and to specific users and then
+wish to remove that source, you will need to do so in separate steps. The
+`riak-admin security del-source all ...` command by itself is not sufficient.
 
-For example, if you have assigned the source <code>password</code> to
-both <code>all</code> and to the user <code>riakuser</code> on the
-network <code>127.0.0.1/32</code>, the following two-step process would
-be required to fully remove the source:
+For example, if you have assigned the source `password` to both `all` and to
+the user `riakuser` on the network `127.0.0.1/32`, the following two-step
+process would be required to fully remove the source:
 
 ```bash
 riak-admin security del-source all 127.0.0.1/32 password
 riak-admin security del-source riakuser 127.0.0.1/32 password
 ```
-</div>
+{{% /note %}}
 
 ### More Usage Examples
 

--- a/content/riak/kv/2.0.0/using/security/managing-sources.md
+++ b/content/riak/kv/2.0.0/using/security/managing-sources.md
@@ -29,11 +29,10 @@ The examples below will assume that the network in question is
 [created](/riak/kv/2.0.0/using/security/basics/#user-management) and that
 security has been [enabled](/riak/kv/2.0.0/using/security/basics/#the-basics).
 
-<div class="note">
-<div class="title">Note on SSL connections</div>
-If you use <em>any</em> of the aforementioned security sources, even
-<code>trust</code>, you will need to do so via a secure SSL connection.
-</div>
+{{% note title="Note on SSL connections" %}}
+If you use _any_ of the aforementioned security sources, even `trust`, you
+will need to do so via a secure SSL connection.
+{{% /note %}}
 
 ## Trust-based Authentication
 

--- a/content/riak/kv/2.0.1/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.0.1/configuring/load-balancing-proxy.md
@@ -184,15 +184,13 @@ act as a front-end proxy to a 5-node Riak cluster.
 This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
-<div class="note">
-<div class="title">Nginx version notes</div>
-This example configuration was verified on <strong>Nginx version
-1.2.3</strong>. Please be aware that earlier versions of Nginx did not
-support any HTTP 1.1 semantics for upstream communication to backends.
-You should carefully examine this configuration and make changes
-appropriate to your specific environment before attempting to use
-it
-</div>
+{{% note title="Nginx version notes" %}}
+This example configuration was verified on **Nginx version 1.2.3**. Please be
+aware that earlier versions of Nginx did not support any HTTP 1.1 semantics
+for upstream communication to backends. You should carefully examine this
+configuration and make changes appropriate to your specific environment before
+attempting to use it
+{{% /note %}}
 
 Here is an example `nginx.conf` file:
 
@@ -250,13 +248,12 @@ server {
 }
 ```
 
-<div class="note">
-<div class="title">Note on access controls</div>
-Even when filtering and limiting requests to GETs only as done in the
-example, you should strongly consider additional access controls beyond
-what Nginx can provide directly, such as specific firewall rules to
-limit inbound connections to trusted sources.
-</div>
+{{% note title="Note on access controls" %}}
+Even when filtering and limiting requests to GETs only as done in the example,
+you should strongly consider additional access controls beyond what Nginx can
+provide directly, such as specific firewall rules to limit inbound connections
+to trusted sources.
+{{% /note %}}
 
 ### Querying Secondary Indexes Over HTTP
 

--- a/content/riak/kv/2.0.1/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.0.1/configuring/load-balancing-proxy.md
@@ -185,7 +185,7 @@ This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
 <div class="note">
-<div class="title">Nginx version notes</div
+<div class="title">Nginx version notes</div>
 This example configuration was verified on <strong>Nginx version
 1.2.3</strong>. Please be aware that earlier versions of Nginx did not
 support any HTTP 1.1 semantics for upstream communication to backends.

--- a/content/riak/kv/2.0.1/configuring/v2-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.0.1/configuring/v2-multi-datacenter/ssl.md
@@ -64,8 +64,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -73,7 +72,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.0.1/configuring/v3-multi-datacenter/quick-start.md
+++ b/content/riak/kv/2.0.1/configuring/v3-multi-datacenter/quick-start.md
@@ -137,13 +137,11 @@ Sink             Cluster Name         <Ctrl-Pid>      [Members]
 Cluster1          Cluster1            <0.4456.0>      ["10.60.67.149:9080"] (via 10.60.67.149:9080)
 ```
 
-<div class="note">
-<div class="title">Note on connections</div>
-At this point, if you do not have connections, replication will not
-work. Check your IP bindings by running <code>netstat -a</code> on all
-nodes. You should see <code>*:9080 LISTENING</code>. If not, you have
-configuration problems.
-</div>
+{{% note title="Note on connections" %}}
+At this point, if you do not have connections, replication will not work.
+Check your IP bindings by running `netstat -a` on all nodes. You should see
+`*:9080 LISTENING`. If not, you have configuration problems.
+{{% /note %}}
 
 ### Enable Realtime Replication
 

--- a/content/riak/kv/2.0.1/configuring/v3-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.0.1/configuring/v3-multi-datacenter/ssl.md
@@ -54,12 +54,11 @@ the `riak-core` section of [`advanced.confg`][config reference#advanced.config]:
 The `cacertsdir` is a directory containing all the CA certificates
 needed to verify the CA chain back to the root.
 
-<div class="note">
-<div class="title">Note on configuration</div>
+{{% note title="Note on configuration" %}}
 In Version 3 replication, the SSL settings need to be placed in the
-<code>riak-core</code> section of <code>advanced.config</code> as opposed to
-the <code>riak-repl</code> section used by Version 2 replication.
-</div>
+`riak-core` section of `advanced.config` as opposed to the `riak-repl` section
+used by Version 2 replication.
+{{% /note %}}
 
 ## Verifying Peer Certificates
 
@@ -80,8 +79,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -89,7 +87,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.0.1/developing/api/http/fetch-object.md
+++ b/content/riak/kv/2.0.1/developing/api/http/fetch-object.md
@@ -79,22 +79,23 @@ datetime format
 The body of the response will be the contents of the object except when siblings
 are present.
 
-<div class="note"><div class="title">Siblings</div>
-<p>When `allow_mult` is set to true in the bucket properties, concurrent updates
-are allowed to create "sibling" objects, meaning that the object has any number
-of different values that are related to one another by the vector clock.  This
-allows your application to use its own conflict resolution technique.</p>
+{{% note title="Siblings" %}}
+When `allow_mult` is set to true in the bucket properties, concurrent updates
+are allowed to create "sibling" objects, meaning that the object has any
+number of different values that are related to one another by the vector
+clock.  This allows your application to use its own conflict resolution
+technique.
 
-<p>An object with multiple sibling values will result in a `300 Multiple
-Choices` response.  If the `Accept` header prefers `multipart/mixed`, all
-siblings will be returned in a single request as sections of the
-`multipart/mixed` response body.  Otherwise, a list of "vtags" will be given in
-a simple text format. You can request individual siblings by adding the `vtag`
-query parameter. Scroll down to the 'manually requesting siblings' example below for more information.</p>
+An object with multiple sibling values will result in a `300 Multiple Choices`
+response.  If the `Accept` header prefers `multipart/mixed`, all siblings will
+be returned in a single request as sections of the `multipart/mixed` response
+body.  Otherwise, a list of "vtags" will be given in a simple text format. You
+can request individual siblings by adding the `vtag` query parameter. Scroll
+down to the 'manually requesting siblings' example below for more information.
 
-<p>To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
-given in the response.</p>
-</div>
+To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
+given in the response.
+{{% /note %}}
 
 ## Simple Example
 

--- a/content/riak/kv/2.0.1/developing/api/http/link-walking.md
+++ b/content/riak/kv/2.0.1/developing/api/http/link-walking.md
@@ -26,22 +26,19 @@ is a special case of [MapReduce](/riak/kv/2.0.1/developing/usage/mapreduce), and
 GET /buckets/bucket/keys/key/[bucket],[tag],[keep]
 ```
 
-<div class="info"><div class="title">Link filters</div>
-<p>A link filter within the request URL is made of three parts, separated by
-commas:</p>
+{{% note title="Link filters" %}}
+A link filter within the request URL is made of three parts, separated by
+commas:
 
-<ul>
-<li>Bucket - a bucket name to limit the links to</li>
-<li>Tag - a "riaktag" to limit the links to</li>
-<li>Keep - 0 or 1, whether to return results from this phase</li>
-</ul>
+* Bucket - a bucket name to limit the links to
+* Tag - a "riaktag" to limit the links to
+* Keep - 0 or 1, whether to return results from this phase
 
-<p>Any of the three parts may be replaced with <code>_</code> (underscore),
-signifying that any value is valid. Multiple phases of links can be followed by
-adding additional path segments to the URL, separating the link filters by
-slashes. The final phase in the link-walking query implicitly returns its
-results.</p>
-</div>
+Any of the three parts may be replaced with `_` (underscore), signifying that
+any value is valid. Multiple phases of links can be followed by adding
+additional path segments to the URL, separating the link filters by slashes.
+The final phase in the link-walking query implicitly returns its results.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.0.1/developing/api/http/list-buckets.md
+++ b/content/riak/kv/2.0.1/developing/api/http/list-buckets.md
@@ -17,10 +17,10 @@ aliases:
 
 Lists all known buckets (ones that have keys stored in them).
 
-<div class="note"><div class="title">Not for production use</div>
+{{% note title="Not for production use" %}}
 Similar to the list keys operation, this requires traversing all keys stored
 in the cluster and should not be used in production.
-</div>
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.1/developing/api/http/list-keys.md
+++ b/content/riak/kv/2.0.1/developing/api/http/list-keys.md
@@ -17,12 +17,10 @@ aliases:
 
 Lists keys in a bucket.
 
-<div class="note">
-<div class="title">Not for production use</div>
-
-This operation requires traversing all keys stored in the cluster and should not be used in production.
-
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.1/developing/api/http/set-bucket-props.md
+++ b/content/riak/kv/2.0.1/developing/api/http/set-bucket-props.md
@@ -50,14 +50,12 @@ the bucket
 
 Other properties do exist but are not commonly modified.
 
-<div class="note">
-<div class="title">Property types</div>
-<p>Make sure you use the proper types for attributes like <strong>n_val</strong>
-and <strong>allow_mult</strong>. If you use strings instead of integers and
-booleans respectively, you may see some odd errors in your logs, saying
-something like
-<code>"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"</code>.</p>
-</div>
+{{% note title="Property types" %}}
+Make sure you use the proper types for attributes like **n_val** and
+**allow_mult**. If you use strings instead of integers and booleans
+respectively, you may see some odd errors in your logs, saying something like
+`"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"`.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.0.1/developing/api/protocol-buffers.md
+++ b/content/riak/kv/2.0.1/developing/api/protocol-buffers.md
@@ -106,12 +106,11 @@ Code | Message |
 254 | `RpbAuthResp` |
 255 | `RpbStartTls` |
 
-<div class="info">
-<div class="title">Message Definitions</div>
-All Protocol Buffers messages are defined in the <code>riak.proto</code>
-and other <code>.proto</code> files in the <code>/src</code> directory
-of the <a href="https://github.com/basho/riak_pb">RiakPB</a> project.
-</div>
+{{% note title="Message Definitions" %}}
+All Protocol Buffers messages are defined in the `riak.proto` and other
+`.proto` files in the `/src` directory of the
+<a href="https://github.com/basho/riak_pb">RiakPB</a> project.
+{{% /note %}}
 
 ### Error Response
 

--- a/content/riak/kv/2.0.1/developing/api/protocol-buffers/fetch-object.md
+++ b/content/riak/kv/2.0.1/developing/api/protocol-buffers/fetch-object.md
@@ -137,14 +137,12 @@ of the following optional parameters:
 * `deleted` --- Whether the object has been deleted (i.e. whether a
   tombstone for the object has been found under the specified key)
 
-<div class="note">
-<div class="title">Note on missing keys</div>
-Remember: if a key is not stored in Riak, an <code>RpbGetResp</code>
-response without the <code>content</code> and <code>vclock</code> fields
-will be returned. This should be mapped to whatever convention the
-client language uses to return not found. The Erlang client, for
-example, returns the atom <code>{error, notfound}</code>.
-</div>
+{{% note title="Note on missing keys" %}}
+Remember: if a key is not stored in Riak, an `RpbGetResp` response without the
+`content` and `vclock` fields will be returned. This should be mapped to
+whatever convention the client language uses to return not found. The Erlang
+client, for example, returns the atom `{error, notfound}`.
+{{% /note %}}
 
 ## Example
 

--- a/content/riak/kv/2.0.1/developing/api/protocol-buffers/get-client-id.md
+++ b/content/riak/kv/2.0.1/developing/api/protocol-buffers/get-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.0.1/dev/references/protocol-buffers/get-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Get the client id used for this connection. Client ids are used for
 conflict resolution and each unique actor in the system should be

--- a/content/riak/kv/2.0.1/developing/api/protocol-buffers/list-buckets.md
+++ b/content/riak/kv/2.0.1/developing/api/protocol-buffers/list-buckets.md
@@ -17,12 +17,10 @@ aliases:
 
 List all of the bucket names available.
 
-<div class="note">
-<div class="title">Caution</div>
-
-This call can be expensive for the server. Do not use in
-performance-sensitive code.
-</div>
+{{% note title="Caution" %}}
+This call can be expensive for the server. Do not use in performance-sensitive
+code.
+{{% /note %}}
 
 
 ## Request

--- a/content/riak/kv/2.0.1/developing/api/protocol-buffers/list-keys.md
+++ b/content/riak/kv/2.0.1/developing/api/protocol-buffers/list-keys.md
@@ -18,11 +18,10 @@ aliases:
 List all of the keys in a bucket. This is a streaming call, with
 multiple response messages sent for each request.
 
-<div class="note">
-<div class="title">Not for production use</div>
-This operation requires traversing all keys stored in the cluster and
-should not be used in production.
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.1/developing/api/protocol-buffers/set-client-id.md
+++ b/content/riak/kv/2.0.1/developing/api/protocol-buffers/set-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.0.1/dev/references/protocol-buffers/set-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Set the client ID for this connection. A library may want to set the
 client ID if it has a good way to uniquely identify actors across

--- a/content/riak/kv/2.0.1/developing/app-guide/advanced-mapreduce.md
+++ b/content/riak/kv/2.0.1/developing/app-guide/advanced-mapreduce.md
@@ -253,10 +253,10 @@ curl -XPOST localhost:8098/mapred \
 
 The result should be a JSON map of bucket and key names expressed as key/value pairs.
 
-<div class="info">
-Be sure to install the MapReduce function as described above on all of
-the nodes in your cluster to ensure proper operation.
-</div>
+{{% note %}}
+Be sure to install the MapReduce function as described above on all of the
+nodes in your cluster to ensure proper operation.
+{{% /note %}}
 
 
 ## Phase functions
@@ -481,27 +481,25 @@ takes any of the following forms:
 * `{jsanon, {Bucket, Key}}` where the object at `{Bucket, Key}` contains
   the source for an anonymous Javascript function
 
-<div class="info">
-<div class="title">qfun Note</div>
-Using `qfun` in compiled applications can be a fragile
-operation. Please keep the following points in mind.
+{{% note title="qfun Note" %}}
+Using `qfun` in compiled applications can be a fragile operation. Please keep
+the following points in mind.
 
-1. The module in which the function is defined must be present and
-**exactly the same version** on both the client and Riak nodes.
+1. The module in which the function is defined must be present and **exactly
+   the same version** on both the client and Riak nodes.
 
-2. Any modules and functions used by this function (or any function in
-the resulting call stack) must also be present on the Riak nodes.
+2. Any modules and functions used by this function (or any function in the
+   resulting call stack) must also be present on the Riak nodes.
 
-Errors about failures to ensure both 1 and 2 are often surprising,
-usually seen as opaque **missing-function** or **function-clause**
-errors. Especially in the case of differing module versions, this can be
-difficult to diagnose without expecting the issue and knowing of
-`Module:info/0`.
+Errors about failures to ensure both 1 and 2 are often surprising, usually
+seen as opaque **missing-function** or **function-clause** errors. Especially
+in the case of differing module versions, this can be difficult to diagnose
+without expecting the issue and knowing of `Module:info/0`.
 
-When using the Erlang shell, anonymous MapReduce functions can be
-defined and sent to Riak instead of deploying them to all servers in
-advance, but condition #2 above still holds.
-</div>
+When using the Erlang shell, anonymous MapReduce functions can be defined and
+sent to Riak instead of deploying them to all servers in advance, but
+condition #2 above still holds.
+{{% /note %}}
 
 Link phases are expressed in the following form:
 

--- a/content/riak/kv/2.0.1/developing/app-guide/replication-properties.md
+++ b/content/riak/kv/2.0.1/developing/app-guide/replication-properties.md
@@ -154,15 +154,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -330,15 +328,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -355,14 +352,12 @@ documentation on [Bitcask](/riak/kv/2.0.1/setup/planning/backend/bitcask), [Leve
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.0.1/developing/client-libraries.md
+++ b/content/riak/kv/2.0.1/developing/client-libraries.md
@@ -49,12 +49,11 @@ developing something that you wish to see added to this list, please
 fork the [Riak Docs repo on GitHub](https://github.com/basho/basho_docs)
 and send us a pull request.
 
-<div class="note">
-<div class="title">Note on community-produced libraries</div>
-All of these projects and libraries are at various stages of
-completeness and may not suit your application's needs based on their
-level of maturity and activity.
-</div>
+{{% note title="Note on community-produced libraries" %}}
+All of these projects and libraries are at various stages of completeness and
+may not suit your application's needs based on their level of maturity and
+activity.
+{{% /note %}}
 
 ### Client Libraries and Frameworks
 

--- a/content/riak/kv/2.0.1/developing/getting-started/csharp.md
+++ b/content/riak/kv/2.0.1/developing/getting-started/csharp.md
@@ -25,10 +25,12 @@ To try this flavor of Riak, a working installation of the .NET Framework or Mono
 
 Install [the Riak .NET Client](https://github.com/basho/riak-dotnet-client/wiki/Installation) through [NuGet](http://nuget.org/packages/RiakClient) or the Visual Studio NuGet package manager.
 
-<div class="note">
-<div class="title">Configuring for a remote cluster</div>
-By default, the Riak .NET Client will add a section to your `app.config` file for a four node local cluster. If you are using a remote cluster, open up `app.config` and change the `hostAddress` values to point to nodes in your remote cluster.
-</div>
+{{% note title="Configuring for a remote cluster" %}}
+By default, the Riak .NET Client will add a section to your `app.config` file
+for a four node local cluster. If you are using a remote cluster, open up
+`app.config` and change the `hostAddress` values to point to nodes in your
+remote cluster.
+{{% /note %}}
 
 ### Connecting to Riak
 

--- a/content/riak/kv/2.0.1/developing/getting-started/csharp/object-modeling.md
+++ b/content/riak/kv/2.0.1/developing/getting-started/csharp/object-modeling.md
@@ -64,12 +64,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially when many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially when many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.1/developing/getting-started/erlang/object-modeling.md
+++ b/content/riak/kv/2.0.1/developing/getting-started/erlang/object-modeling.md
@@ -18,14 +18,13 @@ aliases:
 
 To get started, let's create the records that we'll be using.
 
-<div class="note">
-<div class="title">Code Download</div>
+{{% note title="Code Download" %}}
 You can also download the code for this chapter at
 [Github](https://github.com/basho/taste-of-riak/tree/am-dem-erlang-modules/erlang/Ch03-Msgy-Schema).
 
-The Github version includes Erlang type specifications which have been
-omitted here for brevity.
-</div>
+The Github version includes Erlang type specifications which have been omitted
+here for brevity.
+{{% /note %}}
 
 
 ```erlang
@@ -91,13 +90,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.1/developing/getting-started/golang/object-modeling.md
+++ b/content/riak/kv/2.0.1/developing/getting-started/golang/object-modeling.md
@@ -182,13 +182,11 @@ users and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.1/developing/getting-started/java.md
+++ b/content/riak/kv/2.0.1/developing/getting-started/java.md
@@ -40,13 +40,11 @@ Next, download
 [`TasteOfRiak.java`](https://github.com/basho/basho_docs/raw/master/extras/code-examples/TasteOfRiak.java)
 source code for this tutorial, and save it to your working directory.
 
-<div class="note">
-<div class="title">Configuring for a local cluster</div>
-The `TasteOfRiak.java` file that you downloaded is set up to communicate
-with a 1-node Riak cluster listening on `localhost` port 10017. We
-recommend modifying the connection info directly within the
-`setUpCluster()` method.
-</div>
+{{% note title="Configuring for a local cluster" %}}
+The `TasteOfRiak.java` file that you downloaded is set up to communicate with
+a 1-node Riak cluster listening on `localhost` port 10017. We recommend
+modifying the connection info directly within the `setUpCluster()` method.
+{{% /note %}}
 
 If you execute the `TasteOfRiak.java` file within your IDE, you should
 see the following:

--- a/content/riak/kv/2.0.1/developing/getting-started/java/object-modeling.md
+++ b/content/riak/kv/2.0.1/developing/getting-started/java/object-modeling.md
@@ -157,12 +157,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.1/developing/getting-started/nodejs/object-modeling.md
+++ b/content/riak/kv/2.0.1/developing/getting-started/nodejs/object-modeling.md
@@ -73,12 +73,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_SENT_2014-03-06` or `marketing_group_INBOX_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.1/developing/getting-started/python/object-modeling.md
+++ b/content/riak/kv/2.0.1/developing/getting-started/python/object-modeling.md
@@ -83,13 +83,11 @@ users, and `<groupname>_<type>_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-06`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.1/developing/getting-started/ruby/object-modeling.md
+++ b/content/riak/kv/2.0.1/developing/getting-started/ruby/object-modeling.md
@@ -94,13 +94,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.1/developing/usage/conflict-resolution.md
+++ b/content/riak/kv/2.0.1/developing/usage/conflict-resolution.md
@@ -25,16 +25,15 @@ If you are using Riak in an [eventually consistent](/riak/kv/2.0.1/learn/concept
 unavoidable. Often, Riak can resolve these conflicts on its own
 internally if you use causal context, i.e. [vector clocks](/riak/kv/2.0.1/learn/concepts/causal-context#vector-clocks) or [dotted version vectors](/riak/kv/2.0.1/learn/concepts/causal-context#dotted-version-vectors), when updating objects. Instructions on this can be found in the section [below](#siblings).
 
-<div class="note">
-<div class="title">Important note on terminology</div>
-In versions of Riak prior to 2.0, vector clocks were the only causal
-context mechanism available in Riak, which changed with the introduction
-of dotted version vectors in 2.0. Please note that you may frequent find
-terminology in client library APIs, internal Basho documentation, and
-more that uses the term "vector clock" interchangeably with causal
-context in general. Riak's HTTP API still uses a `X-Riak-Vclock` header,
-for example, even if you are using dotted version vectors.
-</div>
+{{% note title="Important note on terminology" %}}
+In versions of Riak prior to 2.0, vector clocks were the only causal context
+mechanism available in Riak, which changed with the introduction of dotted
+version vectors in 2.0. Please note that you may frequent find terminology in
+client library APIs, internal Basho documentation, and more that uses the term
+"vector clock" interchangeably with causal context in general. Riak's HTTP API
+still uses a `X-Riak-Vclock` header, for example, even if you are using dotted
+version vectors.
+{{% /note %}}
 
 But even when you use causal context, Riak cannot always decide which
 value is most causally recent, especially in cases involving concurrent
@@ -118,12 +117,10 @@ will be no concurrent updates. If you are storing immutable data in
 which each object is guaranteed to have its own key or engaging in
 operations related to bulk loading, you should consider LWW.
 
-<div class="note">
-<div class="title">Undefined behavior warning</div>
-Setting both <code>allow_mult</code> and <code>last_write_wins</code> to
-<code>true</code> necessarily leads to unpredictable behavior and should
-always be avoided.
-</div>
+{{% note title="Undefined behavior warning" %}}
+Setting both `allow_mult` and `last_write_wins` to `true` necessarily leads to
+unpredictable behavior and should always be avoided.
+{{% /note %}}
 
 ### Resolve Conflicts on the Application Side
 
@@ -602,13 +599,12 @@ X-Riak-Vclock: a85hYGBgzGDKBVIcR4M2cgczH7HPYEpkzGNlsP/VfYYvCwA=
 # accompany the write for Riak to be able to use the vector clock
 ```
 
-<div class="note">
-<div class="title">Concurrent conflict resolution</div>
+{{% note title="Concurrent conflict resolution" %}}
 It should be noted that it is possible to have two clients that are
 simultaneously engaging in conflict resolution. To avoid a pathological
-divergence, you should be sure to limit the number of reconciliations
-and fail once that limit has been exceeded.
-</div>
+divergence, you should be sure to limit the number of reconciliations and fail
+once that limit has been exceeded.
+{{% /note %}}
 
 ### Sibling Explosion
 
@@ -650,13 +646,10 @@ better performance. Some use cases where you might want to use
 `last_write_wins` include caching, session storage, and insert-only
 (no updates).
 
-<div class="note">
-<div class="title">Note on combining <code>allow_mult</code> and
-<code>last_write_wins</code></div>
-The combination of setting both the <code>allow_mult</code> and
-<code>last_write_wins</code> properties to <code>true</code> leads to
-undefined behavior and should not be used.
-</div>
+{{% note title="Note on combining `allow_mult` and `last_write_wins`" %}}
+The combination of setting both the `allow_mult` and `last_write_wins`
+properties to `true` leads to undefined behavior and should not be used.
+{{% /note %}}
 
 ## Vector Clock Pruning
 

--- a/content/riak/kv/2.0.1/developing/usage/mapreduce.md
+++ b/content/riak/kv/2.0.1/developing/usage/mapreduce.md
@@ -15,16 +15,14 @@ aliases:
   - /riak/kv/2.0.1/dev/using/mapreduce
 ---
 
-<div class="note">
-<div class="title">Use MapReduce sparingly</div>
-In Riak, MapReduce is the primary method for non-primary-key-based
-querying. Although useful for a limited range of purposes, such as batch
-processing jobs, MapReduce operations can be very computationally
-expensive, sometimes to the extent that they can degrade performance in
-production clusters operating under load. Thus, we recommend running
-MapReduce operations in a controlled, rate-limited fashion and never for
-realtime querying purposes.
-</div>
+{{% note title="Use MapReduce sparingly" %}}
+In Riak, MapReduce is the primary method for non-primary-key-based querying.
+Although useful for a limited range of purposes, such as batch processing
+jobs, MapReduce operations can be very computationally expensive, sometimes to
+the extent that they can degrade performance in production clusters operating
+under load. Thus, we recommend running MapReduce operations in a controlled,
+rate-limited fashion and never for realtime querying purposes.
+{{% /note %}}
 
 MapReduce (M/R) is a technique for dividing data processing work across
 a distributed system. It takes advantage of the parallel processing

--- a/content/riak/kv/2.0.1/developing/usage/reading-objects.md
+++ b/content/riak/kv/2.0.1/developing/usage/reading-objects.md
@@ -197,12 +197,10 @@ The most common error code:
 
 * `404 Not Found`
 
-<div class="note">
-<div class="title">Note</div>
-If you're using a Riak client instead of HTTP, these responses will vary
-a great deal, so make sure to check the documentation for your specific
-client.
-</div>
+{{% note title="Note" %}}
+If you're using a Riak client instead of HTTP, these responses will vary a
+great deal, so make sure to check the documentation for your specific client.
+{{% /note %}}
 
 ## No Object Stored
 

--- a/content/riak/kv/2.0.1/developing/usage/replication.md
+++ b/content/riak/kv/2.0.1/developing/usage/replication.md
@@ -45,18 +45,17 @@ is one of the features that differentiates Riak from other databases.
 At the bottom of the page, you'll find a [screencast](/riak/kv/2.0.1/developing/app-guide/replication-properties#screencast) that briefly explains how to adjust your
 replication levels to match your application and business needs.
 
-<div class="note">
-<div class="title">Note on strong consistency</div>
+{{% note title="Note on strong consistency" %}}
 An option introduced in Riak version 2.0 is to use Riak as a
-<a href="/riak/kv/2.0.1/using/reference/strong-consistency/">strongly consistent</a>
-system for data in specified buckets. Using Riak in this way is
-fundamentally different from adjusting replication properties and
-fine-tuning the availability/consistency trade-off, as it sacrifices
-<em>all</em> availability guarantees when necessary. Therefore, you
-should consult the <a href="/riak/kv/2.0.1/developing/app-guide/strong-consistency">Using
-Strong Consistency</a> documentation, as this option will not be covered
-in this tutorial.
-</div>
+<a href="/riak/kv/2.0.1/using/reference/strong-consistency/">strongly
+consistent</a> system for data in specified buckets. Using Riak in this way is
+fundamentally different from adjusting replication properties and fine-tuning
+the availability/consistency trade-off, as it sacrifices _all_ availability
+guarantees when necessary. Therefore, you should consult the
+<a href="/riak/kv/2.0.1/developing/app-guide/strong-consistency">Using Strong
+Consistency</a> documentation, as this option will not be covered in this
+tutorial.
+{{% /note %}}
 
 ## How Replication Properties Work
 
@@ -163,15 +162,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -339,15 +336,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -364,14 +360,12 @@ documentation on [Bitcask][plan backend bitcask], [LevelDB][plan backend leveldb
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.0.1/developing/usage/security/erlang.md
+++ b/content/riak/kv/2.0.1/developing/usage/security/erlang.md
@@ -24,13 +24,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.0.1/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Erlang Client Basics
 

--- a/content/riak/kv/2.0.1/developing/usage/security/java.md
+++ b/content/riak/kv/2.0.1/developing/usage/security/java.md
@@ -23,13 +23,11 @@ If you are using [trust-](/riak/kv/2.0.1/using/security/managing-sources/#trust-
 security setup described [below](#java-client-basics). [Certificate](/riak/kv/2.0.1/using/security/managing-sources/#certificate-based-authentication)-based authentication is not
 yet supported in the Java client.
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Java Client Basics
 

--- a/content/riak/kv/2.0.1/developing/usage/security/python.md
+++ b/content/riak/kv/2.0.1/developing/usage/security/python.md
@@ -25,13 +25,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.0.1/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## OpenSSL Versions
 

--- a/content/riak/kv/2.0.1/developing/usage/security/ruby.md
+++ b/content/riak/kv/2.0.1/developing/usage/security/ruby.md
@@ -25,13 +25,11 @@ can use the security setup described in the [Ruby Client Basics](#ruby-client-ba
 in a [later section](#password-based-authentication), while [certificate](/riak/kv/2.0.1/using/security/managing-sources/#certificate-based-authentication)-based authentication
 is covered [further down](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Ruby Client Basics
 

--- a/content/riak/kv/2.0.1/introduction.md
+++ b/content/riak/kv/2.0.1/introduction.md
@@ -185,14 +185,12 @@ Based on Basho's [Cuttlefish](https://github.com/basho/cuttlefish)
 project, the new system is much simpler, leaving behind the Erlang
 syntax required in `app.config`.
 
-<div class="note">
-<div class="title">Note on upgrading</div>
-Version 2.0 will support both the old and the new configuration system,
-in case you're upgrading. Please note, however, that if you use both
-systems side by side, all settings from the older,
-`app.config`/`vm.args`-based system will override any settings from the
-new system.
-</div>
+{{% note title="Note on upgrading" %}}
+Version 2.0 will support both the old and the new configuration system, in
+case you're upgrading. Please note, however, that if you use both systems side
+by side, all settings from the older, `app.config`/`vm.args`-based system will
+override any settings from the new system.
+{{% /note %}}
 
 #### Relevant Docs
 

--- a/content/riak/kv/2.0.1/learn/concepts/strong-consistency.md
+++ b/content/riak/kv/2.0.1/learn/concepts/strong-consistency.md
@@ -18,10 +18,14 @@ aliases:
 [usage bucket types]: /riak/kv/2.0.1/developing/usage/bucket-types
 [concept eventual consistency]: /riak/kv/2.0.1/learn/concepts/eventual-consistency
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 Riak was originally designed as an [eventually consistent](/riak/kv/2.0.1/learn/concepts/eventual-consistency) system, fundamentally geared toward providing partition
 (i.e. fault) tolerance and high read and write availability.

--- a/content/riak/kv/2.0.1/setup/downgrade.md
+++ b/content/riak/kv/2.0.1/setup/downgrade.md
@@ -37,13 +37,13 @@ additional steps to be performed before, during, and after the upgrade
 on on each node.  These steps are related to changes or new features
 that are not present in the downgraded version.
 
-<div class="note">
-<div class="title">A Note About the Following Instructions</div>
-The below instructions describe the procedures required for a single
-feature release version downgrade. In a downgrade between two feature
-release versions, the steps for the in-between version must also be
-performed. For example, a downgrade from 1.4 to 1.2 requires that the
-downgrade steps for both 1.4 and 1.3 are performed.  </div>
+{{% note title="A Note About the Following Instructions" %}}
+The below instructions describe the procedures required for a single feature
+release version downgrade. In a downgrade between two feature release
+versions, the steps for the in-between version must also be performed. For
+example, a downgrade from 1.4 to 1.2 requires that the downgrade steps for
+both 1.4 and 1.3 are performed.
+{{% /note %}}
 
 ## General Guidelines
 

--- a/content/riak/kv/2.0.1/setup/installing/amazon-web-services.md
+++ b/content/riak/kv/2.0.1/setup/installing/amazon-web-services.md
@@ -62,10 +62,10 @@ You will need need to launch at least 3 instances to form a Riak cluster.  When 
 
 You can find more information on connecting to an instance on the official [Amazon EC2 instance guide](http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/AccessingInstances.html).
 
-<div class="note">
-<div class="title">Note</div>
-The following clustering setup will <em>not</em> be resilient to instance restarts unless deployed in Amazon VPC.
-</div>
+{{% note title="Note" %}}
+The following clustering setup will _not_ be resilient to instance restarts
+unless deployed in Amazon VPC.
+{{% /note %}}
 
 1. On the first node, obtain the internal IP address:
 

--- a/content/riak/kv/2.0.1/setup/installing/mac-osx.md
+++ b/content/riak/kv/2.0.1/setup/installing/mac-osx.md
@@ -52,13 +52,12 @@ directory and execute `bin/riak start` to start the Riak node.
 
 ## Homebrew
 
-<div class="note">
-<div class="title">Warning: Homebrew not always up to date</div>
-Homebrew's Riak recipe is community supported, and thus is not always up
-to date with the latest Riak package. Please ensure that the current
-recipe is using the latest supported code (and don't be afraid to update
-it if it's not).
-</div>
+{{% note title="Warning: Homebrew not always up to date" %}}
+Homebrew's Riak recipe is community supported, and thus is not always up to
+date with the latest Riak package. Please ensure that the current recipe is
+using the latest supported code (and don't be afraid to update it if it's
+not).
+{{% /note %}}
 
 Installing Riak 2.0 with [Homebrew](http://brew.sh/) is easy:
 
@@ -92,11 +91,10 @@ the Riak installation directory via environment variables.
 You must have Xcode tools installed from [Apple's Developer
 website](http://developer.apple.com/).
 
-<div class="note">
-<div class="title">Note on Clang</div>
-Riak will not compile with Clang. Please make sure that your default
-C/C++ compiler is [GCC](https://gcc.gnu.org/).
-</div>
+{{% note title="Note on Clang" %}}
+Riak will not compile with Clang. Please make sure that your default C/C++
+compiler is [GCC](https://gcc.gnu.org/).
+{{% /note %}}
 
 Riak requires [Erlang](http://www.erlang.org/) R16B02+.
 

--- a/content/riak/kv/2.0.1/using/admin/riak-admin.md
+++ b/content/riak/kv/2.0.1/using/admin/riak-admin.md
@@ -185,11 +185,10 @@ rename the nodes of a cluster. For more information, visit the
 riak-admin reip <old nodename> <new nodename>
 ```
 
-<div class="note">
-<div class="title">Note about reip prior to Riak 2.0</title></div>
-Several bugs have been fixed related to reip in Riak 2.0. We recommend
-against using reip prior to 2.0, if possible.
-</div>
+{{% note title="Note about reip prior to Riak 2.0" %}}
+Several bugs have been fixed related to reip in Riak 2.0. We recommend against
+using reip prior to 2.0, if possible.
+{{% /note %}}
 
 
 ## js-reload
@@ -389,12 +388,10 @@ entropy tree building, and key repairs which were triggered by AAE.
  * The *Max* column shows the maximum number of keys repaired during all
    key exchanges since the last node restart.
 
-<div class="note">
-<div class="title">Note in AAE status information</div>
-All AAE status information is in-memory and is reset across a node
-restart. Only tree build times are persistent (since trees themselves
-are persistent)
-</div>
+{{% note title="Note in AAE status information" %}}
+All AAE status information is in-memory and is reset across a node restart.
+Only tree build times are persistent (since trees themselves are persistent)
+{{% /note %}}
 
 More details on the `aae-status` command are available in the [Riak
 version 1.3 release notes](https://github.com/basho/riak/blob/1.3/RELEASE-NOTES.md#active-anti-entropy).
@@ -628,11 +625,10 @@ repaired for a given exchange round since the node has started.
 
 ### switch-to-new-search
 
-<div class="info">
-<div class="title">Only For Legacy Migration</div>
-This is only needed when migrating from legacy riak search to the new
-Search (Yokozuna).
-</div>
+{{% note title="Only For Legacy Migration" %}}
+This is only needed when migrating from legacy riak search to the new Search
+(Yokozuna).
+{{% /note %}}
 
 ```bash
 riak-admin search switch-to-new-search

--- a/content/riak/kv/2.0.1/using/admin/riak-control.md
+++ b/content/riak/kv/2.0.1/using/admin/riak-control.md
@@ -57,12 +57,11 @@ listener.https.<name> = 127.0.0.1:8096
 %%     the `riak_api` tuple's value list.
 ```
 
-<div class="note">
-<div class="title">Note on SSL</div>
-We strongly recommend that you enable SSL for Riak Control. It is
-disabled by default, and if you wish to enable it you must do so
-explicitly. More information can be found in the document below.
-</div>
+{{% note title="Note on SSL" %}}
+We strongly recommend that you enable SSL for Riak Control. It is disabled by
+default, and if you wish to enable it you must do so explicitly. More
+information can be found in the document below.
+{{% /note %}}
 
 ## Enabling and Disabling Riak Control
 
@@ -168,16 +167,15 @@ be because you are using self-signed certificates. If you have
 authentication enabled in your configuration, you will next be asked to
 authenticate. Enter an appropriate username and password now.
 
-<div class="note">
-<div class="title">Note on browser TLS</div>
-Your browser needs to be support TLS v1.2 to use Riak Control over
-HTTPS. A list of browsers that support TLS v1.2 can be found
+{{% note title="Note on browser TLS" %}}
+Your browser needs to be support TLS v1.2 to use Riak Control over HTTPS. A
+list of browsers that support TLS v1.2 can be found
 [here](https://en.wikipedia.org/wiki/Transport_Layer_Security#Web_browsers).
-TLS v1.2 may be disabled by default on your browser, for example if you
-are using Firefox versions earlier than 27, Safari versions earlier than
-7, Chrome versions earlier than 30, or Internet Explorer versions
-earlier than 11.  To enable it, follow browser-specific instructions.
-</div>
+TLS v1.2 may be disabled by default on your browser, for example if you are
+using Firefox versions earlier than 27, Safari versions earlier than 7, Chrome
+versions earlier than 30, or Internet Explorer versions earlier than 11.  To
+enable it, follow browser-specific instructions.
+{{% /note %}}
 
 ### Snapshot View
 

--- a/content/riak/kv/2.0.1/using/cluster-operations/adding-removing-nodes.md
+++ b/content/riak/kv/2.0.1/using/cluster-operations/adding-removing-nodes.md
@@ -136,15 +136,14 @@ Transfers resulting from cluster changes: 51
 If the plan is to your liking, submit the changes by running `riak-admin
 cluster commit`.
 
-<div class="note">
-<div class="title">Note on ring changes</div>
-The algorithm that distributes partitions across the cluster
-during membership changes is non-deterministic. As a result, there is no
-optimal ring. In the event that a plan results in a slightly uneven
-distribution of partitions, the plan can be cleared. Clearing a cluster
-plan with `riak-admin cluster clear` and running `riak-admin cluster
-plan` again will produce a slightly different ring.
-</div>
+{{% note title="Note on ring changes" %}}
+The algorithm that distributes partitions across the cluster during membership
+changes is non-deterministic. As a result, there is no optimal ring. In the
+event that a plan results in a slightly uneven distribution of partitions, the
+plan can be cleared. Clearing a cluster plan with `riak-admin cluster clear`
+and running `riak-admin cluster plan` again will produce a slightly different
+ring.
+{{% /note %}}
 
 ## Removing a Node From a Cluster
 

--- a/content/riak/kv/2.0.1/using/cluster-operations/bucket-types.md
+++ b/content/riak/kv/2.0.1/using/cluster-operations/bucket-types.md
@@ -16,14 +16,13 @@ Buckets are essentially a flat namespace in Riak. They allow the same
 key name to exist in multiple buckets and enable you to apply
 configurations across keys.
 
-<div class="info">
-<div class="title">How Many Buckets Can I Have?</div>
-Buckets come with virtually no cost <em>except for when you modify the
-default bucket properties</em>. Modified bucket properties are gossiped
-around the cluster and therefore add to the amount of data sent around
-the network. In other words, buckets using the <tt>default</tt> bucket
-type are free. More on that in the next section.
-</div>
+{{% note title="How Many Buckets Can I Have?" %}}
+Buckets come with virtually no cost _except for when you modify the default
+bucket properties_. Modified bucket properties are gossiped around the cluster
+and therefore add to the amount of data sent around the network. In other
+words, buckets using the `default` bucket type are free. More on that in the
+next section.
+{{% /note %}}
 
 In Riak versions 2.0 and later, Basho suggests that you [use bucket types](/riak/kv/2.0.1/developing/usage/bucket-types) to namespace and configure all buckets you use. Bucket types have a lower overhead within the cluster than the
 default bucket namespace but require an additional setup step on the

--- a/content/riak/kv/2.0.1/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.0.1/using/cluster-operations/changing-cluster-info.md
@@ -302,9 +302,12 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
-<div class="note"><div class="title">Note</div>
-When using the `riak-admin cluster force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
-</div>
+{{% note title="Note" %}}
+When using the `riak-admin cluster force-replace` command, you will always get
+a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be
+lost`. Since we didn't delete any data files and we are replacing the node
+with itself under a new name, we will not lose any replicas.
+{{% /note %}}
 
 <a id="repeat"></a>
 #### Repeat previous steps on each node

--- a/content/riak/kv/2.0.1/using/cluster-operations/replacing-node.md
+++ b/content/riak/kv/2.0.1/using/cluster-operations/replacing-node.md
@@ -86,12 +86,10 @@ with the [`riak-admin ringready`](/riak/kv/2.0.1/using/admin/riak-admin/#ringrea
 and [`riak-admin member-status`](/riak/kv/2.0.1/using/admin/riak-admin/#member-status)
 commands.
 
-<div class="info">
-<div class="title">Ring Settling</div>
-You'll need to make sure that no other ring changes occur between the
-time when you start the new node and the ring settles with the new IP
-info.
+{{% note title="Ring Settling" %}}
+You'll need to make sure that no other ring changes occur between the time
+when you start the new node and the ring settles with the new IP info.
 
-The ring is considered settled when the new node reports `true` when you
-run the `riak-admin ringready` command.
-</div>
+The ring is considered settled when the new node reports `true` when you run
+the `riak-admin ringready` command.
+{{% /note %}}

--- a/content/riak/kv/2.0.1/using/cluster-operations/strong-consistency.md
+++ b/content/riak/kv/2.0.1/using/cluster-operations/strong-consistency.md
@@ -12,10 +12,14 @@ menu:
 toc: true
 ---
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 ## Monitoring Strong Consistency
 

--- a/content/riak/kv/2.0.1/using/performance.md
+++ b/content/riak/kv/2.0.1/using/performance.md
@@ -26,13 +26,12 @@ changes.
 For performance and tuning recommendations specific to running Riak
 clusters on the Amazon Web Services EC2 environment, see [AWS Performance Tuning](/riak/kv/2.0.1/using/performance/amazon-web-services).
 
-<div class="note">
-<div class="title">Note on other operating systems</div>
+{{% note title="Note on other operating systems" %}}
 Unless otherwise specified, the tunings recommended below are for Linux
-distributions. Users implementing Riak on BSD and Solaris distributions
-can use these tuning recommendations to make analogous changes in those
-operating systems.
-</div>
+distributions. Users implementing Riak on BSD and Solaris distributions can
+use these tuning recommendations to make analogous changes in those operating
+systems.
+{{% /note %}}
 
 ## Storage and File System Tuning
 
@@ -171,12 +170,11 @@ net.ipv4.tcp_tw_reuse = 1
 net.ipv4.tcp_moderate_rcvbuf = 1
 ```
 
-<div class="note">
-<div class="title">Note on system default</div>
+{{% note title="Note on system default" %}}
 In general, these recommended values should be compared with the system
-defaults and only changed if benchmarks or other performance metrics
-indicate that networking is the bottleneck.
-</div>
+defaults and only changed if benchmarks or other performance metrics indicate
+that networking is the bottleneck.
+{{% /note %}}
 
 The following settings are optional, but may improve performance on a
 10Gb network:
@@ -211,11 +209,10 @@ ethtool -K eth0 tso off
 `ethtool` settings can be persisted across reboots by adding the above
 command to the `/etc/rc.local` script.
 
-<div class="info">
-<div class="title">Pro tip</div>
-Tuning these values will be required if they are changed, as they affect
-all network operations.
-</div>
+{{% note title="Pro tip" %}}
+Tuning these values will be required if they are changed, as they affect all
+network operations.
+{{% /note %}}
 
 ## Optional I/O Settings
 

--- a/content/riak/kv/2.0.1/using/performance/amazon-web-services.md
+++ b/content/riak/kv/2.0.1/using/performance/amazon-web-services.md
@@ -54,14 +54,13 @@ indexes are not needed for the application.
 In any case, proper benchmarking and tuning are needed to achieve the
 desired performance.
 
-<div class="info">
-<div class="title">Tip</div>
-Most successful AWS cluster deployments use more EC2 instances than they
-would the same number of physical nodes to compensate for the
-performance variability caused by shared, virtualized resources. Plan to
-have more EC2 instance based nodes than physical server nodes when
-estimating cluster size with respect to node count.
-</div>
+{{% note title="Tip" %}}
+Most successful AWS cluster deployments use more EC2 instances than they would
+the same number of physical nodes to compensate for the performance
+variability caused by shared, virtualized resources. Plan to have more EC2
+instance based nodes than physical server nodes when estimating cluster size
+with respect to node count.
+{{% /note %}}
 
 ## Operating System
 

--- a/content/riak/kv/2.0.1/using/performance/erlang.md
+++ b/content/riak/kv/2.0.1/using/performance/erlang.md
@@ -44,16 +44,15 @@ Erlang parameter | Riak parameter
 [`-env ERL_MAX_ETS_TABLES`](http://learnyousomeerlang.com/ets) | `erlang.max_ets_tables`
 `-name` | `nodename`
 
-<div class="note">
-<div class="title">Note on upgrading to 2.0</div>
-In versions of Riak prior to 2.0, Erlang VM-related parameters were
-specified in a `vm.args` configuration file; in versions 2.0 and later,
-all Erlang-VM-specific parameters are set in the `riak.conf` file. If
-you're upgrading to 2.0 from an earlier version, you can still use your
-old `vm.args` if you wish.  Please note, however, that if you set one or
-more parameters in both `vm.args` and in `riak.conf`, the settings in
-`vm.args` will override those in `riak.conf`.
-</div>
+{{% note title="Note on upgrading to 2.0" %}}
+In versions of Riak prior to 2.0, Erlang VM-related parameters were specified
+in a `vm.args` configuration file; in versions 2.0 and later, all
+Erlang-VM-specific parameters are set in the `riak.conf` file. If you're
+upgrading to 2.0 from an earlier version, you can still use your old `vm.args`
+if you wish.  Please note, however, that if you set one or more parameters in
+both `vm.args` and in `riak.conf`, the settings in `vm.args` will override
+those in `riak.conf`.
+{{% /note %}}
 
 ## SMP
 

--- a/content/riak/kv/2.0.1/using/reference/bucket-types.md
+++ b/content/riak/kv/2.0.1/using/reference/bucket-types.md
@@ -16,14 +16,12 @@ Bucket types allow groups of buckets to share configuration details and
 for Riak users to manage bucket properties more efficiently than in the
 older configuration system based on [bucket properties](/riak/kv/2.0.1/developing/usage/bucket-types/#bucket-properties-and-operations).
 
-<div class="note">
-<div class="title">Important note on cluster downgrades</div>
-If you upgrade a Riak to version 2.0 or later, you can still downgrade
-the cluster to a pre-2.0 version <em>as long as you have not created and
-activated a bucket type in the cluster</em>. Once any bucket type has
-been created and activated, you can no longer downgrade the cluster to a
-pre-2.0 version.
-</div>
+{{% note title="Important note on cluster downgrades" %}}
+If you upgrade a Riak to version 2.0 or later, you can still downgrade the
+cluster to a pre-2.0 version _as long as you have not created and activated a
+bucket type in the cluster_. Once any bucket type has been created and
+activated, you can no longer downgrade the cluster to a pre-2.0 version.
+{{% /note %}}
 
 ## How Bucket Types Work
 
@@ -129,11 +127,11 @@ If creation is successful, you should see the following output:
 type_using_defaults created
 ```
 
-<div class="note">
+{{% note %}}
 The `create` command can be run multiple times prior to a bucket type being
 activated. Riak will persist only those properties contained in the final call
 of the command.
-</div>
+{{% /note %}}
 
 Creating bucket types that assign properties _always_ involves passing
 stringified JSON to the `create` command. One way to do that is to pass
@@ -243,11 +241,22 @@ of the type:
 riak-admin bucket-type update type_to_update '{"props":{ ... }}'
 ```
 
-> **Note**
->
-> Any bucket properties associated with a type can be modified after a bucket is created, with two important exceptions: `consistent` and `datatype`. If a bucket type entails strong consistency (requiring that `consistent` be set to `true`) or is set up as a `map`, `set`, or `counter`, then this will be true of the bucket type once and for all.
->
-> If you need to change one of these properties, it is recommended that you simply create and activate a new bucket type.
+{{% note title="Immutable Configurations" %}}
+Any bucket properties associated with a type can be modified after a bucket is
+created, with three important exceptions:
+
+* `consistent`
+* `datatype`
+* `write_once`
+
+If a bucket type entails strong consistency (requiring that `consistent` be
+set to `true`), is set up as a `map`, `set`, or `counter`, or is defined as a
+write-once  bucket (requiring `write_once` be set to `true`), then this will
+be true of the bucket types.
+
+If you need to change one of these properties, we recommend that you simply
+create and activate a new bucket type.
+{{% /note %}}
 
 ## Buckets as Namespaces
 
@@ -375,12 +384,11 @@ curl http://localhost:8098/types/type1/buckets/my_bucket/keys/my_key
 curl http://localhost:8098/types/type2/buckets/my_bucket/keys/my_key
 ```
 
-<div class="note">
-<div class="title">Note on object location</div>
-In Riak 2.x, <em>all requests</em> must be made to a location specified
-by a bucket type, bucket, and key rather than to a bucket/key pair, as
-in previous versions.
-</div>
+{{% note title="Note on object location" %}}
+In Riak 2.x, _all requests_ must be made to a location specified by a bucket
+type, bucket, and key rather than to a bucket/key pair, as in previous
+versions.
+{{% /note %}}
 
 If requests are made to a bucket/key pair without a specified bucket
 type, `default` will be used in place of a bucket type. The following

--- a/content/riak/kv/2.0.1/using/reference/custom-code.md
+++ b/content/riak/kv/2.0.1/using/reference/custom-code.md
@@ -31,13 +31,13 @@ name must have the same name the module. So if you are given a file named
 If you have been given Erlang code and are expected to compile it for
 your developers, keep the following notes in mind.
 
-<div class="info"><div class="title">Note on the Erlang Compiler</div> You
-must use the Erlang compiler (<tt>erlc</tt>) associated with the Riak
+{{% note title="Note on the Erlang Compiler" %}}
+You must use the Erlang compiler (`erlc`) associated with the Riak
 installation or the version of Erlang used when compiling Riak from source.
-For packaged Riak installations, you can consult Table 1 below for the
-default location of Riak's <tt>erlc</tt> for each supported platform.
-If you compiled from source, use the <tt>erlc</tt> from the Erlang version
-you used to compile Riak.</div>
+For packaged Riak installations, you can consult Table 1 below for the default
+location of Riak's `erlc` for each supported platform. If you compiled from
+source, use the `erlc` from the Erlang version you used to compile Riak.
+{{% /note %}}
 
 <table style="width: 100%; border-spacing: 0px;">
 <tbody>
@@ -88,8 +88,9 @@ and loaded. For our example, we'll use a temporary directory `/tmp/beams`,
 but you should choose a directory for production functions based on your
 own requirements such that they will be available where and when needed.
 
-<div class="info">Ensure that the directory chosen above can be read by
-the <tt>riak</tt> user.</div>
+{{% note %}}
+Ensure that the directory chosen above can be read by the `riak` user.
+{{% /note %}}
 
 Successful compilation will result in a new `.beam` file,
 `validate_json.beam`.
@@ -124,5 +125,7 @@ value store has fully initialized and become available for use.
 This is done with the `riak-admin wait-for-service` command as detailed
 in the [Commands documentation](/riak/kv/2.0.1/using/admin/riak-admin/#wait-for-service).
 
-<div class="note">It is important that you ensure riak_kv is
-active before restarting the next node.</div>
+{{% note %}}
+It is important that you ensure riak_kv is active before restarting the next
+node.
+{{% /note %}}

--- a/content/riak/kv/2.0.1/using/reference/multi-datacenter/comparison.md
+++ b/content/riak/kv/2.0.1/using/reference/multi-datacenter/comparison.md
@@ -18,13 +18,12 @@ aliases:
 This document is a systematic comparison of [Version 2](/riak/kv/2.0.1/using/reference/v2-multi-datacenter) and [Version 3](/riak/kv/2.0.1/using/reference/v3-multi-datacenter) of Riak Enterprise's Multi-Datacenter
 Replication capabilities.
 
-<div class="note">
-<div class="title">Important note on mixing versions</div>
+{{% note title="Important note on mixing versions" %}}
 If you are installing Riak Enterprise anew, you should use version 3
-replication. Under no circumstances should you mix version 2 and version
-3 replication. This comparison is meant only to list improvements
-introduced in version 3.
-</div>
+replication. Under no circumstances should you mix version 2 and version 3
+replication. This comparison is meant only to list improvements introduced in
+version 3.
+{{% /note %}}
 
 ## Version 2
 

--- a/content/riak/kv/2.0.1/using/reference/multi-datacenter/monitoring.md
+++ b/content/riak/kv/2.0.1/using/reference/multi-datacenter/monitoring.md
@@ -34,14 +34,12 @@ replication:
 * Use canary (test) objects to test replication and establish trip times
   from source to sink clusters
 
-<div class="note">
-<div class="title">Note on querying and time windows</div>
-Riak's statistics are calculated over a sliding 60-second window. Each
-time you query the stats interface, each sliding statistic shown is a
-sum or histogram value calculated from the previous 60 seconds of data.
-Because of this, the stats interface should not be queried more than
-once per minute.
-</div>
+{{% note title="Note on querying and time windows" %}}
+Riak's statistics are calculated over a sliding 60-second window. Each time
+you query the stats interface, each sliding statistic shown is a sum or
+histogram value calculated from the previous 60 seconds of data. Because of
+this, the stats interface should not be queried more than once per minute.
+{{% /note %}}
 
 ## Statistics
 

--- a/content/riak/kv/2.0.1/using/reference/statistics-monitoring.md
+++ b/content/riak/kv/2.0.1/using/reference/statistics-monitoring.md
@@ -92,15 +92,13 @@ As with the throughput metrics, keeping an eye on average (and max)
 latency times will help detect usage patterns, and provide advanced
 warnings for potential problems.
 
-<div class="note">
-<div class="title">Note on FSM Time Stats</div>
-FSM Time Stats represent the amount of time in microseconds required
-to traverse the GET or PUT Finite State Machine code, offering a
-picture of general node health. From your application's perspective,
-FSM Time effectively represents experienced latency. Mean, Median, and
-95th-, 99th-, and 100th-percentile (Max) counters are displayed. These
-are one-minute stats.
-</div>
+{{% note title="Note on FSM Time Stats" %}}
+FSM Time Stats represent the amount of time in microseconds required to
+traverse the GET or PUT Finite State Machine code, offering a picture of
+general node health. From your application's perspective, FSM Time effectively
+represents experienced latency. Mean, Median, and 95th-, 99th-, and
+100th-percentile (Max) counters are displayed. These are one-minute stats.
+{{% /note %}}
 
 Metric | Also | Relevance | Latency (in microseconds)
 :------|:-----|:----------|:-------------------------
@@ -191,19 +189,21 @@ reported success with when used for monitoring the operational status of
 their Riak clusters. Community and open source projects are presented
 along with commercial and hosted services.
 
-<div class="note">
-<div class="title">Note on Riak 2.x Statistics Support</div>
-Many of the below tools were either created by third-parties or Basho engineers
-for general usage, and have been passed to the community for further updates. As
-such, many of the below only aggregate the statistics and messages that were
-output by Riak 1.4.x.</br>
+{{% note title="Note on Riak 2.x Statistics Support" %}}
+Many of the below tools were either created by third-parties or Basho
+engineers for general usage, and have been passed to the community for further
+updates. As such, many of the below only aggregate the statistics and messages
+that were output by Riak 1.4.x.
+
 Like all code under [Basho Labs](https://github.com/basho-labs/), the below
-tools are "best effort" and have no dedicated Basho support. We both appreciate
-and need your contribution to keep these tools stable and up to date. Please
-open up a GitHub issue on the repository if you'd like to be a maintainer.</br>
-Look for banners calling out the tools we've verified that support the latest Riak 2.x
-statistics!
-</div>
+tools are "best effort" and have no dedicated Basho support. We both
+appreciate and need your contribution to keep these tools stable and up to
+date. Please open up a GitHub issue on the repository if you'd like to be a
+maintainer.
+
+Look for banners calling out the tools we've verified that support the latest
+Riak 2.x statistics!
+{{% /note %}}
 
 ### Self-Hosted Monitoring Tools
 
@@ -250,9 +250,9 @@ the Riak HTTP [`/stats`](/riak/kv/2.0.1/developing/api/http/status) endpoint is 
 
 #### Nagios
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x.**
+{{% /note %}}
 
 [Nagios](http://www.nagios.org) is a monitoring and alerting solution
 that can provide information on the status of Riak cluster nodes, in
@@ -286,9 +286,9 @@ module specifically designed to read Riak statistics.
 
 #### Zabbix
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [Zabbix](http://www.zabbix.com) is an open-source performance monitoring,
 alerting, and graphing solution that can provide information on the state of
@@ -312,9 +312,9 @@ capacity planning in a Riak cluster environment.
 
 #### New Relic
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [New Relic](http://newrelic.com) is a data analytics and visualization platform
 that can provide information on the current and past states of Riak nodes and

--- a/content/riak/kv/2.0.1/using/reference/v3-multi-datacenter/cascading-writes.md
+++ b/content/riak/kv/2.0.1/using/reference/v3-multi-datacenter/cascading-writes.md
@@ -28,13 +28,11 @@ Riak Enterprise. It will need to be manually enabled on new clusters.
 Cascading realtime requires the `{riak_repl, rtq_meta}` capability to
 function.
 
-<div class="note">
-<div class="title">Note on cascading tracking</div>
-Cascading tracking is a simple list of where an object has been written.
-This works well for most common configurations. Larger installations,
-however, may have writes cascade to clusters to which other clusters
-have already written.
-</div>
+{{% note title="Note on cascading tracking" %}}
+Cascading tracking is a simple list of where an object has been written. This
+works well for most common configurations. Larger installations, however, may
+have writes cascade to clusters to which other clusters have already written.
+{{% /note %}}
 
 
 ```

--- a/content/riak/kv/2.0.1/using/repair-recovery/errors.md
+++ b/content/riak/kv/2.0.1/using/repair-recovery/errors.md
@@ -135,11 +135,10 @@ Riak to explain the correct course of action. For example, the
 `map/reduce` `parse_input` phase will respond like this when it
 encounters an invalid input:
 
-<div class="note">
-<div class="title">Note on inputs</div>
-Inputs must be a binary bucket, a tuple of bucket and key-filters, a
-list of target tuples, a search index, or modfun tuple: `INPUT`.
-</div>
+{{% note title="Note on inputs" %}}
+Inputs must be a binary bucket, a tuple of bucket and key-filters, a list of
+target tuples, a search index, or modfun tuple: `INPUT`.
+{{% /note %}}
 
 For the remaining common error codes, they are often marked by Erlang
 atoms (and quite often wrapped within an `{error,{badmatch,{...` tuple,

--- a/content/riak/kv/2.0.1/using/repair-recovery/failure-recovery.md
+++ b/content/riak/kv/2.0.1/using/repair-recovery/failure-recovery.md
@@ -117,6 +117,8 @@ spreading load and increasing available CPU and IOPS.
 
 See [Changing Cluster Information](/riak/kv/2.1.4/using/cluster-operations/changing-cluster-info/#clusters-from-backups) for instructions on cluster recovery.
 
-<div class="info">
-<div class="title">Tip</div> If you are a licensed Riak Enterprise or CS customer and require assistance or further advice with a cluster recovery, please file a ticket with the <a href="https://help.basho.com">Basho Helpdesk</a>.
-</div>
+{{% note title="Tip" %}}
+If you are a licensed Riak Enterprise or CS customer and require assistance or
+further advice with a cluster recovery, please file a ticket with the
+<a href="https://help.basho.com">Basho Helpdesk</a>.
+{{% /note %}}

--- a/content/riak/kv/2.0.1/using/repair-recovery/repairs.md
+++ b/content/riak/kv/2.0.1/using/repair-recovery/repairs.md
@@ -169,10 +169,11 @@ If there are compaction errors in any of your vnodes, those will be listed in th
 ./442446784738847563128068650529343492278651453440/LOG 
 ```
 
-<div class="note">
-<div class="title">Note</div>
-While corruption on one vnode is not uncommon, corruption in several vnodes very likely means that there is a deeper problem that needs to be address, perhaps on the OS or hardware level.
-</div>
+{{% note title="Note" %}}
+While corruption on one vnode is not uncommon, corruption in several vnodes
+very likely means that there is a deeper problem that needs to be address,
+perhaps on the OS or hardware level.
+{{% /note %}}
 
 ## Healing Corrupted LevelDBs
 

--- a/content/riak/kv/2.0.1/using/running-a-cluster.md
+++ b/content/riak/kv/2.0.1/using/running-a-cluster.md
@@ -171,14 +171,13 @@ the node's ring file.
 riak-admin cluster replace riak@127.0.0.1 riak@192.168.1.10
 ```
 
-<div class="note">
-<div class="title">Note on single nodes</div>
-If a node is started singly using default settings, as you might do when
-you are building your first test environment, you will need to remove
-the ring files from the data directory after you edit your configuration
-files. `riak-admin cluster replace` will not work since the node has not
-been joined to a cluster.
-</div>
+{{% note title="Note on single nodes" %}}
+If a node is started singly using default settings, as you might do when you
+are building your first test environment, you will need to remove the ring
+files from the data directory after you edit your configuration files.
+`riak-admin cluster replace` will not work since the node has not been joined
+to a cluster.
+{{% /note %}}
 
 As with all cluster changes, you need to view the planned changes by
 running `riak-admin cluster plan` and then running `riak-admin cluster

--- a/content/riak/kv/2.0.1/using/security/basics.md
+++ b/content/riak/kv/2.0.1/using/security/basics.md
@@ -444,13 +444,11 @@ Permission | Operation |
 `riak_kv.list_keys` | List all of the keys in a bucket
 `riak_kv.list_buckets` | List all buckets
 
-<div class="note">
-<div class="title">Note on Listing Keys and Buckets</div>
-<code>riak_kv.list_keys</code> and <code>riak_kv.list_buckets</code> are
-both very expensive operations that should be performed very rarely and
-never in production. Access to this functionality should be granted very
-carefully.
-</div>
+{{% note title="Note on Listing Keys and Buckets" %}}
+`riak_kv.list_keys` and `riak_kv.list_buckets` are both very expensive
+operations that should be performed very rarely and never in production.
+Access to this functionality should be granted very carefully.
+{{% /note %}}
 
 If you'd like to create, for example, a `client` account that is
 allowed only to run `GET` and `PUT` requests on all buckets:
@@ -631,23 +629,20 @@ The following command would remove the source for `riakuser` on
 riak-admin security del-source riakuser 127.0.0.1/32
 ```
 
-<div class="note">
-<div class="title">Note on Removing Sources</div>
-If you apply a security source both to <code>all</code> and to specific
-users and then wish to remove that source, you will need to do so in
-separate steps. The <code>riak-admin security del-source all ...</code>
-command by itself is not sufficient.
+{{% note title="Note on Removing Sources" %}}
+If you apply a security source both to `all` and to specific users and then
+wish to remove that source, you will need to do so in separate steps. The
+`riak-admin security del-source all ...` command by itself is not sufficient.
 
-For example, if you have assigned the source <code>password</code> to
-both <code>all</code> and to the user <code>riakuser</code> on the
-network <code>127.0.0.1/32</code>, the following two-step process would
-be required to fully remove the source:
+For example, if you have assigned the source `password` to both `all` and to
+the user `riakuser` on the network `127.0.0.1/32`, the following two-step
+process would be required to fully remove the source:
 
 ```bash
 riak-admin security del-source all 127.0.0.1/32 password
 riak-admin security del-source riakuser 127.0.0.1/32 password
 ```
-</div>
+{{% /note %}}
 
 ### More Usage Examples
 

--- a/content/riak/kv/2.0.1/using/security/managing-sources.md
+++ b/content/riak/kv/2.0.1/using/security/managing-sources.md
@@ -29,11 +29,10 @@ The examples below will assume that the network in question is
 [created](/riak/kv/2.0.1/using/security/basics/#user-management) and that
 security has been [enabled](/riak/kv/2.0.1/using/security/basics/#the-basics).
 
-<div class="note">
-<div class="title">Note on SSL connections</div>
-If you use <em>any</em> of the aforementioned security sources, even
-<code>trust</code>, you will need to do so via a secure SSL connection.
-</div>
+{{% note title="Note on SSL connections" %}}
+If you use _any_ of the aforementioned security sources, even `trust`, you
+will need to do so via a secure SSL connection.
+{{% /note %}}
 
 ## Trust-based Authentication
 

--- a/content/riak/kv/2.0.2/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.0.2/configuring/load-balancing-proxy.md
@@ -184,15 +184,13 @@ act as a front-end proxy to a 5-node Riak cluster.
 This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
-<div class="note">
-<div class="title">Nginx version notes</div>
-This example configuration was verified on <strong>Nginx version
-1.2.3</strong>. Please be aware that earlier versions of Nginx did not
-support any HTTP 1.1 semantics for upstream communication to backends.
-You should carefully examine this configuration and make changes
-appropriate to your specific environment before attempting to use
-it
-</div>
+{{% note title="Nginx version notes" %}}
+This example configuration was verified on **Nginx version 1.2.3**. Please be
+aware that earlier versions of Nginx did not support any HTTP 1.1 semantics
+for upstream communication to backends. You should carefully examine this
+configuration and make changes appropriate to your specific environment before
+attempting to use it
+{{% /note %}}
 
 Here is an example `nginx.conf` file:
 
@@ -250,13 +248,12 @@ server {
 }
 ```
 
-<div class="note">
-<div class="title">Note on access controls</div>
-Even when filtering and limiting requests to GETs only as done in the
-example, you should strongly consider additional access controls beyond
-what Nginx can provide directly, such as specific firewall rules to
-limit inbound connections to trusted sources.
-</div>
+{{% note title="Note on access controls" %}}
+Even when filtering and limiting requests to GETs only as done in the example,
+you should strongly consider additional access controls beyond what Nginx can
+provide directly, such as specific firewall rules to limit inbound connections
+to trusted sources.
+{{% /note %}}
 
 ### Querying Secondary Indexes Over HTTP
 

--- a/content/riak/kv/2.0.2/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.0.2/configuring/load-balancing-proxy.md
@@ -185,7 +185,7 @@ This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
 <div class="note">
-<div class="title">Nginx version notes</div
+<div class="title">Nginx version notes</div>
 This example configuration was verified on <strong>Nginx version
 1.2.3</strong>. Please be aware that earlier versions of Nginx did not
 support any HTTP 1.1 semantics for upstream communication to backends.

--- a/content/riak/kv/2.0.2/configuring/v2-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.0.2/configuring/v2-multi-datacenter/ssl.md
@@ -63,8 +63,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -72,7 +71,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.0.2/configuring/v3-multi-datacenter/quick-start.md
+++ b/content/riak/kv/2.0.2/configuring/v3-multi-datacenter/quick-start.md
@@ -136,13 +136,11 @@ Sink             Cluster Name         <Ctrl-Pid>      [Members]
 Cluster1          Cluster1            <0.4456.0>      ["10.60.67.149:9080"] (via 10.60.67.149:9080)
 ```
 
-<div class="note">
-<div class="title">Note on connections</div>
-At this point, if you do not have connections, replication will not
-work. Check your IP bindings by running <code>netstat -a</code> on all
-nodes. You should see <code>*:9080 LISTENING</code>. If not, you have
-configuration problems.
-</div>
+{{% note title="Note on connections" %}}
+At this point, if you do not have connections, replication will not work.
+Check your IP bindings by running `netstat -a` on all nodes. You should see
+`*:9080 LISTENING`. If not, you have configuration problems.
+{{% /note %}}
 
 ### Enable Realtime Replication
 

--- a/content/riak/kv/2.0.2/configuring/v3-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.0.2/configuring/v3-multi-datacenter/ssl.md
@@ -53,12 +53,11 @@ the `riak-core` section of [`advanced.confg`][config reference#advanced.config]:
 The `cacertsdir` is a directory containing all the CA certificates
 needed to verify the CA chain back to the root.
 
-<div class="note">
-<div class="title">Note on configuration</div>
+{{% note title="Note on configuration" %}}
 In Version 3 replication, the SSL settings need to be placed in the
-<code>riak-core</code> section of <code>advanced.config</code> as opposed to
-the <code>riak-repl</code> section used by Version 2 replication.
-</div>
+`riak-core` section of `advanced.config` as opposed to the `riak-repl` section
+used by Version 2 replication.
+{{% /note %}}
 
 ## Verifying Peer Certificates
 
@@ -79,8 +78,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -88,7 +86,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.0.2/developing/api/http/fetch-object.md
+++ b/content/riak/kv/2.0.2/developing/api/http/fetch-object.md
@@ -78,22 +78,23 @@ datetime format
 The body of the response will be the contents of the object except when siblings
 are present.
 
-<div class="note"><div class="title">Siblings</div>
-<p>When `allow_mult` is set to true in the bucket properties, concurrent updates
-are allowed to create "sibling" objects, meaning that the object has any number
-of different values that are related to one another by the vector clock.  This
-allows your application to use its own conflict resolution technique.</p>
+{{% note title="Siblings" %}}
+When `allow_mult` is set to true in the bucket properties, concurrent updates
+are allowed to create "sibling" objects, meaning that the object has any
+number of different values that are related to one another by the vector
+clock.  This allows your application to use its own conflict resolution
+technique.
 
-<p>An object with multiple sibling values will result in a `300 Multiple
-Choices` response.  If the `Accept` header prefers `multipart/mixed`, all
-siblings will be returned in a single request as sections of the
-`multipart/mixed` response body.  Otherwise, a list of "vtags" will be given in
-a simple text format. You can request individual siblings by adding the `vtag`
-query parameter. Scroll down to the 'manually requesting siblings' example below for more information.</p>
+An object with multiple sibling values will result in a `300 Multiple Choices`
+response.  If the `Accept` header prefers `multipart/mixed`, all siblings will
+be returned in a single request as sections of the `multipart/mixed` response
+body.  Otherwise, a list of "vtags" will be given in a simple text format. You
+can request individual siblings by adding the `vtag` query parameter. Scroll
+down to the 'manually requesting siblings' example below for more information.
 
-<p>To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
-given in the response.</p>
-</div>
+To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
+given in the response.
+{{% /note %}}
 
 ## Simple Example
 

--- a/content/riak/kv/2.0.2/developing/api/http/link-walking.md
+++ b/content/riak/kv/2.0.2/developing/api/http/link-walking.md
@@ -25,22 +25,19 @@ is a special case of [MapReduce](/riak/kv/2.0.2/developing/usage/mapreduce), and
 GET /buckets/bucket/keys/key/[bucket],[tag],[keep]
 ```
 
-<div class="info"><div class="title">Link filters</div>
-<p>A link filter within the request URL is made of three parts, separated by
-commas:</p>
+{{% note title="Link filters" %}}
+A link filter within the request URL is made of three parts, separated by
+commas:
 
-<ul>
-<li>Bucket - a bucket name to limit the links to</li>
-<li>Tag - a "riaktag" to limit the links to</li>
-<li>Keep - 0 or 1, whether to return results from this phase</li>
-</ul>
+* Bucket - a bucket name to limit the links to
+* Tag - a "riaktag" to limit the links to
+* Keep - 0 or 1, whether to return results from this phase
 
-<p>Any of the three parts may be replaced with <code>_</code> (underscore),
-signifying that any value is valid. Multiple phases of links can be followed by
-adding additional path segments to the URL, separating the link filters by
-slashes. The final phase in the link-walking query implicitly returns its
-results.</p>
-</div>
+Any of the three parts may be replaced with `_` (underscore), signifying that
+any value is valid. Multiple phases of links can be followed by adding
+additional path segments to the URL, separating the link filters by slashes.
+The final phase in the link-walking query implicitly returns its results.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.0.2/developing/api/http/list-buckets.md
+++ b/content/riak/kv/2.0.2/developing/api/http/list-buckets.md
@@ -16,10 +16,10 @@ aliases:
 
 Lists all known buckets (ones that have keys stored in them).
 
-<div class="note"><div class="title">Not for production use</div>
+{{% note title="Not for production use" %}}
 Similar to the list keys operation, this requires traversing all keys stored
 in the cluster and should not be used in production.
-</div>
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.2/developing/api/http/list-keys.md
+++ b/content/riak/kv/2.0.2/developing/api/http/list-keys.md
@@ -16,12 +16,10 @@ aliases:
 
 Lists keys in a bucket.
 
-<div class="note">
-<div class="title">Not for production use</div>
-
-This operation requires traversing all keys stored in the cluster and should not be used in production.
-
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.2/developing/api/http/set-bucket-props.md
+++ b/content/riak/kv/2.0.2/developing/api/http/set-bucket-props.md
@@ -49,14 +49,12 @@ the bucket
 
 Other properties do exist but are not commonly modified.
 
-<div class="note">
-<div class="title">Property types</div>
-<p>Make sure you use the proper types for attributes like <strong>n_val</strong>
-and <strong>allow_mult</strong>. If you use strings instead of integers and
-booleans respectively, you may see some odd errors in your logs, saying
-something like
-<code>"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"</code>.</p>
-</div>
+{{% note title="Property types" %}}
+Make sure you use the proper types for attributes like **n_val** and
+**allow_mult**. If you use strings instead of integers and booleans
+respectively, you may see some odd errors in your logs, saying something like
+`"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"`.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.0.2/developing/api/protocol-buffers.md
+++ b/content/riak/kv/2.0.2/developing/api/protocol-buffers.md
@@ -106,12 +106,11 @@ Code | Message |
 254 | `RpbAuthResp` |
 255 | `RpbStartTls` |
 
-<div class="info">
-<div class="title">Message Definitions</div>
-All Protocol Buffers messages are defined in the <code>riak.proto</code>
-and other <code>.proto</code> files in the <code>/src</code> directory
-of the <a href="https://github.com/basho/riak_pb">RiakPB</a> project.
-</div>
+{{% note title="Message Definitions" %}}
+All Protocol Buffers messages are defined in the `riak.proto` and other
+`.proto` files in the `/src` directory of the
+<a href="https://github.com/basho/riak_pb">RiakPB</a> project.
+{{% /note %}}
 
 ### Error Response
 

--- a/content/riak/kv/2.0.2/developing/api/protocol-buffers/fetch-object.md
+++ b/content/riak/kv/2.0.2/developing/api/protocol-buffers/fetch-object.md
@@ -136,14 +136,12 @@ of the following optional parameters:
 * `deleted` --- Whether the object has been deleted (i.e. whether a
   tombstone for the object has been found under the specified key)
 
-<div class="note">
-<div class="title">Note on missing keys</div>
-Remember: if a key is not stored in Riak, an <code>RpbGetResp</code>
-response without the <code>content</code> and <code>vclock</code> fields
-will be returned. This should be mapped to whatever convention the
-client language uses to return not found. The Erlang client, for
-example, returns the atom <code>{error, notfound}</code>.
-</div>
+{{% note title="Note on missing keys" %}}
+Remember: if a key is not stored in Riak, an `RpbGetResp` response without the
+`content` and `vclock` fields will be returned. This should be mapped to
+whatever convention the client language uses to return not found. The Erlang
+client, for example, returns the atom `{error, notfound}`.
+{{% /note %}}
 
 ## Example
 

--- a/content/riak/kv/2.0.2/developing/api/protocol-buffers/get-client-id.md
+++ b/content/riak/kv/2.0.2/developing/api/protocol-buffers/get-client-id.md
@@ -14,12 +14,11 @@ aliases:
   - /riak/2.0.2/dev/references/protocol-buffers/get-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Get the client id used for this connection. Client ids are used for
 conflict resolution and each unique actor in the system should be

--- a/content/riak/kv/2.0.2/developing/api/protocol-buffers/list-buckets.md
+++ b/content/riak/kv/2.0.2/developing/api/protocol-buffers/list-buckets.md
@@ -16,12 +16,10 @@ aliases:
 
 List all of the bucket names available.
 
-<div class="note">
-<div class="title">Caution</div>
-
-This call can be expensive for the server. Do not use in
-performance-sensitive code.
-</div>
+{{% note title="Caution" %}}
+This call can be expensive for the server. Do not use in performance-sensitive
+code.
+{{% /note %}}
 
 
 ## Request

--- a/content/riak/kv/2.0.2/developing/api/protocol-buffers/list-keys.md
+++ b/content/riak/kv/2.0.2/developing/api/protocol-buffers/list-keys.md
@@ -17,11 +17,10 @@ aliases:
 List all of the keys in a bucket. This is a streaming call, with
 multiple response messages sent for each request.
 
-<div class="note">
-<div class="title">Not for production use</div>
-This operation requires traversing all keys stored in the cluster and
-should not be used in production.
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.2/developing/api/protocol-buffers/set-client-id.md
+++ b/content/riak/kv/2.0.2/developing/api/protocol-buffers/set-client-id.md
@@ -14,12 +14,11 @@ aliases:
   - /riak/2.0.2/dev/references/protocol-buffers/set-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Set the client ID for this connection. A library may want to set the
 client ID if it has a good way to uniquely identify actors across

--- a/content/riak/kv/2.0.2/developing/app-guide/advanced-mapreduce.md
+++ b/content/riak/kv/2.0.2/developing/app-guide/advanced-mapreduce.md
@@ -252,10 +252,10 @@ curl -XPOST localhost:8098/mapred \
 
 The result should be a JSON map of bucket and key names expressed as key/value pairs.
 
-<div class="info">
-Be sure to install the MapReduce function as described above on all of
-the nodes in your cluster to ensure proper operation.
-</div>
+{{% note %}}
+Be sure to install the MapReduce function as described above on all of the
+nodes in your cluster to ensure proper operation.
+{{% /note %}}
 
 
 ## Phase functions
@@ -480,27 +480,25 @@ takes any of the following forms:
 * `{jsanon, {Bucket, Key}}` where the object at `{Bucket, Key}` contains
   the source for an anonymous Javascript function
 
-<div class="info">
-<div class="title">qfun Note</div>
-Using `qfun` in compiled applications can be a fragile
-operation. Please keep the following points in mind.
+{{% note title="qfun Note" %}}
+Using `qfun` in compiled applications can be a fragile operation. Please keep
+the following points in mind.
 
-1. The module in which the function is defined must be present and
-**exactly the same version** on both the client and Riak nodes.
+1. The module in which the function is defined must be present and **exactly
+   the same version** on both the client and Riak nodes.
 
-2. Any modules and functions used by this function (or any function in
-the resulting call stack) must also be present on the Riak nodes.
+2. Any modules and functions used by this function (or any function in the
+   resulting call stack) must also be present on the Riak nodes.
 
-Errors about failures to ensure both 1 and 2 are often surprising,
-usually seen as opaque **missing-function** or **function-clause**
-errors. Especially in the case of differing module versions, this can be
-difficult to diagnose without expecting the issue and knowing of
-`Module:info/0`.
+Errors about failures to ensure both 1 and 2 are often surprising, usually
+seen as opaque **missing-function** or **function-clause** errors. Especially
+in the case of differing module versions, this can be difficult to diagnose
+without expecting the issue and knowing of `Module:info/0`.
 
-When using the Erlang shell, anonymous MapReduce functions can be
-defined and sent to Riak instead of deploying them to all servers in
-advance, but condition #2 above still holds.
-</div>
+When using the Erlang shell, anonymous MapReduce functions can be defined and
+sent to Riak instead of deploying them to all servers in advance, but
+condition #2 above still holds.
+{{% /note %}}
 
 Link phases are expressed in the following form:
 

--- a/content/riak/kv/2.0.2/developing/app-guide/replication-properties.md
+++ b/content/riak/kv/2.0.2/developing/app-guide/replication-properties.md
@@ -154,15 +154,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -330,15 +328,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -355,14 +352,12 @@ documentation on [Bitcask](/riak/kv/2.0.2/setup/planning/backend/bitcask), [Leve
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.0.2/developing/client-libraries.md
+++ b/content/riak/kv/2.0.2/developing/client-libraries.md
@@ -48,12 +48,11 @@ developing something that you wish to see added to this list, please
 fork the [Riak Docs repo on GitHub](https://github.com/basho/basho_docs)
 and send us a pull request.
 
-<div class="note">
-<div class="title">Note on community-produced libraries</div>
-All of these projects and libraries are at various stages of
-completeness and may not suit your application's needs based on their
-level of maturity and activity.
-</div>
+{{% note title="Note on community-produced libraries" %}}
+All of these projects and libraries are at various stages of completeness and
+may not suit your application's needs based on their level of maturity and
+activity.
+{{% /note %}}
 
 ### Client Libraries and Frameworks
 

--- a/content/riak/kv/2.0.2/developing/getting-started/csharp.md
+++ b/content/riak/kv/2.0.2/developing/getting-started/csharp.md
@@ -25,10 +25,12 @@ To try this flavor of Riak, a working installation of the .NET Framework or Mono
 
 Install [the Riak .NET Client](https://github.com/basho/riak-dotnet-client/wiki/Installation) through [NuGet](http://nuget.org/packages/RiakClient) or the Visual Studio NuGet package manager.
 
-<div class="note">
-<div class="title">Configuring for a remote cluster</div>
-By default, the Riak .NET Client will add a section to your `app.config` file for a four node local cluster. If you are using a remote cluster, open up `app.config` and change the `hostAddress` values to point to nodes in your remote cluster.
-</div>
+{{% note title="Configuring for a remote cluster" %}}
+By default, the Riak .NET Client will add a section to your `app.config` file
+for a four node local cluster. If you are using a remote cluster, open up
+`app.config` and change the `hostAddress` values to point to nodes in your
+remote cluster.
+{{% /note %}}
 
 ### Connecting to Riak
 

--- a/content/riak/kv/2.0.2/developing/getting-started/csharp/object-modeling.md
+++ b/content/riak/kv/2.0.2/developing/getting-started/csharp/object-modeling.md
@@ -64,12 +64,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially when many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially when many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.2/developing/getting-started/erlang/object-modeling.md
+++ b/content/riak/kv/2.0.2/developing/getting-started/erlang/object-modeling.md
@@ -18,14 +18,13 @@ aliases:
 
 To get started, let's create the records that we'll be using.
 
-<div class="note">
-<div class="title">Code Download</div>
+{{% note title="Code Download" %}}
 You can also download the code for this chapter at
 [Github](https://github.com/basho/taste-of-riak/tree/am-dem-erlang-modules/erlang/Ch03-Msgy-Schema).
 
-The Github version includes Erlang type specifications which have been
-omitted here for brevity.
-</div>
+The Github version includes Erlang type specifications which have been omitted
+here for brevity.
+{{% /note %}}
 
 
 ```erlang
@@ -91,13 +90,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.2/developing/getting-started/golang/object-modeling.md
+++ b/content/riak/kv/2.0.2/developing/getting-started/golang/object-modeling.md
@@ -182,13 +182,11 @@ users and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.2/developing/getting-started/java.md
+++ b/content/riak/kv/2.0.2/developing/getting-started/java.md
@@ -40,13 +40,11 @@ Next, download
 [`TasteOfRiak.java`](https://github.com/basho/basho_docs/raw/master/extras/code-examples/TasteOfRiak.java)
 source code for this tutorial, and save it to your working directory.
 
-<div class="note">
-<div class="title">Configuring for a local cluster</div>
-The `TasteOfRiak.java` file that you downloaded is set up to communicate
-with a 1-node Riak cluster listening on `localhost` port 10017. We
-recommend modifying the connection info directly within the
-`setUpCluster()` method.
-</div>
+{{% note title="Configuring for a local cluster" %}}
+The `TasteOfRiak.java` file that you downloaded is set up to communicate with
+a 1-node Riak cluster listening on `localhost` port 10017. We recommend
+modifying the connection info directly within the `setUpCluster()` method.
+{{% /note %}}
 
 If you execute the `TasteOfRiak.java` file within your IDE, you should
 see the following:

--- a/content/riak/kv/2.0.2/developing/getting-started/java/object-modeling.md
+++ b/content/riak/kv/2.0.2/developing/getting-started/java/object-modeling.md
@@ -157,12 +157,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.2/developing/getting-started/nodejs/object-modeling.md
+++ b/content/riak/kv/2.0.2/developing/getting-started/nodejs/object-modeling.md
@@ -73,12 +73,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_SENT_2014-03-06` or `marketing_group_INBOX_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.2/developing/getting-started/python/object-modeling.md
+++ b/content/riak/kv/2.0.2/developing/getting-started/python/object-modeling.md
@@ -83,13 +83,11 @@ users, and `<groupname>_<type>_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-06`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.2/developing/getting-started/ruby/object-modeling.md
+++ b/content/riak/kv/2.0.2/developing/getting-started/ruby/object-modeling.md
@@ -94,13 +94,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.2/developing/usage/conflict-resolution.md
+++ b/content/riak/kv/2.0.2/developing/usage/conflict-resolution.md
@@ -24,16 +24,15 @@ If you are using Riak in an [eventually consistent](/riak/kv/2.0.2/learn/concept
 unavoidable. Often, Riak can resolve these conflicts on its own
 internally if you use causal context, i.e. [vector clocks](/riak/kv/2.0.2/learn/concepts/causal-context#vector-clocks) or [dotted version vectors](/riak/kv/2.0.2/learn/concepts/causal-context#dotted-version-vectors), when updating objects. Instructions on this can be found in the section [below](#siblings).
 
-<div class="note">
-<div class="title">Important note on terminology</div>
-In versions of Riak prior to 2.0, vector clocks were the only causal
-context mechanism available in Riak, which changed with the introduction
-of dotted version vectors in 2.0. Please note that you may frequent find
-terminology in client library APIs, internal Basho documentation, and
-more that uses the term "vector clock" interchangeably with causal
-context in general. Riak's HTTP API still uses a `X-Riak-Vclock` header,
-for example, even if you are using dotted version vectors.
-</div>
+{{% note title="Important note on terminology" %}}
+In versions of Riak prior to 2.0, vector clocks were the only causal context
+mechanism available in Riak, which changed with the introduction of dotted
+version vectors in 2.0. Please note that you may frequent find terminology in
+client library APIs, internal Basho documentation, and more that uses the term
+"vector clock" interchangeably with causal context in general. Riak's HTTP API
+still uses a `X-Riak-Vclock` header, for example, even if you are using dotted
+version vectors.
+{{% /note %}}
 
 But even when you use causal context, Riak cannot always decide which
 value is most causally recent, especially in cases involving concurrent
@@ -117,12 +116,10 @@ will be no concurrent updates. If you are storing immutable data in
 which each object is guaranteed to have its own key or engaging in
 operations related to bulk loading, you should consider LWW.
 
-<div class="note">
-<div class="title">Undefined behavior warning</div>
-Setting both <code>allow_mult</code> and <code>last_write_wins</code> to
-<code>true</code> necessarily leads to unpredictable behavior and should
-always be avoided.
-</div>
+{{% note title="Undefined behavior warning" %}}
+Setting both `allow_mult` and `last_write_wins` to `true` necessarily leads to
+unpredictable behavior and should always be avoided.
+{{% /note %}}
 
 ### Resolve Conflicts on the Application Side
 
@@ -601,13 +598,12 @@ X-Riak-Vclock: a85hYGBgzGDKBVIcR4M2cgczH7HPYEpkzGNlsP/VfYYvCwA=
 # accompany the write for Riak to be able to use the vector clock
 ```
 
-<div class="note">
-<div class="title">Concurrent conflict resolution</div>
+{{% note title="Concurrent conflict resolution" %}}
 It should be noted that it is possible to have two clients that are
 simultaneously engaging in conflict resolution. To avoid a pathological
-divergence, you should be sure to limit the number of reconciliations
-and fail once that limit has been exceeded.
-</div>
+divergence, you should be sure to limit the number of reconciliations and fail
+once that limit has been exceeded.
+{{% /note %}}
 
 ### Sibling Explosion
 
@@ -649,13 +645,10 @@ better performance. Some use cases where you might want to use
 `last_write_wins` include caching, session storage, and insert-only
 (no updates).
 
-<div class="note">
-<div class="title">Note on combining <code>allow_mult</code> and
-<code>last_write_wins</code></div>
-The combination of setting both the <code>allow_mult</code> and
-<code>last_write_wins</code> properties to <code>true</code> leads to
-undefined behavior and should not be used.
-</div>
+{{% note title="Note on combining `allow_mult` and `last_write_wins`" %}}
+The combination of setting both the `allow_mult` and `last_write_wins`
+properties to `true` leads to undefined behavior and should not be used.
+{{% /note %}}
 
 ## Vector Clock Pruning
 

--- a/content/riak/kv/2.0.2/developing/usage/mapreduce.md
+++ b/content/riak/kv/2.0.2/developing/usage/mapreduce.md
@@ -14,16 +14,14 @@ aliases:
   - /riak/2.0.2/dev/using/mapreduce
 ---
 
-<div class="note">
-<div class="title">Use MapReduce sparingly</div>
-In Riak, MapReduce is the primary method for non-primary-key-based
-querying. Although useful for a limited range of purposes, such as batch
-processing jobs, MapReduce operations can be very computationally
-expensive, sometimes to the extent that they can degrade performance in
-production clusters operating under load. Thus, we recommend running
-MapReduce operations in a controlled, rate-limited fashion and never for
-realtime querying purposes.
-</div>
+{{% note title="Use MapReduce sparingly" %}}
+In Riak, MapReduce is the primary method for non-primary-key-based querying.
+Although useful for a limited range of purposes, such as batch processing
+jobs, MapReduce operations can be very computationally expensive, sometimes to
+the extent that they can degrade performance in production clusters operating
+under load. Thus, we recommend running MapReduce operations in a controlled,
+rate-limited fashion and never for realtime querying purposes.
+{{% /note %}}
 
 MapReduce (M/R) is a technique for dividing data processing work across
 a distributed system. It takes advantage of the parallel processing

--- a/content/riak/kv/2.0.2/developing/usage/reading-objects.md
+++ b/content/riak/kv/2.0.2/developing/usage/reading-objects.md
@@ -197,12 +197,10 @@ The most common error code:
 
 * `404 Not Found`
 
-<div class="note">
-<div class="title">Note</div>
-If you're using a Riak client instead of HTTP, these responses will vary
-a great deal, so make sure to check the documentation for your specific
-client.
-</div>
+{{% note title="Note" %}}
+If you're using a Riak client instead of HTTP, these responses will vary a
+great deal, so make sure to check the documentation for your specific client.
+{{% /note %}}
 
 ## No Object Stored
 

--- a/content/riak/kv/2.0.2/developing/usage/replication.md
+++ b/content/riak/kv/2.0.2/developing/usage/replication.md
@@ -44,18 +44,17 @@ is one of the features that differentiates Riak from other databases.
 At the bottom of the page, you'll find a [screencast](/riak/kv/2.0.2/developing/app-guide/replication-properties#screencast) that briefly explains how to adjust your
 replication levels to match your application and business needs.
 
-<div class="note">
-<div class="title">Note on strong consistency</div>
+{{% note title="Note on strong consistency" %}}
 An option introduced in Riak version 2.0 is to use Riak as a
-<a href="/riak/kv/2.0.2/using/reference/strong-consistency/">strongly consistent</a>
-system for data in specified buckets. Using Riak in this way is
-fundamentally different from adjusting replication properties and
-fine-tuning the availability/consistency trade-off, as it sacrifices
-<em>all</em> availability guarantees when necessary. Therefore, you
-should consult the <a href="/riak/kv/2.0.2/developing/app-guide/strong-consistency">Using
-Strong Consistency</a> documentation, as this option will not be covered
-in this tutorial.
-</div>
+<a href="/riak/kv/2.0.2/using/reference/strong-consistency/">strongly
+consistent</a> system for data in specified buckets. Using Riak in this way is
+fundamentally different from adjusting replication properties and fine-tuning
+the availability/consistency trade-off, as it sacrifices _all_ availability
+guarantees when necessary. Therefore, you should consult the
+<a href="/riak/kv/2.0.2/developing/app-guide/strong-consistency">Using Strong
+Consistency</a> documentation, as this option will not be covered in this
+tutorial.
+{{% /note %}}
 
 ## How Replication Properties Work
 
@@ -162,15 +161,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -338,15 +335,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -363,14 +359,12 @@ documentation on [Bitcask][plan backend bitcask], [LevelDB][plan backend leveldb
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.0.2/developing/usage/security/erlang.md
+++ b/content/riak/kv/2.0.2/developing/usage/security/erlang.md
@@ -23,13 +23,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.0.2/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Erlang Client Basics
 

--- a/content/riak/kv/2.0.2/developing/usage/security/java.md
+++ b/content/riak/kv/2.0.2/developing/usage/security/java.md
@@ -22,13 +22,11 @@ If you are using [trust-](/riak/kv/2.0.2/using/security/managing-sources/#trust-
 security setup described [below](#java-client-basics). [Certificate](/riak/kv/2.0.2/using/security/managing-sources/#certificate-based-authentication)-based authentication is not
 yet supported in the Java client.
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Java Client Basics
 

--- a/content/riak/kv/2.0.2/developing/usage/security/python.md
+++ b/content/riak/kv/2.0.2/developing/usage/security/python.md
@@ -24,13 +24,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.0.2/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## OpenSSL Versions
 

--- a/content/riak/kv/2.0.2/developing/usage/security/ruby.md
+++ b/content/riak/kv/2.0.2/developing/usage/security/ruby.md
@@ -24,13 +24,11 @@ can use the security setup described in the [Ruby Client Basics](#ruby-client-ba
 in a [later section](#password-based-authentication), while [certificate](/riak/kv/2.0.2/using/security/managing-sources/#certificate-based-authentication)-based authentication
 is covered [further down](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Ruby Client Basics
 

--- a/content/riak/kv/2.0.2/introduction.md
+++ b/content/riak/kv/2.0.2/introduction.md
@@ -185,14 +185,12 @@ Based on Basho's [Cuttlefish](https://github.com/basho/cuttlefish)
 project, the new system is much simpler, leaving behind the Erlang
 syntax required in `app.config`.
 
-<div class="note">
-<div class="title">Note on upgrading</div>
-Version 2.0 will support both the old and the new configuration system,
-in case you're upgrading. Please note, however, that if you use both
-systems side by side, all settings from the older,
-`app.config`/`vm.args`-based system will override any settings from the
-new system.
-</div>
+{{% note title="Note on upgrading" %}}
+Version 2.0 will support both the old and the new configuration system, in
+case you're upgrading. Please note, however, that if you use both systems side
+by side, all settings from the older, `app.config`/`vm.args`-based system will
+override any settings from the new system.
+{{% /note %}}
 
 #### Relevant Docs
 

--- a/content/riak/kv/2.0.2/learn/concepts/strong-consistency.md
+++ b/content/riak/kv/2.0.2/learn/concepts/strong-consistency.md
@@ -18,10 +18,14 @@ aliases:
 [usage bucket types]: /riak/kv/2.0.2/developing/usage/bucket-types
 [concept eventual consistency]: /riak/kv/2.0.2/learn/concepts/eventual-consistency
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 Riak was originally designed as an [eventually consistent](/riak/kv/2.0.2/learn/concepts/eventual-consistency) system, fundamentally geared toward providing partition
 (i.e. fault) tolerance and high read and write availability.

--- a/content/riak/kv/2.0.2/setup/downgrade.md
+++ b/content/riak/kv/2.0.2/setup/downgrade.md
@@ -37,13 +37,13 @@ additional steps to be performed before, during, and after the upgrade
 on on each node.  These steps are related to changes or new features
 that are not present in the downgraded version.
 
-<div class="note">
-<div class="title">A Note About the Following Instructions</div>
-The below instructions describe the procedures required for a single
-feature release version downgrade. In a downgrade between two feature
-release versions, the steps for the in-between version must also be
-performed. For example, a downgrade from 1.4 to 1.2 requires that the
-downgrade steps for both 1.4 and 1.3 are performed.  </div>
+{{% note title="A Note About the Following Instructions" %}}
+The below instructions describe the procedures required for a single feature
+release version downgrade. In a downgrade between two feature release
+versions, the steps for the in-between version must also be performed. For
+example, a downgrade from 1.4 to 1.2 requires that the downgrade steps for
+both 1.4 and 1.3 are performed.
+{{% /note %}}
 
 ## General Guidelines
 

--- a/content/riak/kv/2.0.2/setup/installing/amazon-web-services.md
+++ b/content/riak/kv/2.0.2/setup/installing/amazon-web-services.md
@@ -62,10 +62,10 @@ You will need need to launch at least 3 instances to form a Riak cluster.  When 
 
 You can find more information on connecting to an instance on the official [Amazon EC2 instance guide](http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/AccessingInstances.html).
 
-<div class="note">
-<div class="title">Note</div>
-The following clustering setup will <em>not</em> be resilient to instance restarts unless deployed in Amazon VPC.
-</div>
+{{% note title="Note" %}}
+The following clustering setup will _not_ be resilient to instance restarts
+unless deployed in Amazon VPC.
+{{% /note %}}
 
 1. On the first node, obtain the internal IP address:
 

--- a/content/riak/kv/2.0.2/setup/installing/mac-osx.md
+++ b/content/riak/kv/2.0.2/setup/installing/mac-osx.md
@@ -52,13 +52,12 @@ directory and execute `bin/riak start` to start the Riak node.
 
 ## Homebrew
 
-<div class="note">
-<div class="title">Warning: Homebrew not always up to date</div>
-Homebrew's Riak recipe is community supported, and thus is not always up
-to date with the latest Riak package. Please ensure that the current
-recipe is using the latest supported code (and don't be afraid to update
-it if it's not).
-</div>
+{{% note title="Warning: Homebrew not always up to date" %}}
+Homebrew's Riak recipe is community supported, and thus is not always up to
+date with the latest Riak package. Please ensure that the current recipe is
+using the latest supported code (and don't be afraid to update it if it's
+not).
+{{% /note %}}
 
 Installing Riak 2.0 with [Homebrew](http://brew.sh/) is easy:
 
@@ -92,11 +91,10 @@ the Riak installation directory via environment variables.
 You must have Xcode tools installed from [Apple's Developer
 website](http://developer.apple.com/).
 
-<div class="note">
-<div class="title">Note on Clang</div>
-Riak will not compile with Clang. Please make sure that your default
-C/C++ compiler is [GCC](https://gcc.gnu.org/).
-</div>
+{{% note title="Note on Clang" %}}
+Riak will not compile with Clang. Please make sure that your default C/C++
+compiler is [GCC](https://gcc.gnu.org/).
+{{% /note %}}
 
 Riak requires [Erlang](http://www.erlang.org/) R16B02+.
 

--- a/content/riak/kv/2.0.2/using/admin/riak-admin.md
+++ b/content/riak/kv/2.0.2/using/admin/riak-admin.md
@@ -184,11 +184,10 @@ rename the nodes of a cluster. For more information, visit the
 riak-admin reip <old nodename> <new nodename>
 ```
 
-<div class="note">
-<div class="title">Note about reip prior to Riak 2.0</title></div>
-Several bugs have been fixed related to reip in Riak 2.0. We recommend
-against using reip prior to 2.0, if possible.
-</div>
+{{% note title="Note about reip prior to Riak 2.0" %}}
+Several bugs have been fixed related to reip in Riak 2.0. We recommend against
+using reip prior to 2.0, if possible.
+{{% /note %}}
 
 
 ## js-reload
@@ -388,12 +387,10 @@ entropy tree building, and key repairs which were triggered by AAE.
  * The *Max* column shows the maximum number of keys repaired during all
    key exchanges since the last node restart.
 
-<div class="note">
-<div class="title">Note in AAE status information</div>
-All AAE status information is in-memory and is reset across a node
-restart. Only tree build times are persistent (since trees themselves
-are persistent)
-</div>
+{{% note title="Note in AAE status information" %}}
+All AAE status information is in-memory and is reset across a node restart.
+Only tree build times are persistent (since trees themselves are persistent)
+{{% /note %}}
 
 More details on the `aae-status` command are available in the [Riak
 version 1.3 release notes](https://github.com/basho/riak/blob/1.3/RELEASE-NOTES.md#active-anti-entropy).
@@ -627,11 +624,10 @@ repaired for a given exchange round since the node has started.
 
 ### switch-to-new-search
 
-<div class="info">
-<div class="title">Only For Legacy Migration</div>
-This is only needed when migrating from legacy riak search to the new
-Search (Yokozuna).
-</div>
+{{% note title="Only For Legacy Migration" %}}
+This is only needed when migrating from legacy riak search to the new Search
+(Yokozuna).
+{{% /note %}}
 
 ```bash
 riak-admin search switch-to-new-search

--- a/content/riak/kv/2.0.2/using/admin/riak-control.md
+++ b/content/riak/kv/2.0.2/using/admin/riak-control.md
@@ -56,12 +56,11 @@ listener.https.<name> = 127.0.0.1:8096
 %%     the `riak_api` tuple's value list.
 ```
 
-<div class="note">
-<div class="title">Note on SSL</div>
-We strongly recommend that you enable SSL for Riak Control. It is
-disabled by default, and if you wish to enable it you must do so
-explicitly. More information can be found in the document below.
-</div>
+{{% note title="Note on SSL" %}}
+We strongly recommend that you enable SSL for Riak Control. It is disabled by
+default, and if you wish to enable it you must do so explicitly. More
+information can be found in the document below.
+{{% /note %}}
 
 ## Enabling and Disabling Riak Control
 
@@ -167,16 +166,15 @@ be because you are using self-signed certificates. If you have
 authentication enabled in your configuration, you will next be asked to
 authenticate. Enter an appropriate username and password now.
 
-<div class="note">
-<div class="title">Note on browser TLS</div>
-Your browser needs to be support TLS v1.2 to use Riak Control over
-HTTPS. A list of browsers that support TLS v1.2 can be found
+{{% note title="Note on browser TLS" %}}
+Your browser needs to be support TLS v1.2 to use Riak Control over HTTPS. A
+list of browsers that support TLS v1.2 can be found
 [here](https://en.wikipedia.org/wiki/Transport_Layer_Security#Web_browsers).
-TLS v1.2 may be disabled by default on your browser, for example if you
-are using Firefox versions earlier than 27, Safari versions earlier than
-7, Chrome versions earlier than 30, or Internet Explorer versions
-earlier than 11.  To enable it, follow browser-specific instructions.
-</div>
+TLS v1.2 may be disabled by default on your browser, for example if you are
+using Firefox versions earlier than 27, Safari versions earlier than 7, Chrome
+versions earlier than 30, or Internet Explorer versions earlier than 11.  To
+enable it, follow browser-specific instructions.
+{{% /note %}}
 
 ### Snapshot View
 

--- a/content/riak/kv/2.0.2/using/cluster-operations/adding-removing-nodes.md
+++ b/content/riak/kv/2.0.2/using/cluster-operations/adding-removing-nodes.md
@@ -136,15 +136,14 @@ Transfers resulting from cluster changes: 51
 If the plan is to your liking, submit the changes by running `riak-admin
 cluster commit`.
 
-<div class="note">
-<div class="title">Note on ring changes</div>
-The algorithm that distributes partitions across the cluster
-during membership changes is non-deterministic. As a result, there is no
-optimal ring. In the event that a plan results in a slightly uneven
-distribution of partitions, the plan can be cleared. Clearing a cluster
-plan with `riak-admin cluster clear` and running `riak-admin cluster
-plan` again will produce a slightly different ring.
-</div>
+{{% note title="Note on ring changes" %}}
+The algorithm that distributes partitions across the cluster during membership
+changes is non-deterministic. As a result, there is no optimal ring. In the
+event that a plan results in a slightly uneven distribution of partitions, the
+plan can be cleared. Clearing a cluster plan with `riak-admin cluster clear`
+and running `riak-admin cluster plan` again will produce a slightly different
+ring.
+{{% /note %}}
 
 ## Removing a Node From a Cluster
 

--- a/content/riak/kv/2.0.2/using/cluster-operations/bucket-types.md
+++ b/content/riak/kv/2.0.2/using/cluster-operations/bucket-types.md
@@ -16,14 +16,13 @@ Buckets are essentially a flat namespace in Riak. They allow the same
 key name to exist in multiple buckets and enable you to apply
 configurations across keys.
 
-<div class="info">
-<div class="title">How Many Buckets Can I Have?</div>
-Buckets come with virtually no cost <em>except for when you modify the
-default bucket properties</em>. Modified bucket properties are gossiped
-around the cluster and therefore add to the amount of data sent around
-the network. In other words, buckets using the <tt>default</tt> bucket
-type are free. More on that in the next section.
-</div>
+{{% note title="How Many Buckets Can I Have?" %}}
+Buckets come with virtually no cost _except for when you modify the default
+bucket properties_. Modified bucket properties are gossiped around the cluster
+and therefore add to the amount of data sent around the network. In other
+words, buckets using the `default` bucket type are free. More on that in the
+next section.
+{{% /note %}}
 
 In Riak versions 2.0 and later, Basho suggests that you [use bucket types](/riak/kv/2.0.2/developing/usage/bucket-types) to namespace and configure all buckets you use. Bucket types have a lower overhead within the cluster than the
 default bucket namespace but require an additional setup step on the

--- a/content/riak/kv/2.0.2/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.0.2/using/cluster-operations/changing-cluster-info.md
@@ -302,9 +302,12 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
-<div class="note"><div class="title">Note</div>
-When using the `riak-admin cluster force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
-</div>
+{{% note title="Note" %}}
+When using the `riak-admin cluster force-replace` command, you will always get
+a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be
+lost`. Since we didn't delete any data files and we are replacing the node
+with itself under a new name, we will not lose any replicas.
+{{% /note %}}
 
 <a id="repeat"></a>
 #### Repeat previous steps on each node

--- a/content/riak/kv/2.0.2/using/cluster-operations/replacing-node.md
+++ b/content/riak/kv/2.0.2/using/cluster-operations/replacing-node.md
@@ -86,12 +86,10 @@ with the [`riak-admin ringready`](/riak/kv/2.0.2/using/admin/riak-admin/#ringrea
 and [`riak-admin member-status`](/riak/kv/2.0.2/using/admin/riak-admin/#member-status)
 commands.
 
-<div class="info">
-<div class="title">Ring Settling</div>
-You'll need to make sure that no other ring changes occur between the
-time when you start the new node and the ring settles with the new IP
-info.
+{{% note title="Ring Settling" %}}
+You'll need to make sure that no other ring changes occur between the time
+when you start the new node and the ring settles with the new IP info.
 
-The ring is considered settled when the new node reports `true` when you
-run the `riak-admin ringready` command.
-</div>
+The ring is considered settled when the new node reports `true` when you run
+the `riak-admin ringready` command.
+{{% /note %}}

--- a/content/riak/kv/2.0.2/using/cluster-operations/strong-consistency.md
+++ b/content/riak/kv/2.0.2/using/cluster-operations/strong-consistency.md
@@ -12,10 +12,14 @@ menu:
 toc: true
 ---
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 ## Monitoring Strong Consistency
 

--- a/content/riak/kv/2.0.2/using/performance.md
+++ b/content/riak/kv/2.0.2/using/performance.md
@@ -26,13 +26,12 @@ changes.
 For performance and tuning recommendations specific to running Riak
 clusters on the Amazon Web Services EC2 environment, see [AWS Performance Tuning](/riak/kv/2.0.2/using/performance/amazon-web-services).
 
-<div class="note">
-<div class="title">Note on other operating systems</div>
+{{% note title="Note on other operating systems" %}}
 Unless otherwise specified, the tunings recommended below are for Linux
-distributions. Users implementing Riak on BSD and Solaris distributions
-can use these tuning recommendations to make analogous changes in those
-operating systems.
-</div>
+distributions. Users implementing Riak on BSD and Solaris distributions can
+use these tuning recommendations to make analogous changes in those operating
+systems.
+{{% /note %}}
 
 ## Storage and File System Tuning
 
@@ -171,12 +170,11 @@ net.ipv4.tcp_tw_reuse = 1
 net.ipv4.tcp_moderate_rcvbuf = 1
 ```
 
-<div class="note">
-<div class="title">Note on system default</div>
+{{% note title="Note on system default" %}}
 In general, these recommended values should be compared with the system
-defaults and only changed if benchmarks or other performance metrics
-indicate that networking is the bottleneck.
-</div>
+defaults and only changed if benchmarks or other performance metrics indicate
+that networking is the bottleneck.
+{{% /note %}}
 
 The following settings are optional, but may improve performance on a
 10Gb network:
@@ -211,11 +209,10 @@ ethtool -K eth0 tso off
 `ethtool` settings can be persisted across reboots by adding the above
 command to the `/etc/rc.local` script.
 
-<div class="info">
-<div class="title">Pro tip</div>
-Tuning these values will be required if they are changed, as they affect
-all network operations.
-</div>
+{{% note title="Pro tip" %}}
+Tuning these values will be required if they are changed, as they affect all
+network operations.
+{{% /note %}}
 
 ## Optional I/O Settings
 

--- a/content/riak/kv/2.0.2/using/performance/amazon-web-services.md
+++ b/content/riak/kv/2.0.2/using/performance/amazon-web-services.md
@@ -54,14 +54,13 @@ indexes are not needed for the application.
 In any case, proper benchmarking and tuning are needed to achieve the
 desired performance.
 
-<div class="info">
-<div class="title">Tip</div>
-Most successful AWS cluster deployments use more EC2 instances than they
-would the same number of physical nodes to compensate for the
-performance variability caused by shared, virtualized resources. Plan to
-have more EC2 instance based nodes than physical server nodes when
-estimating cluster size with respect to node count.
-</div>
+{{% note title="Tip" %}}
+Most successful AWS cluster deployments use more EC2 instances than they would
+the same number of physical nodes to compensate for the performance
+variability caused by shared, virtualized resources. Plan to have more EC2
+instance based nodes than physical server nodes when estimating cluster size
+with respect to node count.
+{{% /note %}}
 
 ## Operating System
 

--- a/content/riak/kv/2.0.2/using/performance/erlang.md
+++ b/content/riak/kv/2.0.2/using/performance/erlang.md
@@ -44,16 +44,15 @@ Erlang parameter | Riak parameter
 [`-env ERL_MAX_ETS_TABLES`](http://learnyousomeerlang.com/ets) | `erlang.max_ets_tables`
 `-name` | `nodename`
 
-<div class="note">
-<div class="title">Note on upgrading to 2.0</div>
-In versions of Riak prior to 2.0, Erlang VM-related parameters were
-specified in a `vm.args` configuration file; in versions 2.0 and later,
-all Erlang-VM-specific parameters are set in the `riak.conf` file. If
-you're upgrading to 2.0 from an earlier version, you can still use your
-old `vm.args` if you wish.  Please note, however, that if you set one or
-more parameters in both `vm.args` and in `riak.conf`, the settings in
-`vm.args` will override those in `riak.conf`.
-</div>
+{{% note title="Note on upgrading to 2.0" %}}
+In versions of Riak prior to 2.0, Erlang VM-related parameters were specified
+in a `vm.args` configuration file; in versions 2.0 and later, all
+Erlang-VM-specific parameters are set in the `riak.conf` file. If you're
+upgrading to 2.0 from an earlier version, you can still use your old `vm.args`
+if you wish.  Please note, however, that if you set one or more parameters in
+both `vm.args` and in `riak.conf`, the settings in `vm.args` will override
+those in `riak.conf`.
+{{% /note %}}
 
 ## SMP
 

--- a/content/riak/kv/2.0.2/using/reference/bucket-types.md
+++ b/content/riak/kv/2.0.2/using/reference/bucket-types.md
@@ -16,14 +16,12 @@ Bucket types allow groups of buckets to share configuration details and
 for Riak users to manage bucket properties more efficiently than in the
 older configuration system based on [bucket properties](/riak/kv/2.0.2/developing/usage/bucket-types/#bucket-properties-and-operations).
 
-<div class="note">
-<div class="title">Important note on cluster downgrades</div>
-If you upgrade a Riak to version 2.0 or later, you can still downgrade
-the cluster to a pre-2.0 version <em>as long as you have not created and
-activated a bucket type in the cluster</em>. Once any bucket type has
-been created and activated, you can no longer downgrade the cluster to a
-pre-2.0 version.
-</div>
+{{% note title="Important note on cluster downgrades" %}}
+If you upgrade a Riak to version 2.0 or later, you can still downgrade the
+cluster to a pre-2.0 version _as long as you have not created and activated a
+bucket type in the cluster_. Once any bucket type has been created and
+activated, you can no longer downgrade the cluster to a pre-2.0 version.
+{{% /note %}}
 
 ## How Bucket Types Work
 
@@ -129,11 +127,11 @@ If creation is successful, you should see the following output:
 type_using_defaults created
 ```
 
-<div class="note">
+{{% note %}}
 The `create` command can be run multiple times prior to a bucket type being
 activated. Riak will persist only those properties contained in the final call
 of the command.
-</div>
+{{% /note %}}
 
 Creating bucket types that assign properties _always_ involves passing
 stringified JSON to the `create` command. One way to do that is to pass
@@ -243,11 +241,22 @@ of the type:
 riak-admin bucket-type update type_to_update '{"props":{ ... }}'
 ```
 
-> **Note**
->
-> Any bucket properties associated with a type can be modified after a bucket is created, with two important exceptions: `consistent` and `datatype`. If a bucket type entails strong consistency (requiring that `consistent` be set to `true`) or is set up as a `map`, `set`, or `counter`, then this will be true of the bucket type once and for all.
->
-> If you need to change one of these properties, it is recommended that you simply create and activate a new bucket type.
+{{% note title="Immutable Configurations" %}}
+Any bucket properties associated with a type can be modified after a bucket is
+created, with three important exceptions:
+
+* `consistent`
+* `datatype`
+* `write_once`
+
+If a bucket type entails strong consistency (requiring that `consistent` be
+set to `true`), is set up as a `map`, `set`, or `counter`, or is defined as a
+write-once  bucket (requiring `write_once` be set to `true`), then this will
+be true of the bucket types.
+
+If you need to change one of these properties, we recommend that you simply
+create and activate a new bucket type.
+{{% /note %}}
 
 ## Buckets as Namespaces
 
@@ -375,12 +384,11 @@ curl http://localhost:8098/types/type1/buckets/my_bucket/keys/my_key
 curl http://localhost:8098/types/type2/buckets/my_bucket/keys/my_key
 ```
 
-<div class="note">
-<div class="title">Note on object location</div>
-In Riak 2.x, <em>all requests</em> must be made to a location specified
-by a bucket type, bucket, and key rather than to a bucket/key pair, as
-in previous versions.
-</div>
+{{% note title="Note on object location" %}}
+In Riak 2.x, _all requests_ must be made to a location specified by a bucket
+type, bucket, and key rather than to a bucket/key pair, as in previous
+versions.
+{{% /note %}}
 
 If requests are made to a bucket/key pair without a specified bucket
 type, `default` will be used in place of a bucket type. The following

--- a/content/riak/kv/2.0.2/using/reference/custom-code.md
+++ b/content/riak/kv/2.0.2/using/reference/custom-code.md
@@ -30,13 +30,13 @@ name must have the same name the module. So if you are given a file named
 If you have been given Erlang code and are expected to compile it for
 your developers, keep the following notes in mind.
 
-<div class="info"><div class="title">Note on the Erlang Compiler</div> You
-must use the Erlang compiler (<tt>erlc</tt>) associated with the Riak
+{{% note title="Note on the Erlang Compiler" %}}
+You must use the Erlang compiler (`erlc`) associated with the Riak
 installation or the version of Erlang used when compiling Riak from source.
-For packaged Riak installations, you can consult Table 1 below for the
-default location of Riak's <tt>erlc</tt> for each supported platform.
-If you compiled from source, use the <tt>erlc</tt> from the Erlang version
-you used to compile Riak.</div>
+For packaged Riak installations, you can consult Table 1 below for the default
+location of Riak's `erlc` for each supported platform. If you compiled from
+source, use the `erlc` from the Erlang version you used to compile Riak.
+{{% /note %}}
 
 <table style="width: 100%; border-spacing: 0px;">
 <tbody>
@@ -87,8 +87,9 @@ and loaded. For our example, we'll use a temporary directory `/tmp/beams`,
 but you should choose a directory for production functions based on your
 own requirements such that they will be available where and when needed.
 
-<div class="info">Ensure that the directory chosen above can be read by
-the <tt>riak</tt> user.</div>
+{{% note %}}
+Ensure that the directory chosen above can be read by the `riak` user.
+{{% /note %}}
 
 Successful compilation will result in a new `.beam` file,
 `validate_json.beam`.
@@ -123,5 +124,7 @@ value store has fully initialized and become available for use.
 This is done with the `riak-admin wait-for-service` command as detailed
 in the [Commands documentation](/riak/kv/2.0.2/using/admin/riak-admin/#wait-for-service).
 
-<div class="note">It is important that you ensure riak_kv is
-active before restarting the next node.</div>
+{{% note %}}
+It is important that you ensure riak_kv is active before restarting the next
+node.
+{{% /note %}}

--- a/content/riak/kv/2.0.2/using/reference/multi-datacenter/comparison.md
+++ b/content/riak/kv/2.0.2/using/reference/multi-datacenter/comparison.md
@@ -17,13 +17,12 @@ aliases:
 This document is a systematic comparison of [Version 2](/riak/kv/2.0.2/using/reference/v2-multi-datacenter) and [Version 3](/riak/kv/2.0.2/using/reference/v3-multi-datacenter) of Riak Enterprise's Multi-Datacenter
 Replication capabilities.
 
-<div class="note">
-<div class="title">Important note on mixing versions</div>
+{{% note title="Important note on mixing versions" %}}
 If you are installing Riak Enterprise anew, you should use version 3
-replication. Under no circumstances should you mix version 2 and version
-3 replication. This comparison is meant only to list improvements
-introduced in version 3.
-</div>
+replication. Under no circumstances should you mix version 2 and version 3
+replication. This comparison is meant only to list improvements introduced in
+version 3.
+{{% /note %}}
 
 ## Version 2
 

--- a/content/riak/kv/2.0.2/using/reference/multi-datacenter/monitoring.md
+++ b/content/riak/kv/2.0.2/using/reference/multi-datacenter/monitoring.md
@@ -34,14 +34,12 @@ replication:
 * Use canary (test) objects to test replication and establish trip times
   from source to sink clusters
 
-<div class="note">
-<div class="title">Note on querying and time windows</div>
-Riak's statistics are calculated over a sliding 60-second window. Each
-time you query the stats interface, each sliding statistic shown is a
-sum or histogram value calculated from the previous 60 seconds of data.
-Because of this, the stats interface should not be queried more than
-once per minute.
-</div>
+{{% note title="Note on querying and time windows" %}}
+Riak's statistics are calculated over a sliding 60-second window. Each time
+you query the stats interface, each sliding statistic shown is a sum or
+histogram value calculated from the previous 60 seconds of data. Because of
+this, the stats interface should not be queried more than once per minute.
+{{% /note %}}
 
 ## Statistics
 

--- a/content/riak/kv/2.0.2/using/reference/statistics-monitoring.md
+++ b/content/riak/kv/2.0.2/using/reference/statistics-monitoring.md
@@ -91,15 +91,13 @@ As with the throughput metrics, keeping an eye on average (and max)
 latency times will help detect usage patterns, and provide advanced
 warnings for potential problems.
 
-<div class="note">
-<div class="title">Note on FSM Time Stats</div>
-FSM Time Stats represent the amount of time in microseconds required
-to traverse the GET or PUT Finite State Machine code, offering a
-picture of general node health. From your application's perspective,
-FSM Time effectively represents experienced latency. Mean, Median, and
-95th-, 99th-, and 100th-percentile (Max) counters are displayed. These
-are one-minute stats.
-</div>
+{{% note title="Note on FSM Time Stats" %}}
+FSM Time Stats represent the amount of time in microseconds required to
+traverse the GET or PUT Finite State Machine code, offering a picture of
+general node health. From your application's perspective, FSM Time effectively
+represents experienced latency. Mean, Median, and 95th-, 99th-, and
+100th-percentile (Max) counters are displayed. These are one-minute stats.
+{{% /note %}}
 
 Metric | Also | Relevance | Latency (in microseconds)
 :------|:-----|:----------|:-------------------------
@@ -190,19 +188,21 @@ reported success with when used for monitoring the operational status of
 their Riak clusters. Community and open source projects are presented
 along with commercial and hosted services.
 
-<div class="note">
-<div class="title">Note on Riak 2.x Statistics Support</div>
-Many of the below tools were either created by third-parties or Basho engineers
-for general usage, and have been passed to the community for further updates. As
-such, many of the below only aggregate the statistics and messages that were
-output by Riak 1.4.x.</br>
+{{% note title="Note on Riak 2.x Statistics Support" %}}
+Many of the below tools were either created by third-parties or Basho
+engineers for general usage, and have been passed to the community for further
+updates. As such, many of the below only aggregate the statistics and messages
+that were output by Riak 1.4.x.
+
 Like all code under [Basho Labs](https://github.com/basho-labs/), the below
-tools are "best effort" and have no dedicated Basho support. We both appreciate
-and need your contribution to keep these tools stable and up to date. Please
-open up a GitHub issue on the repository if you'd like to be a maintainer.</br>
-Look for banners calling out the tools we've verified that support the latest Riak 2.x
-statistics!
-</div>
+tools are "best effort" and have no dedicated Basho support. We both
+appreciate and need your contribution to keep these tools stable and up to
+date. Please open up a GitHub issue on the repository if you'd like to be a
+maintainer.
+
+Look for banners calling out the tools we've verified that support the latest
+Riak 2.x statistics!
+{{% /note %}}
 
 ### Self-Hosted Monitoring Tools
 
@@ -249,9 +249,9 @@ the Riak HTTP [`/stats`](/riak/kv/2.0.2/developing/api/http/status) endpoint is 
 
 #### Nagios
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x.**
+{{% /note %}}
 
 [Nagios](http://www.nagios.org) is a monitoring and alerting solution
 that can provide information on the status of Riak cluster nodes, in
@@ -285,9 +285,9 @@ module specifically designed to read Riak statistics.
 
 #### Zabbix
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [Zabbix](http://www.zabbix.com) is an open-source performance monitoring,
 alerting, and graphing solution that can provide information on the state of
@@ -311,9 +311,9 @@ capacity planning in a Riak cluster environment.
 
 #### New Relic
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [New Relic](http://newrelic.com) is a data analytics and visualization platform
 that can provide information on the current and past states of Riak nodes and

--- a/content/riak/kv/2.0.2/using/reference/v3-multi-datacenter/cascading-writes.md
+++ b/content/riak/kv/2.0.2/using/reference/v3-multi-datacenter/cascading-writes.md
@@ -27,13 +27,11 @@ Riak Enterprise. It will need to be manually enabled on new clusters.
 Cascading realtime requires the `{riak_repl, rtq_meta}` capability to
 function.
 
-<div class="note">
-<div class="title">Note on cascading tracking</div>
-Cascading tracking is a simple list of where an object has been written.
-This works well for most common configurations. Larger installations,
-however, may have writes cascade to clusters to which other clusters
-have already written.
-</div>
+{{% note title="Note on cascading tracking" %}}
+Cascading tracking is a simple list of where an object has been written. This
+works well for most common configurations. Larger installations, however, may
+have writes cascade to clusters to which other clusters have already written.
+{{% /note %}}
 
 
 ```

--- a/content/riak/kv/2.0.2/using/repair-recovery/errors.md
+++ b/content/riak/kv/2.0.2/using/repair-recovery/errors.md
@@ -134,11 +134,10 @@ Riak to explain the correct course of action. For example, the
 `map/reduce` `parse_input` phase will respond like this when it
 encounters an invalid input:
 
-<div class="note">
-<div class="title">Note on inputs</div>
-Inputs must be a binary bucket, a tuple of bucket and key-filters, a
-list of target tuples, a search index, or modfun tuple: `INPUT`.
-</div>
+{{% note title="Note on inputs" %}}
+Inputs must be a binary bucket, a tuple of bucket and key-filters, a list of
+target tuples, a search index, or modfun tuple: `INPUT`.
+{{% /note %}}
 
 For the remaining common error codes, they are often marked by Erlang
 atoms (and quite often wrapped within an `{error,{badmatch,{...` tuple,

--- a/content/riak/kv/2.0.2/using/repair-recovery/failure-recovery.md
+++ b/content/riak/kv/2.0.2/using/repair-recovery/failure-recovery.md
@@ -116,6 +116,8 @@ spreading load and increasing available CPU and IOPS.
 
 See [Changing Cluster Information](/riak/kv/2.1.4/using/cluster-operations/changing-cluster-info/#clusters-from-backups) for instructions on cluster recovery.
 
-<div class="info">
-<div class="title">Tip</div> If you are a licensed Riak Enterprise or CS customer and require assistance or further advice with a cluster recovery, please file a ticket with the <a href="https://help.basho.com">Basho Helpdesk</a>.
-</div>
+{{% note title="Tip" %}}
+If you are a licensed Riak Enterprise or CS customer and require assistance or
+further advice with a cluster recovery, please file a ticket with the
+<a href="https://help.basho.com">Basho Helpdesk</a>.
+{{% /note %}}

--- a/content/riak/kv/2.0.2/using/repair-recovery/repairs.md
+++ b/content/riak/kv/2.0.2/using/repair-recovery/repairs.md
@@ -165,10 +165,11 @@ If there are compaction errors in any of your vnodes, those will be listed in th
 ./442446784738847563128068650529343492278651453440/LOG 
 ```
 
-<div class="note">
-<div class="title">Note</div>
-While corruption on one vnode is not uncommon, corruption in several vnodes very likely means that there is a deeper problem that needs to be address, perhaps on the OS or hardware level.
-</div>
+{{% note title="Note" %}}
+While corruption on one vnode is not uncommon, corruption in several vnodes
+very likely means that there is a deeper problem that needs to be address,
+perhaps on the OS or hardware level.
+{{% /note %}}
 
 ## Healing Corrupted LevelDBs
 

--- a/content/riak/kv/2.0.2/using/running-a-cluster.md
+++ b/content/riak/kv/2.0.2/using/running-a-cluster.md
@@ -170,14 +170,13 @@ the node's ring file.
 riak-admin cluster replace riak@127.0.0.1 riak@192.168.1.10
 ```
 
-<div class="note">
-<div class="title">Note on single nodes</div>
-If a node is started singly using default settings, as you might do when
-you are building your first test environment, you will need to remove
-the ring files from the data directory after you edit your configuration
-files. `riak-admin cluster replace` will not work since the node has not
-been joined to a cluster.
-</div>
+{{% note title="Note on single nodes" %}}
+If a node is started singly using default settings, as you might do when you
+are building your first test environment, you will need to remove the ring
+files from the data directory after you edit your configuration files.
+`riak-admin cluster replace` will not work since the node has not been joined
+to a cluster.
+{{% /note %}}
 
 As with all cluster changes, you need to view the planned changes by
 running `riak-admin cluster plan` and then running `riak-admin cluster

--- a/content/riak/kv/2.0.2/using/security/basics.md
+++ b/content/riak/kv/2.0.2/using/security/basics.md
@@ -444,13 +444,11 @@ Permission | Operation |
 `riak_kv.list_keys` | List all of the keys in a bucket
 `riak_kv.list_buckets` | List all buckets
 
-<div class="note">
-<div class="title">Note on Listing Keys and Buckets</div>
-<code>riak_kv.list_keys</code> and <code>riak_kv.list_buckets</code> are
-both very expensive operations that should be performed very rarely and
-never in production. Access to this functionality should be granted very
-carefully.
-</div>
+{{% note title="Note on Listing Keys and Buckets" %}}
+`riak_kv.list_keys` and `riak_kv.list_buckets` are both very expensive
+operations that should be performed very rarely and never in production.
+Access to this functionality should be granted very carefully.
+{{% /note %}}
 
 If you'd like to create, for example, a `client` account that is
 allowed only to run `GET` and `PUT` requests on all buckets:
@@ -631,23 +629,20 @@ The following command would remove the source for `riakuser` on
 riak-admin security del-source riakuser 127.0.0.1/32
 ```
 
-<div class="note">
-<div class="title">Note on Removing Sources</div>
-If you apply a security source both to <code>all</code> and to specific
-users and then wish to remove that source, you will need to do so in
-separate steps. The <code>riak-admin security del-source all ...</code>
-command by itself is not sufficient.
+{{% note title="Note on Removing Sources" %}}
+If you apply a security source both to `all` and to specific users and then
+wish to remove that source, you will need to do so in separate steps. The
+`riak-admin security del-source all ...` command by itself is not sufficient.
 
-For example, if you have assigned the source <code>password</code> to
-both <code>all</code> and to the user <code>riakuser</code> on the
-network <code>127.0.0.1/32</code>, the following two-step process would
-be required to fully remove the source:
+For example, if you have assigned the source `password` to both `all` and to
+the user `riakuser` on the network `127.0.0.1/32`, the following two-step
+process would be required to fully remove the source:
 
 ```bash
 riak-admin security del-source all 127.0.0.1/32 password
 riak-admin security del-source riakuser 127.0.0.1/32 password
 ```
-</div>
+{{% /note %}}
 
 ### More Usage Examples
 

--- a/content/riak/kv/2.0.2/using/security/managing-sources.md
+++ b/content/riak/kv/2.0.2/using/security/managing-sources.md
@@ -28,11 +28,10 @@ The examples below will assume that the network in question is
 [created](/riak/kv/2.0.2/using/security/basics/#user-management) and that
 security has been [enabled](/riak/kv/2.0.2/using/security/basics/#the-basics).
 
-<div class="note">
-<div class="title">Note on SSL connections</div>
-If you use <em>any</em> of the aforementioned security sources, even
-<code>trust</code>, you will need to do so via a secure SSL connection.
-</div>
+{{% note title="Note on SSL connections" %}}
+If you use _any_ of the aforementioned security sources, even `trust`, you
+will need to do so via a secure SSL connection.
+{{% /note %}}
 
 ## Trust-based Authentication
 

--- a/content/riak/kv/2.0.4/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.0.4/configuring/load-balancing-proxy.md
@@ -184,15 +184,13 @@ act as a front-end proxy to a 5-node Riak cluster.
 This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
-<div class="note">
-<div class="title">Nginx version notes</div>
-This example configuration was verified on <strong>Nginx version
-1.2.3</strong>. Please be aware that earlier versions of Nginx did not
-support any HTTP 1.1 semantics for upstream communication to backends.
-You should carefully examine this configuration and make changes
-appropriate to your specific environment before attempting to use
-it
-</div>
+{{% note title="Nginx version notes" %}}
+This example configuration was verified on **Nginx version 1.2.3**. Please be
+aware that earlier versions of Nginx did not support any HTTP 1.1 semantics
+for upstream communication to backends. You should carefully examine this
+configuration and make changes appropriate to your specific environment before
+attempting to use it
+{{% /note %}}
 
 Here is an example `nginx.conf` file:
 
@@ -250,13 +248,12 @@ server {
 }
 ```
 
-<div class="note">
-<div class="title">Note on access controls</div>
-Even when filtering and limiting requests to GETs only as done in the
-example, you should strongly consider additional access controls beyond
-what Nginx can provide directly, such as specific firewall rules to
-limit inbound connections to trusted sources.
-</div>
+{{% note title="Note on access controls" %}}
+Even when filtering and limiting requests to GETs only as done in the example,
+you should strongly consider additional access controls beyond what Nginx can
+provide directly, such as specific firewall rules to limit inbound connections
+to trusted sources.
+{{% /note %}}
 
 ### Querying Secondary Indexes Over HTTP
 

--- a/content/riak/kv/2.0.4/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.0.4/configuring/load-balancing-proxy.md
@@ -185,7 +185,7 @@ This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
 <div class="note">
-<div class="title">Nginx version notes</div
+<div class="title">Nginx version notes</div>
 This example configuration was verified on <strong>Nginx version
 1.2.3</strong>. Please be aware that earlier versions of Nginx did not
 support any HTTP 1.1 semantics for upstream communication to backends.

--- a/content/riak/kv/2.0.4/configuring/v2-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.0.4/configuring/v2-multi-datacenter/ssl.md
@@ -64,8 +64,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -73,7 +72,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.0.4/configuring/v3-multi-datacenter/quick-start.md
+++ b/content/riak/kv/2.0.4/configuring/v3-multi-datacenter/quick-start.md
@@ -137,13 +137,11 @@ Sink             Cluster Name         <Ctrl-Pid>      [Members]
 Cluster1          Cluster1            <0.4456.0>      ["10.60.67.149:9080"] (via 10.60.67.149:9080)
 ```
 
-<div class="note">
-<div class="title">Note on connections</div>
-At this point, if you do not have connections, replication will not
-work. Check your IP bindings by running <code>netstat -a</code> on all
-nodes. You should see <code>*:9080 LISTENING</code>. If not, you have
-configuration problems.
-</div>
+{{% note title="Note on connections" %}}
+At this point, if you do not have connections, replication will not work.
+Check your IP bindings by running `netstat -a` on all nodes. You should see
+`*:9080 LISTENING`. If not, you have configuration problems.
+{{% /note %}}
 
 ### Enable Realtime Replication
 

--- a/content/riak/kv/2.0.4/configuring/v3-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.0.4/configuring/v3-multi-datacenter/ssl.md
@@ -54,12 +54,11 @@ the `riak-core` section of [`advanced.confg`][config reference#advanced.config]:
 The `cacertsdir` is a directory containing all the CA certificates
 needed to verify the CA chain back to the root.
 
-<div class="note">
-<div class="title">Note on configuration</div>
+{{% note title="Note on configuration" %}}
 In Version 3 replication, the SSL settings need to be placed in the
-<code>riak-core</code> section of <code>advanced.config</code> as opposed to
-the <code>riak-repl</code> section used by Version 2 replication.
-</div>
+`riak-core` section of `advanced.config` as opposed to the `riak-repl` section
+used by Version 2 replication.
+{{% /note %}}
 
 ## Verifying Peer Certificates
 
@@ -80,8 +79,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -89,7 +87,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.0.4/developing/api/http/fetch-object.md
+++ b/content/riak/kv/2.0.4/developing/api/http/fetch-object.md
@@ -79,22 +79,23 @@ datetime format
 The body of the response will be the contents of the object except when siblings
 are present.
 
-<div class="note"><div class="title">Siblings</div>
-<p>When `allow_mult` is set to true in the bucket properties, concurrent updates
-are allowed to create "sibling" objects, meaning that the object has any number
-of different values that are related to one another by the vector clock.  This
-allows your application to use its own conflict resolution technique.</p>
+{{% note title="Siblings" %}}
+When `allow_mult` is set to true in the bucket properties, concurrent updates
+are allowed to create "sibling" objects, meaning that the object has any
+number of different values that are related to one another by the vector
+clock.  This allows your application to use its own conflict resolution
+technique.
 
-<p>An object with multiple sibling values will result in a `300 Multiple
-Choices` response.  If the `Accept` header prefers `multipart/mixed`, all
-siblings will be returned in a single request as sections of the
-`multipart/mixed` response body.  Otherwise, a list of "vtags" will be given in
-a simple text format. You can request individual siblings by adding the `vtag`
-query parameter. Scroll down to the 'manually requesting siblings' example below for more information.</p>
+An object with multiple sibling values will result in a `300 Multiple Choices`
+response.  If the `Accept` header prefers `multipart/mixed`, all siblings will
+be returned in a single request as sections of the `multipart/mixed` response
+body.  Otherwise, a list of "vtags" will be given in a simple text format. You
+can request individual siblings by adding the `vtag` query parameter. Scroll
+down to the 'manually requesting siblings' example below for more information.
 
-<p>To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
-given in the response.</p>
-</div>
+To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
+given in the response.
+{{% /note %}}
 
 ## Simple Example
 

--- a/content/riak/kv/2.0.4/developing/api/http/link-walking.md
+++ b/content/riak/kv/2.0.4/developing/api/http/link-walking.md
@@ -26,22 +26,19 @@ is a special case of [MapReduce](/riak/kv/2.0.4/developing/usage/mapreduce), and
 GET /buckets/bucket/keys/key/[bucket],[tag],[keep]
 ```
 
-<div class="info"><div class="title">Link filters</div>
-<p>A link filter within the request URL is made of three parts, separated by
-commas:</p>
+{{% note title="Link filters" %}}
+A link filter within the request URL is made of three parts, separated by
+commas:
 
-<ul>
-<li>Bucket - a bucket name to limit the links to</li>
-<li>Tag - a "riaktag" to limit the links to</li>
-<li>Keep - 0 or 1, whether to return results from this phase</li>
-</ul>
+* Bucket - a bucket name to limit the links to
+* Tag - a "riaktag" to limit the links to
+* Keep - 0 or 1, whether to return results from this phase
 
-<p>Any of the three parts may be replaced with <code>_</code> (underscore),
-signifying that any value is valid. Multiple phases of links can be followed by
-adding additional path segments to the URL, separating the link filters by
-slashes. The final phase in the link-walking query implicitly returns its
-results.</p>
-</div>
+Any of the three parts may be replaced with `_` (underscore), signifying that
+any value is valid. Multiple phases of links can be followed by adding
+additional path segments to the URL, separating the link filters by slashes.
+The final phase in the link-walking query implicitly returns its results.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.0.4/developing/api/http/list-buckets.md
+++ b/content/riak/kv/2.0.4/developing/api/http/list-buckets.md
@@ -17,10 +17,10 @@ aliases:
 
 Lists all known buckets (ones that have keys stored in them).
 
-<div class="note"><div class="title">Not for production use</div>
+{{% note title="Not for production use" %}}
 Similar to the list keys operation, this requires traversing all keys stored
 in the cluster and should not be used in production.
-</div>
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.4/developing/api/http/list-keys.md
+++ b/content/riak/kv/2.0.4/developing/api/http/list-keys.md
@@ -17,12 +17,10 @@ aliases:
 
 Lists keys in a bucket.
 
-<div class="note">
-<div class="title">Not for production use</div>
-
-This operation requires traversing all keys stored in the cluster and should not be used in production.
-
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.4/developing/api/http/set-bucket-props.md
+++ b/content/riak/kv/2.0.4/developing/api/http/set-bucket-props.md
@@ -50,14 +50,12 @@ the bucket
 
 Other properties do exist but are not commonly modified.
 
-<div class="note">
-<div class="title">Property types</div>
-<p>Make sure you use the proper types for attributes like <strong>n_val</strong>
-and <strong>allow_mult</strong>. If you use strings instead of integers and
-booleans respectively, you may see some odd errors in your logs, saying
-something like
-<code>"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"</code>.</p>
-</div>
+{{% note title="Property types" %}}
+Make sure you use the proper types for attributes like **n_val** and
+**allow_mult**. If you use strings instead of integers and booleans
+respectively, you may see some odd errors in your logs, saying something like
+`"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"`.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.0.4/developing/api/protocol-buffers.md
+++ b/content/riak/kv/2.0.4/developing/api/protocol-buffers.md
@@ -106,12 +106,11 @@ Code | Message |
 254 | `RpbAuthResp` |
 255 | `RpbStartTls` |
 
-<div class="info">
-<div class="title">Message Definitions</div>
-All Protocol Buffers messages are defined in the <code>riak.proto</code>
-and other <code>.proto</code> files in the <code>/src</code> directory
-of the <a href="https://github.com/basho/riak_pb">RiakPB</a> project.
-</div>
+{{% note title="Message Definitions" %}}
+All Protocol Buffers messages are defined in the `riak.proto` and other
+`.proto` files in the `/src` directory of the
+<a href="https://github.com/basho/riak_pb">RiakPB</a> project.
+{{% /note %}}
 
 ### Error Response
 

--- a/content/riak/kv/2.0.4/developing/api/protocol-buffers/fetch-object.md
+++ b/content/riak/kv/2.0.4/developing/api/protocol-buffers/fetch-object.md
@@ -137,14 +137,12 @@ of the following optional parameters:
 * `deleted` --- Whether the object has been deleted (i.e. whether a
   tombstone for the object has been found under the specified key)
 
-<div class="note">
-<div class="title">Note on missing keys</div>
-Remember: if a key is not stored in Riak, an <code>RpbGetResp</code>
-response without the <code>content</code> and <code>vclock</code> fields
-will be returned. This should be mapped to whatever convention the
-client language uses to return not found. The Erlang client, for
-example, returns the atom <code>{error, notfound}</code>.
-</div>
+{{% note title="Note on missing keys" %}}
+Remember: if a key is not stored in Riak, an `RpbGetResp` response without the
+`content` and `vclock` fields will be returned. This should be mapped to
+whatever convention the client language uses to return not found. The Erlang
+client, for example, returns the atom `{error, notfound}`.
+{{% /note %}}
 
 ## Example
 

--- a/content/riak/kv/2.0.4/developing/api/protocol-buffers/get-client-id.md
+++ b/content/riak/kv/2.0.4/developing/api/protocol-buffers/get-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.0.4/dev/references/protocol-buffers/get-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Get the client id used for this connection. Client ids are used for
 conflict resolution and each unique actor in the system should be

--- a/content/riak/kv/2.0.4/developing/api/protocol-buffers/list-buckets.md
+++ b/content/riak/kv/2.0.4/developing/api/protocol-buffers/list-buckets.md
@@ -17,12 +17,10 @@ aliases:
 
 List all of the bucket names available.
 
-<div class="note">
-<div class="title">Caution</div>
-
-This call can be expensive for the server. Do not use in
-performance-sensitive code.
-</div>
+{{% note title="Caution" %}}
+This call can be expensive for the server. Do not use in performance-sensitive
+code.
+{{% /note %}}
 
 
 ## Request

--- a/content/riak/kv/2.0.4/developing/api/protocol-buffers/list-keys.md
+++ b/content/riak/kv/2.0.4/developing/api/protocol-buffers/list-keys.md
@@ -18,11 +18,10 @@ aliases:
 List all of the keys in a bucket. This is a streaming call, with
 multiple response messages sent for each request.
 
-<div class="note">
-<div class="title">Not for production use</div>
-This operation requires traversing all keys stored in the cluster and
-should not be used in production.
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.4/developing/api/protocol-buffers/set-client-id.md
+++ b/content/riak/kv/2.0.4/developing/api/protocol-buffers/set-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.0.4/dev/references/protocol-buffers/set-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Set the client ID for this connection. A library may want to set the
 client ID if it has a good way to uniquely identify actors across

--- a/content/riak/kv/2.0.4/developing/app-guide/advanced-mapreduce.md
+++ b/content/riak/kv/2.0.4/developing/app-guide/advanced-mapreduce.md
@@ -253,10 +253,10 @@ curl -XPOST localhost:8098/mapred \
 
 The result should be a JSON map of bucket and key names expressed as key/value pairs.
 
-<div class="info">
-Be sure to install the MapReduce function as described above on all of
-the nodes in your cluster to ensure proper operation.
-</div>
+{{% note %}}
+Be sure to install the MapReduce function as described above on all of the
+nodes in your cluster to ensure proper operation.
+{{% /note %}}
 
 
 ## Phase functions
@@ -481,27 +481,25 @@ takes any of the following forms:
 * `{jsanon, {Bucket, Key}}` where the object at `{Bucket, Key}` contains
   the source for an anonymous Javascript function
 
-<div class="info">
-<div class="title">qfun Note</div>
-Using `qfun` in compiled applications can be a fragile
-operation. Please keep the following points in mind.
+{{% note title="qfun Note" %}}
+Using `qfun` in compiled applications can be a fragile operation. Please keep
+the following points in mind.
 
-1. The module in which the function is defined must be present and
-**exactly the same version** on both the client and Riak nodes.
+1. The module in which the function is defined must be present and **exactly
+   the same version** on both the client and Riak nodes.
 
-2. Any modules and functions used by this function (or any function in
-the resulting call stack) must also be present on the Riak nodes.
+2. Any modules and functions used by this function (or any function in the
+   resulting call stack) must also be present on the Riak nodes.
 
-Errors about failures to ensure both 1 and 2 are often surprising,
-usually seen as opaque **missing-function** or **function-clause**
-errors. Especially in the case of differing module versions, this can be
-difficult to diagnose without expecting the issue and knowing of
-`Module:info/0`.
+Errors about failures to ensure both 1 and 2 are often surprising, usually
+seen as opaque **missing-function** or **function-clause** errors. Especially
+in the case of differing module versions, this can be difficult to diagnose
+without expecting the issue and knowing of `Module:info/0`.
 
-When using the Erlang shell, anonymous MapReduce functions can be
-defined and sent to Riak instead of deploying them to all servers in
-advance, but condition #2 above still holds.
-</div>
+When using the Erlang shell, anonymous MapReduce functions can be defined and
+sent to Riak instead of deploying them to all servers in advance, but
+condition #2 above still holds.
+{{% /note %}}
 
 Link phases are expressed in the following form:
 

--- a/content/riak/kv/2.0.4/developing/app-guide/replication-properties.md
+++ b/content/riak/kv/2.0.4/developing/app-guide/replication-properties.md
@@ -154,15 +154,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -330,15 +328,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -355,14 +352,12 @@ documentation on [Bitcask](/riak/kv/2.0.4/setup/planning/backend/bitcask), [Leve
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.0.4/developing/client-libraries.md
+++ b/content/riak/kv/2.0.4/developing/client-libraries.md
@@ -49,12 +49,11 @@ developing something that you wish to see added to this list, please
 fork the [Riak Docs repo on GitHub](https://github.com/basho/basho_docs)
 and send us a pull request.
 
-<div class="note">
-<div class="title">Note on community-produced libraries</div>
-All of these projects and libraries are at various stages of
-completeness and may not suit your application's needs based on their
-level of maturity and activity.
-</div>
+{{% note title="Note on community-produced libraries" %}}
+All of these projects and libraries are at various stages of completeness and
+may not suit your application's needs based on their level of maturity and
+activity.
+{{% /note %}}
 
 ### Client Libraries and Frameworks
 

--- a/content/riak/kv/2.0.4/developing/getting-started/csharp.md
+++ b/content/riak/kv/2.0.4/developing/getting-started/csharp.md
@@ -25,10 +25,12 @@ To try this flavor of Riak, a working installation of the .NET Framework or Mono
 
 Install [the Riak .NET Client](https://github.com/basho/riak-dotnet-client/wiki/Installation) through [NuGet](http://nuget.org/packages/RiakClient) or the Visual Studio NuGet package manager.
 
-<div class="note">
-<div class="title">Configuring for a remote cluster</div>
-By default, the Riak .NET Client will add a section to your `app.config` file for a four node local cluster. If you are using a remote cluster, open up `app.config` and change the `hostAddress` values to point to nodes in your remote cluster.
-</div>
+{{% note title="Configuring for a remote cluster" %}}
+By default, the Riak .NET Client will add a section to your `app.config` file
+for a four node local cluster. If you are using a remote cluster, open up
+`app.config` and change the `hostAddress` values to point to nodes in your
+remote cluster.
+{{% /note %}}
 
 ### Connecting to Riak
 

--- a/content/riak/kv/2.0.4/developing/getting-started/csharp/object-modeling.md
+++ b/content/riak/kv/2.0.4/developing/getting-started/csharp/object-modeling.md
@@ -64,12 +64,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially when many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially when many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.4/developing/getting-started/erlang/object-modeling.md
+++ b/content/riak/kv/2.0.4/developing/getting-started/erlang/object-modeling.md
@@ -18,14 +18,13 @@ aliases:
 
 To get started, let's create the records that we'll be using.
 
-<div class="note">
-<div class="title">Code Download</div>
+{{% note title="Code Download" %}}
 You can also download the code for this chapter at
 [Github](https://github.com/basho/taste-of-riak/tree/am-dem-erlang-modules/erlang/Ch03-Msgy-Schema).
 
-The Github version includes Erlang type specifications which have been
-omitted here for brevity.
-</div>
+The Github version includes Erlang type specifications which have been omitted
+here for brevity.
+{{% /note %}}
 
 
 ```erlang
@@ -91,13 +90,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.4/developing/getting-started/golang/object-modeling.md
+++ b/content/riak/kv/2.0.4/developing/getting-started/golang/object-modeling.md
@@ -182,13 +182,11 @@ users and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.4/developing/getting-started/java.md
+++ b/content/riak/kv/2.0.4/developing/getting-started/java.md
@@ -40,13 +40,11 @@ Next, download
 [`TasteOfRiak.java`](https://github.com/basho/basho_docs/raw/master/extras/code-examples/TasteOfRiak.java)
 source code for this tutorial, and save it to your working directory.
 
-<div class="note">
-<div class="title">Configuring for a local cluster</div>
-The `TasteOfRiak.java` file that you downloaded is set up to communicate
-with a 1-node Riak cluster listening on `localhost` port 10017. We
-recommend modifying the connection info directly within the
-`setUpCluster()` method.
-</div>
+{{% note title="Configuring for a local cluster" %}}
+The `TasteOfRiak.java` file that you downloaded is set up to communicate with
+a 1-node Riak cluster listening on `localhost` port 10017. We recommend
+modifying the connection info directly within the `setUpCluster()` method.
+{{% /note %}}
 
 If you execute the `TasteOfRiak.java` file within your IDE, you should
 see the following:

--- a/content/riak/kv/2.0.4/developing/getting-started/java/object-modeling.md
+++ b/content/riak/kv/2.0.4/developing/getting-started/java/object-modeling.md
@@ -157,12 +157,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.4/developing/getting-started/nodejs/object-modeling.md
+++ b/content/riak/kv/2.0.4/developing/getting-started/nodejs/object-modeling.md
@@ -73,12 +73,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_SENT_2014-03-06` or `marketing_group_INBOX_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.4/developing/getting-started/python/object-modeling.md
+++ b/content/riak/kv/2.0.4/developing/getting-started/python/object-modeling.md
@@ -83,13 +83,11 @@ users, and `<groupname>_<type>_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-06`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.4/developing/getting-started/ruby/object-modeling.md
+++ b/content/riak/kv/2.0.4/developing/getting-started/ruby/object-modeling.md
@@ -94,13 +94,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.4/developing/usage/conflict-resolution.md
+++ b/content/riak/kv/2.0.4/developing/usage/conflict-resolution.md
@@ -25,16 +25,15 @@ If you are using Riak in an [eventually consistent](/riak/kv/2.0.4/learn/concept
 unavoidable. Often, Riak can resolve these conflicts on its own
 internally if you use causal context, i.e. [vector clocks](/riak/kv/2.0.4/learn/concepts/causal-context#vector-clocks) or [dotted version vectors](/riak/kv/2.0.4/learn/concepts/causal-context#dotted-version-vectors), when updating objects. Instructions on this can be found in the section [below](#siblings).
 
-<div class="note">
-<div class="title">Important note on terminology</div>
-In versions of Riak prior to 2.0, vector clocks were the only causal
-context mechanism available in Riak, which changed with the introduction
-of dotted version vectors in 2.0. Please note that you may frequent find
-terminology in client library APIs, internal Basho documentation, and
-more that uses the term "vector clock" interchangeably with causal
-context in general. Riak's HTTP API still uses a `X-Riak-Vclock` header,
-for example, even if you are using dotted version vectors.
-</div>
+{{% note title="Important note on terminology" %}}
+In versions of Riak prior to 2.0, vector clocks were the only causal context
+mechanism available in Riak, which changed with the introduction of dotted
+version vectors in 2.0. Please note that you may frequent find terminology in
+client library APIs, internal Basho documentation, and more that uses the term
+"vector clock" interchangeably with causal context in general. Riak's HTTP API
+still uses a `X-Riak-Vclock` header, for example, even if you are using dotted
+version vectors.
+{{% /note %}}
 
 But even when you use causal context, Riak cannot always decide which
 value is most causally recent, especially in cases involving concurrent
@@ -118,12 +117,10 @@ will be no concurrent updates. If you are storing immutable data in
 which each object is guaranteed to have its own key or engaging in
 operations related to bulk loading, you should consider LWW.
 
-<div class="note">
-<div class="title">Undefined behavior warning</div>
-Setting both <code>allow_mult</code> and <code>last_write_wins</code> to
-<code>true</code> necessarily leads to unpredictable behavior and should
-always be avoided.
-</div>
+{{% note title="Undefined behavior warning" %}}
+Setting both `allow_mult` and `last_write_wins` to `true` necessarily leads to
+unpredictable behavior and should always be avoided.
+{{% /note %}}
 
 ### Resolve Conflicts on the Application Side
 
@@ -602,13 +599,12 @@ X-Riak-Vclock: a85hYGBgzGDKBVIcR4M2cgczH7HPYEpkzGNlsP/VfYYvCwA=
 # accompany the write for Riak to be able to use the vector clock
 ```
 
-<div class="note">
-<div class="title">Concurrent conflict resolution</div>
+{{% note title="Concurrent conflict resolution" %}}
 It should be noted that it is possible to have two clients that are
 simultaneously engaging in conflict resolution. To avoid a pathological
-divergence, you should be sure to limit the number of reconciliations
-and fail once that limit has been exceeded.
-</div>
+divergence, you should be sure to limit the number of reconciliations and fail
+once that limit has been exceeded.
+{{% /note %}}
 
 ### Sibling Explosion
 
@@ -650,13 +646,10 @@ better performance. Some use cases where you might want to use
 `last_write_wins` include caching, session storage, and insert-only
 (no updates).
 
-<div class="note">
-<div class="title">Note on combining <code>allow_mult</code> and
-<code>last_write_wins</code></div>
-The combination of setting both the <code>allow_mult</code> and
-<code>last_write_wins</code> properties to <code>true</code> leads to
-undefined behavior and should not be used.
-</div>
+{{% note title="Note on combining `allow_mult` and `last_write_wins`" %}}
+The combination of setting both the `allow_mult` and `last_write_wins`
+properties to `true` leads to undefined behavior and should not be used.
+{{% /note %}}
 
 ## Vector Clock Pruning
 

--- a/content/riak/kv/2.0.4/developing/usage/mapreduce.md
+++ b/content/riak/kv/2.0.4/developing/usage/mapreduce.md
@@ -15,16 +15,14 @@ aliases:
   - /riak/kv/2.0.4/dev/using/mapreduce
 ---
 
-<div class="note">
-<div class="title">Use MapReduce sparingly</div>
-In Riak, MapReduce is the primary method for non-primary-key-based
-querying. Although useful for a limited range of purposes, such as batch
-processing jobs, MapReduce operations can be very computationally
-expensive, sometimes to the extent that they can degrade performance in
-production clusters operating under load. Thus, we recommend running
-MapReduce operations in a controlled, rate-limited fashion and never for
-realtime querying purposes.
-</div>
+{{% note title="Use MapReduce sparingly" %}}
+In Riak, MapReduce is the primary method for non-primary-key-based querying.
+Although useful for a limited range of purposes, such as batch processing
+jobs, MapReduce operations can be very computationally expensive, sometimes to
+the extent that they can degrade performance in production clusters operating
+under load. Thus, we recommend running MapReduce operations in a controlled,
+rate-limited fashion and never for realtime querying purposes.
+{{% /note %}}
 
 MapReduce (M/R) is a technique for dividing data processing work across
 a distributed system. It takes advantage of the parallel processing

--- a/content/riak/kv/2.0.4/developing/usage/reading-objects.md
+++ b/content/riak/kv/2.0.4/developing/usage/reading-objects.md
@@ -197,12 +197,10 @@ The most common error code:
 
 * `404 Not Found`
 
-<div class="note">
-<div class="title">Note</div>
-If you're using a Riak client instead of HTTP, these responses will vary
-a great deal, so make sure to check the documentation for your specific
-client.
-</div>
+{{% note title="Note" %}}
+If you're using a Riak client instead of HTTP, these responses will vary a
+great deal, so make sure to check the documentation for your specific client.
+{{% /note %}}
 
 ## No Object Stored
 

--- a/content/riak/kv/2.0.4/developing/usage/replication.md
+++ b/content/riak/kv/2.0.4/developing/usage/replication.md
@@ -45,18 +45,17 @@ is one of the features that differentiates Riak from other databases.
 At the bottom of the page, you'll find a [screencast](/riak/kv/2.0.4/developing/app-guide/replication-properties#screencast) that briefly explains how to adjust your
 replication levels to match your application and business needs.
 
-<div class="note">
-<div class="title">Note on strong consistency</div>
+{{% note title="Note on strong consistency" %}}
 An option introduced in Riak version 2.0 is to use Riak as a
-<a href="/riak/kv/2.0.4/using/reference/strong-consistency/">strongly consistent</a>
-system for data in specified buckets. Using Riak in this way is
-fundamentally different from adjusting replication properties and
-fine-tuning the availability/consistency trade-off, as it sacrifices
-<em>all</em> availability guarantees when necessary. Therefore, you
-should consult the <a href="/riak/kv/2.0.4/developing/app-guide/strong-consistency">Using
-Strong Consistency</a> documentation, as this option will not be covered
-in this tutorial.
-</div>
+<a href="/riak/kv/2.0.4/using/reference/strong-consistency/">strongly
+consistent</a> system for data in specified buckets. Using Riak in this way is
+fundamentally different from adjusting replication properties and fine-tuning
+the availability/consistency trade-off, as it sacrifices _all_ availability
+guarantees when necessary. Therefore, you should consult the
+<a href="/riak/kv/2.0.4/developing/app-guide/strong-consistency">Using Strong
+Consistency</a> documentation, as this option will not be covered in this
+tutorial.
+{{% /note %}}
 
 ## How Replication Properties Work
 
@@ -163,15 +162,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -339,15 +336,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -364,14 +360,12 @@ documentation on [Bitcask][plan backend bitcask], [LevelDB][plan backend leveldb
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.0.4/developing/usage/security/erlang.md
+++ b/content/riak/kv/2.0.4/developing/usage/security/erlang.md
@@ -24,13 +24,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.0.4/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Erlang Client Basics
 

--- a/content/riak/kv/2.0.4/developing/usage/security/java.md
+++ b/content/riak/kv/2.0.4/developing/usage/security/java.md
@@ -23,13 +23,11 @@ If you are using [trust-](/riak/kv/2.0.4/using/security/managing-sources/#trust-
 security setup described [below](#java-client-basics). [Certificate](/riak/kv/2.0.4/using/security/managing-sources/#certificate-based-authentication)-based authentication is not
 yet supported in the Java client.
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Java Client Basics
 

--- a/content/riak/kv/2.0.4/developing/usage/security/python.md
+++ b/content/riak/kv/2.0.4/developing/usage/security/python.md
@@ -25,13 +25,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.0.4/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## OpenSSL Versions
 

--- a/content/riak/kv/2.0.4/developing/usage/security/ruby.md
+++ b/content/riak/kv/2.0.4/developing/usage/security/ruby.md
@@ -25,13 +25,11 @@ can use the security setup described in the [Ruby Client Basics](#ruby-client-ba
 in a [later section](#password-based-authentication), while [certificate](/riak/kv/2.0.4/using/security/managing-sources/#certificate-based-authentication)-based authentication
 is covered [further down](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Ruby Client Basics
 

--- a/content/riak/kv/2.0.4/introduction.md
+++ b/content/riak/kv/2.0.4/introduction.md
@@ -185,14 +185,12 @@ Based on Basho's [Cuttlefish](https://github.com/basho/cuttlefish)
 project, the new system is much simpler, leaving behind the Erlang
 syntax required in `app.config`.
 
-<div class="note">
-<div class="title">Note on upgrading</div>
-Version 2.0 will support both the old and the new configuration system,
-in case you're upgrading. Please note, however, that if you use both
-systems side by side, all settings from the older,
-`app.config`/`vm.args`-based system will override any settings from the
-new system.
-</div>
+{{% note title="Note on upgrading" %}}
+Version 2.0 will support both the old and the new configuration system, in
+case you're upgrading. Please note, however, that if you use both systems side
+by side, all settings from the older, `app.config`/`vm.args`-based system will
+override any settings from the new system.
+{{% /note %}}
 
 #### Relevant Docs
 

--- a/content/riak/kv/2.0.4/learn/concepts/strong-consistency.md
+++ b/content/riak/kv/2.0.4/learn/concepts/strong-consistency.md
@@ -18,10 +18,14 @@ aliases:
 [usage bucket types]: /riak/kv/2.0.4/developing/usage/bucket-types
 [concept eventual consistency]: /riak/kv/2.0.4/learn/concepts/eventual-consistency
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 Riak was originally designed as an [eventually consistent](/riak/kv/2.0.4/learn/concepts/eventual-consistency) system, fundamentally geared toward providing partition
 (i.e. fault) tolerance and high read and write availability.

--- a/content/riak/kv/2.0.4/setup/downgrade.md
+++ b/content/riak/kv/2.0.4/setup/downgrade.md
@@ -37,13 +37,13 @@ additional steps to be performed before, during, and after the upgrade
 on on each node.  These steps are related to changes or new features
 that are not present in the downgraded version.
 
-<div class="note">
-<div class="title">A Note About the Following Instructions</div>
-The below instructions describe the procedures required for a single
-feature release version downgrade. In a downgrade between two feature
-release versions, the steps for the in-between version must also be
-performed. For example, a downgrade from 1.4 to 1.2 requires that the
-downgrade steps for both 1.4 and 1.3 are performed.  </div>
+{{% note title="A Note About the Following Instructions" %}}
+The below instructions describe the procedures required for a single feature
+release version downgrade. In a downgrade between two feature release
+versions, the steps for the in-between version must also be performed. For
+example, a downgrade from 1.4 to 1.2 requires that the downgrade steps for
+both 1.4 and 1.3 are performed.
+{{% /note %}}
 
 ## General Guidelines
 

--- a/content/riak/kv/2.0.4/setup/installing/amazon-web-services.md
+++ b/content/riak/kv/2.0.4/setup/installing/amazon-web-services.md
@@ -62,10 +62,10 @@ You will need need to launch at least 3 instances to form a Riak cluster.  When 
 
 You can find more information on connecting to an instance on the official [Amazon EC2 instance guide](http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/AccessingInstances.html).
 
-<div class="note">
-<div class="title">Note</div>
-The following clustering setup will <em>not</em> be resilient to instance restarts unless deployed in Amazon VPC.
-</div>
+{{% note title="Note" %}}
+The following clustering setup will _not_ be resilient to instance restarts
+unless deployed in Amazon VPC.
+{{% /note %}}
 
 1. On the first node, obtain the internal IP address:
 

--- a/content/riak/kv/2.0.4/setup/installing/mac-osx.md
+++ b/content/riak/kv/2.0.4/setup/installing/mac-osx.md
@@ -52,13 +52,12 @@ directory and execute `bin/riak start` to start the Riak node.
 
 ## Homebrew
 
-<div class="note">
-<div class="title">Warning: Homebrew not always up to date</div>
-Homebrew's Riak recipe is community supported, and thus is not always up
-to date with the latest Riak package. Please ensure that the current
-recipe is using the latest supported code (and don't be afraid to update
-it if it's not).
-</div>
+{{% note title="Warning: Homebrew not always up to date" %}}
+Homebrew's Riak recipe is community supported, and thus is not always up to
+date with the latest Riak package. Please ensure that the current recipe is
+using the latest supported code (and don't be afraid to update it if it's
+not).
+{{% /note %}}
 
 Installing Riak 2.0 with [Homebrew](http://brew.sh/) is easy:
 
@@ -92,11 +91,10 @@ the Riak installation directory via environment variables.
 You must have Xcode tools installed from [Apple's Developer
 website](http://developer.apple.com/).
 
-<div class="note">
-<div class="title">Note on Clang</div>
-Riak will not compile with Clang. Please make sure that your default
-C/C++ compiler is [GCC](https://gcc.gnu.org/).
-</div>
+{{% note title="Note on Clang" %}}
+Riak will not compile with Clang. Please make sure that your default C/C++
+compiler is [GCC](https://gcc.gnu.org/).
+{{% /note %}}
 
 Riak requires [Erlang](http://www.erlang.org/) R16B02+.
 

--- a/content/riak/kv/2.0.4/using/admin/riak-admin.md
+++ b/content/riak/kv/2.0.4/using/admin/riak-admin.md
@@ -185,11 +185,10 @@ rename the nodes of a cluster. For more information, visit the
 riak-admin reip <old nodename> <new nodename>
 ```
 
-<div class="note">
-<div class="title">Note about reip prior to Riak 2.0</title></div>
-Several bugs have been fixed related to reip in Riak 2.0. We recommend
-against using reip prior to 2.0, if possible.
-</div>
+{{% note title="Note about reip prior to Riak 2.0" %}}
+Several bugs have been fixed related to reip in Riak 2.0. We recommend against
+using reip prior to 2.0, if possible.
+{{% /note %}}
 
 
 ## js-reload
@@ -389,12 +388,10 @@ entropy tree building, and key repairs which were triggered by AAE.
  * The *Max* column shows the maximum number of keys repaired during all
    key exchanges since the last node restart.
 
-<div class="note">
-<div class="title">Note in AAE status information</div>
-All AAE status information is in-memory and is reset across a node
-restart. Only tree build times are persistent (since trees themselves
-are persistent)
-</div>
+{{% note title="Note in AAE status information" %}}
+All AAE status information is in-memory and is reset across a node restart.
+Only tree build times are persistent (since trees themselves are persistent)
+{{% /note %}}
 
 More details on the `aae-status` command are available in the [Riak
 version 1.3 release notes](https://github.com/basho/riak/blob/1.3/RELEASE-NOTES.md#active-anti-entropy).
@@ -628,11 +625,10 @@ repaired for a given exchange round since the node has started.
 
 ### switch-to-new-search
 
-<div class="info">
-<div class="title">Only For Legacy Migration</div>
-This is only needed when migrating from legacy riak search to the new
-Search (Yokozuna).
-</div>
+{{% note title="Only For Legacy Migration" %}}
+This is only needed when migrating from legacy riak search to the new Search
+(Yokozuna).
+{{% /note %}}
 
 ```bash
 riak-admin search switch-to-new-search

--- a/content/riak/kv/2.0.4/using/admin/riak-control.md
+++ b/content/riak/kv/2.0.4/using/admin/riak-control.md
@@ -57,12 +57,11 @@ listener.https.<name> = 127.0.0.1:8096
 %%     the `riak_api` tuple's value list.
 ```
 
-<div class="note">
-<div class="title">Note on SSL</div>
-We strongly recommend that you enable SSL for Riak Control. It is
-disabled by default, and if you wish to enable it you must do so
-explicitly. More information can be found in the document below.
-</div>
+{{% note title="Note on SSL" %}}
+We strongly recommend that you enable SSL for Riak Control. It is disabled by
+default, and if you wish to enable it you must do so explicitly. More
+information can be found in the document below.
+{{% /note %}}
 
 ## Enabling and Disabling Riak Control
 
@@ -168,16 +167,15 @@ be because you are using self-signed certificates. If you have
 authentication enabled in your configuration, you will next be asked to
 authenticate. Enter an appropriate username and password now.
 
-<div class="note">
-<div class="title">Note on browser TLS</div>
-Your browser needs to be support TLS v1.2 to use Riak Control over
-HTTPS. A list of browsers that support TLS v1.2 can be found
+{{% note title="Note on browser TLS" %}}
+Your browser needs to be support TLS v1.2 to use Riak Control over HTTPS. A
+list of browsers that support TLS v1.2 can be found
 [here](https://en.wikipedia.org/wiki/Transport_Layer_Security#Web_browsers).
-TLS v1.2 may be disabled by default on your browser, for example if you
-are using Firefox versions earlier than 27, Safari versions earlier than
-7, Chrome versions earlier than 30, or Internet Explorer versions
-earlier than 11.  To enable it, follow browser-specific instructions.
-</div>
+TLS v1.2 may be disabled by default on your browser, for example if you are
+using Firefox versions earlier than 27, Safari versions earlier than 7, Chrome
+versions earlier than 30, or Internet Explorer versions earlier than 11.  To
+enable it, follow browser-specific instructions.
+{{% /note %}}
 
 ### Snapshot View
 

--- a/content/riak/kv/2.0.4/using/cluster-operations/adding-removing-nodes.md
+++ b/content/riak/kv/2.0.4/using/cluster-operations/adding-removing-nodes.md
@@ -136,15 +136,14 @@ Transfers resulting from cluster changes: 51
 If the plan is to your liking, submit the changes by running `riak-admin
 cluster commit`.
 
-<div class="note">
-<div class="title">Note on ring changes</div>
-The algorithm that distributes partitions across the cluster
-during membership changes is non-deterministic. As a result, there is no
-optimal ring. In the event that a plan results in a slightly uneven
-distribution of partitions, the plan can be cleared. Clearing a cluster
-plan with `riak-admin cluster clear` and running `riak-admin cluster
-plan` again will produce a slightly different ring.
-</div>
+{{% note title="Note on ring changes" %}}
+The algorithm that distributes partitions across the cluster during membership
+changes is non-deterministic. As a result, there is no optimal ring. In the
+event that a plan results in a slightly uneven distribution of partitions, the
+plan can be cleared. Clearing a cluster plan with `riak-admin cluster clear`
+and running `riak-admin cluster plan` again will produce a slightly different
+ring.
+{{% /note %}}
 
 ## Removing a Node From a Cluster
 

--- a/content/riak/kv/2.0.4/using/cluster-operations/bucket-types.md
+++ b/content/riak/kv/2.0.4/using/cluster-operations/bucket-types.md
@@ -16,14 +16,13 @@ Buckets are essentially a flat namespace in Riak. They allow the same
 key name to exist in multiple buckets and enable you to apply
 configurations across keys.
 
-<div class="info">
-<div class="title">How Many Buckets Can I Have?</div>
-Buckets come with virtually no cost <em>except for when you modify the
-default bucket properties</em>. Modified bucket properties are gossiped
-around the cluster and therefore add to the amount of data sent around
-the network. In other words, buckets using the <tt>default</tt> bucket
-type are free. More on that in the next section.
-</div>
+{{% note title="How Many Buckets Can I Have?" %}}
+Buckets come with virtually no cost _except for when you modify the default
+bucket properties_. Modified bucket properties are gossiped around the cluster
+and therefore add to the amount of data sent around the network. In other
+words, buckets using the `default` bucket type are free. More on that in the
+next section.
+{{% /note %}}
 
 In Riak versions 2.0 and later, Basho suggests that you [use bucket types](/riak/kv/2.0.4/developing/usage/bucket-types) to namespace and configure all buckets you use. Bucket types have a lower overhead within the cluster than the
 default bucket namespace but require an additional setup step on the

--- a/content/riak/kv/2.0.4/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.0.4/using/cluster-operations/changing-cluster-info.md
@@ -302,9 +302,12 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
-<div class="note"><div class="title">Note</div>
-When using the `riak-admin cluster force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
-</div>
+{{% note title="Note" %}}
+When using the `riak-admin cluster force-replace` command, you will always get
+a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be
+lost`. Since we didn't delete any data files and we are replacing the node
+with itself under a new name, we will not lose any replicas.
+{{% /note %}}
 
 <a id="repeat"></a>
 #### Repeat previous steps on each node

--- a/content/riak/kv/2.0.4/using/cluster-operations/replacing-node.md
+++ b/content/riak/kv/2.0.4/using/cluster-operations/replacing-node.md
@@ -86,12 +86,10 @@ with the [`riak-admin ringready`](/riak/kv/2.0.4/using/admin/riak-admin/#ringrea
 and [`riak-admin member-status`](/riak/kv/2.0.4/using/admin/riak-admin/#member-status)
 commands.
 
-<div class="info">
-<div class="title">Ring Settling</div>
-You'll need to make sure that no other ring changes occur between the
-time when you start the new node and the ring settles with the new IP
-info.
+{{% note title="Ring Settling" %}}
+You'll need to make sure that no other ring changes occur between the time
+when you start the new node and the ring settles with the new IP info.
 
-The ring is considered settled when the new node reports `true` when you
-run the `riak-admin ringready` command.
-</div>
+The ring is considered settled when the new node reports `true` when you run
+the `riak-admin ringready` command.
+{{% /note %}}

--- a/content/riak/kv/2.0.4/using/cluster-operations/strong-consistency.md
+++ b/content/riak/kv/2.0.4/using/cluster-operations/strong-consistency.md
@@ -12,10 +12,14 @@ menu:
 toc: true
 ---
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 ## Monitoring Strong Consistency
 

--- a/content/riak/kv/2.0.4/using/performance.md
+++ b/content/riak/kv/2.0.4/using/performance.md
@@ -26,13 +26,12 @@ changes.
 For performance and tuning recommendations specific to running Riak
 clusters on the Amazon Web Services EC2 environment, see [AWS Performance Tuning](/riak/kv/2.0.4/using/performance/amazon-web-services).
 
-<div class="note">
-<div class="title">Note on other operating systems</div>
+{{% note title="Note on other operating systems" %}}
 Unless otherwise specified, the tunings recommended below are for Linux
-distributions. Users implementing Riak on BSD and Solaris distributions
-can use these tuning recommendations to make analogous changes in those
-operating systems.
-</div>
+distributions. Users implementing Riak on BSD and Solaris distributions can
+use these tuning recommendations to make analogous changes in those operating
+systems.
+{{% /note %}}
 
 ## Storage and File System Tuning
 
@@ -171,12 +170,11 @@ net.ipv4.tcp_tw_reuse = 1
 net.ipv4.tcp_moderate_rcvbuf = 1
 ```
 
-<div class="note">
-<div class="title">Note on system default</div>
+{{% note title="Note on system default" %}}
 In general, these recommended values should be compared with the system
-defaults and only changed if benchmarks or other performance metrics
-indicate that networking is the bottleneck.
-</div>
+defaults and only changed if benchmarks or other performance metrics indicate
+that networking is the bottleneck.
+{{% /note %}}
 
 The following settings are optional, but may improve performance on a
 10Gb network:
@@ -211,11 +209,10 @@ ethtool -K eth0 tso off
 `ethtool` settings can be persisted across reboots by adding the above
 command to the `/etc/rc.local` script.
 
-<div class="info">
-<div class="title">Pro tip</div>
-Tuning these values will be required if they are changed, as they affect
-all network operations.
-</div>
+{{% note title="Pro tip" %}}
+Tuning these values will be required if they are changed, as they affect all
+network operations.
+{{% /note %}}
 
 ## Optional I/O Settings
 

--- a/content/riak/kv/2.0.4/using/performance/amazon-web-services.md
+++ b/content/riak/kv/2.0.4/using/performance/amazon-web-services.md
@@ -54,14 +54,13 @@ indexes are not needed for the application.
 In any case, proper benchmarking and tuning are needed to achieve the
 desired performance.
 
-<div class="info">
-<div class="title">Tip</div>
-Most successful AWS cluster deployments use more EC2 instances than they
-would the same number of physical nodes to compensate for the
-performance variability caused by shared, virtualized resources. Plan to
-have more EC2 instance based nodes than physical server nodes when
-estimating cluster size with respect to node count.
-</div>
+{{% note title="Tip" %}}
+Most successful AWS cluster deployments use more EC2 instances than they would
+the same number of physical nodes to compensate for the performance
+variability caused by shared, virtualized resources. Plan to have more EC2
+instance based nodes than physical server nodes when estimating cluster size
+with respect to node count.
+{{% /note %}}
 
 ## Operating System
 

--- a/content/riak/kv/2.0.4/using/performance/erlang.md
+++ b/content/riak/kv/2.0.4/using/performance/erlang.md
@@ -44,16 +44,15 @@ Erlang parameter | Riak parameter
 [`-env ERL_MAX_ETS_TABLES`](http://learnyousomeerlang.com/ets) | `erlang.max_ets_tables`
 `-name` | `nodename`
 
-<div class="note">
-<div class="title">Note on upgrading to 2.0</div>
-In versions of Riak prior to 2.0, Erlang VM-related parameters were
-specified in a `vm.args` configuration file; in versions 2.0 and later,
-all Erlang-VM-specific parameters are set in the `riak.conf` file. If
-you're upgrading to 2.0 from an earlier version, you can still use your
-old `vm.args` if you wish.  Please note, however, that if you set one or
-more parameters in both `vm.args` and in `riak.conf`, the settings in
-`vm.args` will override those in `riak.conf`.
-</div>
+{{% note title="Note on upgrading to 2.0" %}}
+In versions of Riak prior to 2.0, Erlang VM-related parameters were specified
+in a `vm.args` configuration file; in versions 2.0 and later, all
+Erlang-VM-specific parameters are set in the `riak.conf` file. If you're
+upgrading to 2.0 from an earlier version, you can still use your old `vm.args`
+if you wish.  Please note, however, that if you set one or more parameters in
+both `vm.args` and in `riak.conf`, the settings in `vm.args` will override
+those in `riak.conf`.
+{{% /note %}}
 
 ## SMP
 

--- a/content/riak/kv/2.0.4/using/reference/bucket-types.md
+++ b/content/riak/kv/2.0.4/using/reference/bucket-types.md
@@ -16,14 +16,12 @@ Bucket types allow groups of buckets to share configuration details and
 for Riak users to manage bucket properties more efficiently than in the
 older configuration system based on [bucket properties](/riak/kv/2.0.4/developing/usage/bucket-types/#bucket-properties-and-operations).
 
-<div class="note">
-<div class="title">Important note on cluster downgrades</div>
-If you upgrade a Riak to version 2.0 or later, you can still downgrade
-the cluster to a pre-2.0 version <em>as long as you have not created and
-activated a bucket type in the cluster</em>. Once any bucket type has
-been created and activated, you can no longer downgrade the cluster to a
-pre-2.0 version.
-</div>
+{{% note title="Important note on cluster downgrades" %}}
+If you upgrade a Riak to version 2.0 or later, you can still downgrade the
+cluster to a pre-2.0 version _as long as you have not created and activated a
+bucket type in the cluster_. Once any bucket type has been created and
+activated, you can no longer downgrade the cluster to a pre-2.0 version.
+{{% /note %}}
 
 ## How Bucket Types Work
 
@@ -129,11 +127,11 @@ If creation is successful, you should see the following output:
 type_using_defaults created
 ```
 
-<div class="note">
+{{% note %}}
 The `create` command can be run multiple times prior to a bucket type being
 activated. Riak will persist only those properties contained in the final call
 of the command.
-</div>
+{{% /note %}}
 
 Creating bucket types that assign properties _always_ involves passing
 stringified JSON to the `create` command. One way to do that is to pass
@@ -243,11 +241,22 @@ of the type:
 riak-admin bucket-type update type_to_update '{"props":{ ... }}'
 ```
 
-> **Note**
->
-> Any bucket properties associated with a type can be modified after a bucket is created, with two important exceptions: `consistent` and `datatype`. If a bucket type entails strong consistency (requiring that `consistent` be set to `true`) or is set up as a `map`, `set`, or `counter`, then this will be true of the bucket type once and for all.
->
-> If you need to change one of these properties, it is recommended that you simply create and activate a new bucket type.
+{{% note title="Immutable Configurations" %}}
+Any bucket properties associated with a type can be modified after a bucket is
+created, with three important exceptions:
+
+* `consistent`
+* `datatype`
+* `write_once`
+
+If a bucket type entails strong consistency (requiring that `consistent` be
+set to `true`), is set up as a `map`, `set`, or `counter`, or is defined as a
+write-once  bucket (requiring `write_once` be set to `true`), then this will
+be true of the bucket types.
+
+If you need to change one of these properties, we recommend that you simply
+create and activate a new bucket type.
+{{% /note %}}
 
 ## Buckets as Namespaces
 
@@ -375,12 +384,11 @@ curl http://localhost:8098/types/type1/buckets/my_bucket/keys/my_key
 curl http://localhost:8098/types/type2/buckets/my_bucket/keys/my_key
 ```
 
-<div class="note">
-<div class="title">Note on object location</div>
-In Riak 2.x, <em>all requests</em> must be made to a location specified
-by a bucket type, bucket, and key rather than to a bucket/key pair, as
-in previous versions.
-</div>
+{{% note title="Note on object location" %}}
+In Riak 2.x, _all requests_ must be made to a location specified by a bucket
+type, bucket, and key rather than to a bucket/key pair, as in previous
+versions.
+{{% /note %}}
 
 If requests are made to a bucket/key pair without a specified bucket
 type, `default` will be used in place of a bucket type. The following

--- a/content/riak/kv/2.0.4/using/reference/custom-code.md
+++ b/content/riak/kv/2.0.4/using/reference/custom-code.md
@@ -31,13 +31,13 @@ name must have the same name the module. So if you are given a file named
 If you have been given Erlang code and are expected to compile it for
 your developers, keep the following notes in mind.
 
-<div class="info"><div class="title">Note on the Erlang Compiler</div> You
-must use the Erlang compiler (<tt>erlc</tt>) associated with the Riak
+{{% note title="Note on the Erlang Compiler" %}}
+You must use the Erlang compiler (`erlc`) associated with the Riak
 installation or the version of Erlang used when compiling Riak from source.
-For packaged Riak installations, you can consult Table 1 below for the
-default location of Riak's <tt>erlc</tt> for each supported platform.
-If you compiled from source, use the <tt>erlc</tt> from the Erlang version
-you used to compile Riak.</div>
+For packaged Riak installations, you can consult Table 1 below for the default
+location of Riak's `erlc` for each supported platform. If you compiled from
+source, use the `erlc` from the Erlang version you used to compile Riak.
+{{% /note %}}
 
 <table style="width: 100%; border-spacing: 0px;">
 <tbody>
@@ -88,8 +88,9 @@ and loaded. For our example, we'll use a temporary directory `/tmp/beams`,
 but you should choose a directory for production functions based on your
 own requirements such that they will be available where and when needed.
 
-<div class="info">Ensure that the directory chosen above can be read by
-the <tt>riak</tt> user.</div>
+{{% note %}}
+Ensure that the directory chosen above can be read by the `riak` user.
+{{% /note %}}
 
 Successful compilation will result in a new `.beam` file,
 `validate_json.beam`.
@@ -124,5 +125,7 @@ value store has fully initialized and become available for use.
 This is done with the `riak-admin wait-for-service` command as detailed
 in the [Commands documentation](/riak/kv/2.0.4/using/admin/riak-admin/#wait-for-service).
 
-<div class="note">It is important that you ensure riak_kv is
-active before restarting the next node.</div>
+{{% note %}}
+It is important that you ensure riak_kv is active before restarting the next
+node.
+{{% /note %}}

--- a/content/riak/kv/2.0.4/using/reference/multi-datacenter/comparison.md
+++ b/content/riak/kv/2.0.4/using/reference/multi-datacenter/comparison.md
@@ -18,13 +18,12 @@ aliases:
 This document is a systematic comparison of [Version 2](/riak/kv/2.0.4/using/reference/v2-multi-datacenter) and [Version 3](/riak/kv/2.0.4/using/reference/v3-multi-datacenter) of Riak Enterprise's Multi-Datacenter
 Replication capabilities.
 
-<div class="note">
-<div class="title">Important note on mixing versions</div>
+{{% note title="Important note on mixing versions" %}}
 If you are installing Riak Enterprise anew, you should use version 3
-replication. Under no circumstances should you mix version 2 and version
-3 replication. This comparison is meant only to list improvements
-introduced in version 3.
-</div>
+replication. Under no circumstances should you mix version 2 and version 3
+replication. This comparison is meant only to list improvements introduced in
+version 3.
+{{% /note %}}
 
 ## Version 2
 

--- a/content/riak/kv/2.0.4/using/reference/multi-datacenter/monitoring.md
+++ b/content/riak/kv/2.0.4/using/reference/multi-datacenter/monitoring.md
@@ -34,14 +34,12 @@ replication:
 * Use canary (test) objects to test replication and establish trip times
   from source to sink clusters
 
-<div class="note">
-<div class="title">Note on querying and time windows</div>
-Riak's statistics are calculated over a sliding 60-second window. Each
-time you query the stats interface, each sliding statistic shown is a
-sum or histogram value calculated from the previous 60 seconds of data.
-Because of this, the stats interface should not be queried more than
-once per minute.
-</div>
+{{% note title="Note on querying and time windows" %}}
+Riak's statistics are calculated over a sliding 60-second window. Each time
+you query the stats interface, each sliding statistic shown is a sum or
+histogram value calculated from the previous 60 seconds of data. Because of
+this, the stats interface should not be queried more than once per minute.
+{{% /note %}}
 
 ## Statistics
 

--- a/content/riak/kv/2.0.4/using/reference/statistics-monitoring.md
+++ b/content/riak/kv/2.0.4/using/reference/statistics-monitoring.md
@@ -92,15 +92,13 @@ As with the throughput metrics, keeping an eye on average (and max)
 latency times will help detect usage patterns, and provide advanced
 warnings for potential problems.
 
-<div class="note">
-<div class="title">Note on FSM Time Stats</div>
-FSM Time Stats represent the amount of time in microseconds required
-to traverse the GET or PUT Finite State Machine code, offering a
-picture of general node health. From your application's perspective,
-FSM Time effectively represents experienced latency. Mean, Median, and
-95th-, 99th-, and 100th-percentile (Max) counters are displayed. These
-are one-minute stats.
-</div>
+{{% note title="Note on FSM Time Stats" %}}
+FSM Time Stats represent the amount of time in microseconds required to
+traverse the GET or PUT Finite State Machine code, offering a picture of
+general node health. From your application's perspective, FSM Time effectively
+represents experienced latency. Mean, Median, and 95th-, 99th-, and
+100th-percentile (Max) counters are displayed. These are one-minute stats.
+{{% /note %}}
 
 Metric | Also | Relevance | Latency (in microseconds)
 :------|:-----|:----------|:-------------------------
@@ -191,19 +189,21 @@ reported success with when used for monitoring the operational status of
 their Riak clusters. Community and open source projects are presented
 along with commercial and hosted services.
 
-<div class="note">
-<div class="title">Note on Riak 2.x Statistics Support</div>
-Many of the below tools were either created by third-parties or Basho engineers
-for general usage, and have been passed to the community for further updates. As
-such, many of the below only aggregate the statistics and messages that were
-output by Riak 1.4.x.</br>
+{{% note title="Note on Riak 2.x Statistics Support" %}}
+Many of the below tools were either created by third-parties or Basho
+engineers for general usage, and have been passed to the community for further
+updates. As such, many of the below only aggregate the statistics and messages
+that were output by Riak 1.4.x.
+
 Like all code under [Basho Labs](https://github.com/basho-labs/), the below
-tools are "best effort" and have no dedicated Basho support. We both appreciate
-and need your contribution to keep these tools stable and up to date. Please
-open up a GitHub issue on the repository if you'd like to be a maintainer.</br>
-Look for banners calling out the tools we've verified that support the latest Riak 2.x
-statistics!
-</div>
+tools are "best effort" and have no dedicated Basho support. We both
+appreciate and need your contribution to keep these tools stable and up to
+date. Please open up a GitHub issue on the repository if you'd like to be a
+maintainer.
+
+Look for banners calling out the tools we've verified that support the latest
+Riak 2.x statistics!
+{{% /note %}}
 
 ### Self-Hosted Monitoring Tools
 
@@ -250,9 +250,9 @@ the Riak HTTP [`/stats`](/riak/kv/2.0.4/developing/api/http/status) endpoint is 
 
 #### Nagios
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x.**
+{{% /note %}}
 
 [Nagios](http://www.nagios.org) is a monitoring and alerting solution
 that can provide information on the status of Riak cluster nodes, in
@@ -286,9 +286,9 @@ module specifically designed to read Riak statistics.
 
 #### Zabbix
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [Zabbix](http://www.zabbix.com) is an open-source performance monitoring,
 alerting, and graphing solution that can provide information on the state of
@@ -312,9 +312,9 @@ capacity planning in a Riak cluster environment.
 
 #### New Relic
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [New Relic](http://newrelic.com) is a data analytics and visualization platform
 that can provide information on the current and past states of Riak nodes and

--- a/content/riak/kv/2.0.4/using/reference/v3-multi-datacenter/cascading-writes.md
+++ b/content/riak/kv/2.0.4/using/reference/v3-multi-datacenter/cascading-writes.md
@@ -28,13 +28,11 @@ Riak Enterprise. It will need to be manually enabled on new clusters.
 Cascading realtime requires the `{riak_repl, rtq_meta}` capability to
 function.
 
-<div class="note">
-<div class="title">Note on cascading tracking</div>
-Cascading tracking is a simple list of where an object has been written.
-This works well for most common configurations. Larger installations,
-however, may have writes cascade to clusters to which other clusters
-have already written.
-</div>
+{{% note title="Note on cascading tracking" %}}
+Cascading tracking is a simple list of where an object has been written. This
+works well for most common configurations. Larger installations, however, may
+have writes cascade to clusters to which other clusters have already written.
+{{% /note %}}
 
 
 ```

--- a/content/riak/kv/2.0.4/using/repair-recovery/errors.md
+++ b/content/riak/kv/2.0.4/using/repair-recovery/errors.md
@@ -135,11 +135,10 @@ Riak to explain the correct course of action. For example, the
 `map/reduce` `parse_input` phase will respond like this when it
 encounters an invalid input:
 
-<div class="note">
-<div class="title">Note on inputs</div>
-Inputs must be a binary bucket, a tuple of bucket and key-filters, a
-list of target tuples, a search index, or modfun tuple: `INPUT`.
-</div>
+{{% note title="Note on inputs" %}}
+Inputs must be a binary bucket, a tuple of bucket and key-filters, a list of
+target tuples, a search index, or modfun tuple: `INPUT`.
+{{% /note %}}
 
 For the remaining common error codes, they are often marked by Erlang
 atoms (and quite often wrapped within an `{error,{badmatch,{...` tuple,

--- a/content/riak/kv/2.0.4/using/repair-recovery/failure-recovery.md
+++ b/content/riak/kv/2.0.4/using/repair-recovery/failure-recovery.md
@@ -117,6 +117,8 @@ spreading load and increasing available CPU and IOPS.
 
 See [Changing Cluster Information](/riak/kv/2.1.4/using/cluster-operations/changing-cluster-info/#clusters-from-backups) for instructions on cluster recovery.
 
-<div class="info">
-<div class="title">Tip</div> If you are a licensed Riak Enterprise or CS customer and require assistance or further advice with a cluster recovery, please file a ticket with the <a href="https://help.basho.com">Basho Helpdesk</a>.
-</div>
+{{% note title="Tip" %}}
+If you are a licensed Riak Enterprise or CS customer and require assistance or
+further advice with a cluster recovery, please file a ticket with the
+<a href="https://help.basho.com">Basho Helpdesk</a>.
+{{% /note %}}

--- a/content/riak/kv/2.0.4/using/repair-recovery/repairs.md
+++ b/content/riak/kv/2.0.4/using/repair-recovery/repairs.md
@@ -169,10 +169,11 @@ If there are compaction errors in any of your vnodes, those will be listed in th
 ./442446784738847563128068650529343492278651453440/LOG 
 ```
 
-<div class="note">
-<div class="title">Note</div>
-While corruption on one vnode is not uncommon, corruption in several vnodes very likely means that there is a deeper problem that needs to be address, perhaps on the OS or hardware level.
-</div>
+{{% note title="Note" %}}
+While corruption on one vnode is not uncommon, corruption in several vnodes
+very likely means that there is a deeper problem that needs to be address,
+perhaps on the OS or hardware level.
+{{% /note %}}
 
 ## Healing Corrupted LevelDBs
 

--- a/content/riak/kv/2.0.4/using/running-a-cluster.md
+++ b/content/riak/kv/2.0.4/using/running-a-cluster.md
@@ -171,14 +171,13 @@ the node's ring file.
 riak-admin cluster replace riak@127.0.0.1 riak@192.168.1.10
 ```
 
-<div class="note">
-<div class="title">Note on single nodes</div>
-If a node is started singly using default settings, as you might do when
-you are building your first test environment, you will need to remove
-the ring files from the data directory after you edit your configuration
-files. `riak-admin cluster replace` will not work since the node has not
-been joined to a cluster.
-</div>
+{{% note title="Note on single nodes" %}}
+If a node is started singly using default settings, as you might do when you
+are building your first test environment, you will need to remove the ring
+files from the data directory after you edit your configuration files.
+`riak-admin cluster replace` will not work since the node has not been joined
+to a cluster.
+{{% /note %}}
 
 As with all cluster changes, you need to view the planned changes by
 running `riak-admin cluster plan` and then running `riak-admin cluster

--- a/content/riak/kv/2.0.4/using/security/basics.md
+++ b/content/riak/kv/2.0.4/using/security/basics.md
@@ -444,13 +444,11 @@ Permission | Operation |
 `riak_kv.list_keys` | List all of the keys in a bucket
 `riak_kv.list_buckets` | List all buckets
 
-<div class="note">
-<div class="title">Note on Listing Keys and Buckets</div>
-<code>riak_kv.list_keys</code> and <code>riak_kv.list_buckets</code> are
-both very expensive operations that should be performed very rarely and
-never in production. Access to this functionality should be granted very
-carefully.
-</div>
+{{% note title="Note on Listing Keys and Buckets" %}}
+`riak_kv.list_keys` and `riak_kv.list_buckets` are both very expensive
+operations that should be performed very rarely and never in production.
+Access to this functionality should be granted very carefully.
+{{% /note %}}
 
 If you'd like to create, for example, a `client` account that is
 allowed only to run `GET` and `PUT` requests on all buckets:
@@ -631,23 +629,20 @@ The following command would remove the source for `riakuser` on
 riak-admin security del-source riakuser 127.0.0.1/32
 ```
 
-<div class="note">
-<div class="title">Note on Removing Sources</div>
-If you apply a security source both to <code>all</code> and to specific
-users and then wish to remove that source, you will need to do so in
-separate steps. The <code>riak-admin security del-source all ...</code>
-command by itself is not sufficient.
+{{% note title="Note on Removing Sources" %}}
+If you apply a security source both to `all` and to specific users and then
+wish to remove that source, you will need to do so in separate steps. The
+`riak-admin security del-source all ...` command by itself is not sufficient.
 
-For example, if you have assigned the source <code>password</code> to
-both <code>all</code> and to the user <code>riakuser</code> on the
-network <code>127.0.0.1/32</code>, the following two-step process would
-be required to fully remove the source:
+For example, if you have assigned the source `password` to both `all` and to
+the user `riakuser` on the network `127.0.0.1/32`, the following two-step
+process would be required to fully remove the source:
 
 ```bash
 riak-admin security del-source all 127.0.0.1/32 password
 riak-admin security del-source riakuser 127.0.0.1/32 password
 ```
-</div>
+{{% /note %}}
 
 ### More Usage Examples
 

--- a/content/riak/kv/2.0.4/using/security/managing-sources.md
+++ b/content/riak/kv/2.0.4/using/security/managing-sources.md
@@ -29,11 +29,10 @@ The examples below will assume that the network in question is
 [created](/riak/kv/2.0.4/using/security/basics/#user-management) and that
 security has been [enabled](/riak/kv/2.0.4/using/security/basics/#the-basics).
 
-<div class="note">
-<div class="title">Note on SSL connections</div>
-If you use <em>any</em> of the aforementioned security sources, even
-<code>trust</code>, you will need to do so via a secure SSL connection.
-</div>
+{{% note title="Note on SSL connections" %}}
+If you use _any_ of the aforementioned security sources, even `trust`, you
+will need to do so via a secure SSL connection.
+{{% /note %}}
 
 ## Trust-based Authentication
 

--- a/content/riak/kv/2.0.5/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.0.5/configuring/load-balancing-proxy.md
@@ -184,15 +184,13 @@ act as a front-end proxy to a 5-node Riak cluster.
 This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
-<div class="note">
-<div class="title">Nginx version notes</div>
-This example configuration was verified on <strong>Nginx version
-1.2.3</strong>. Please be aware that earlier versions of Nginx did not
-support any HTTP 1.1 semantics for upstream communication to backends.
-You should carefully examine this configuration and make changes
-appropriate to your specific environment before attempting to use
-it
-</div>
+{{% note title="Nginx version notes" %}}
+This example configuration was verified on **Nginx version 1.2.3**. Please be
+aware that earlier versions of Nginx did not support any HTTP 1.1 semantics
+for upstream communication to backends. You should carefully examine this
+configuration and make changes appropriate to your specific environment before
+attempting to use it
+{{% /note %}}
 
 Here is an example `nginx.conf` file:
 
@@ -250,13 +248,12 @@ server {
 }
 ```
 
-<div class="note">
-<div class="title">Note on access controls</div>
-Even when filtering and limiting requests to GETs only as done in the
-example, you should strongly consider additional access controls beyond
-what Nginx can provide directly, such as specific firewall rules to
-limit inbound connections to trusted sources.
-</div>
+{{% note title="Note on access controls" %}}
+Even when filtering and limiting requests to GETs only as done in the example,
+you should strongly consider additional access controls beyond what Nginx can
+provide directly, such as specific firewall rules to limit inbound connections
+to trusted sources.
+{{% /note %}}
 
 ### Querying Secondary Indexes Over HTTP
 

--- a/content/riak/kv/2.0.5/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.0.5/configuring/load-balancing-proxy.md
@@ -185,7 +185,7 @@ This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
 <div class="note">
-<div class="title">Nginx version notes</div
+<div class="title">Nginx version notes</div>
 This example configuration was verified on <strong>Nginx version
 1.2.3</strong>. Please be aware that earlier versions of Nginx did not
 support any HTTP 1.1 semantics for upstream communication to backends.

--- a/content/riak/kv/2.0.5/configuring/v2-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.0.5/configuring/v2-multi-datacenter/ssl.md
@@ -64,8 +64,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -73,7 +72,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.0.5/configuring/v3-multi-datacenter/quick-start.md
+++ b/content/riak/kv/2.0.5/configuring/v3-multi-datacenter/quick-start.md
@@ -137,13 +137,11 @@ Sink             Cluster Name         <Ctrl-Pid>      [Members]
 Cluster1          Cluster1            <0.4456.0>      ["10.60.67.149:9080"] (via 10.60.67.149:9080)
 ```
 
-<div class="note">
-<div class="title">Note on connections</div>
-At this point, if you do not have connections, replication will not
-work. Check your IP bindings by running <code>netstat -a</code> on all
-nodes. You should see <code>*:9080 LISTENING</code>. If not, you have
-configuration problems.
-</div>
+{{% note title="Note on connections" %}}
+At this point, if you do not have connections, replication will not work.
+Check your IP bindings by running `netstat -a` on all nodes. You should see
+`*:9080 LISTENING`. If not, you have configuration problems.
+{{% /note %}}
 
 ### Enable Realtime Replication
 

--- a/content/riak/kv/2.0.5/configuring/v3-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.0.5/configuring/v3-multi-datacenter/ssl.md
@@ -54,12 +54,11 @@ the `riak-core` section of [`advanced.confg`][config reference#advanced.config]:
 The `cacertsdir` is a directory containing all the CA certificates
 needed to verify the CA chain back to the root.
 
-<div class="note">
-<div class="title">Note on configuration</div>
+{{% note title="Note on configuration" %}}
 In Version 3 replication, the SSL settings need to be placed in the
-<code>riak-core</code> section of <code>advanced.config</code> as opposed to
-the <code>riak-repl</code> section used by Version 2 replication.
-</div>
+`riak-core` section of `advanced.config` as opposed to the `riak-repl` section
+used by Version 2 replication.
+{{% /note %}}
 
 ## Verifying Peer Certificates
 
@@ -80,8 +79,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -89,7 +87,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.0.5/developing/api/http/fetch-object.md
+++ b/content/riak/kv/2.0.5/developing/api/http/fetch-object.md
@@ -79,22 +79,23 @@ datetime format
 The body of the response will be the contents of the object except when siblings
 are present.
 
-<div class="note"><div class="title">Siblings</div>
-<p>When `allow_mult` is set to true in the bucket properties, concurrent updates
-are allowed to create "sibling" objects, meaning that the object has any number
-of different values that are related to one another by the vector clock.  This
-allows your application to use its own conflict resolution technique.</p>
+{{% note title="Siblings" %}}
+When `allow_mult` is set to true in the bucket properties, concurrent updates
+are allowed to create "sibling" objects, meaning that the object has any
+number of different values that are related to one another by the vector
+clock.  This allows your application to use its own conflict resolution
+technique.
 
-<p>An object with multiple sibling values will result in a `300 Multiple
-Choices` response.  If the `Accept` header prefers `multipart/mixed`, all
-siblings will be returned in a single request as sections of the
-`multipart/mixed` response body.  Otherwise, a list of "vtags" will be given in
-a simple text format. You can request individual siblings by adding the `vtag`
-query parameter. Scroll down to the 'manually requesting siblings' example below for more information.</p>
+An object with multiple sibling values will result in a `300 Multiple Choices`
+response.  If the `Accept` header prefers `multipart/mixed`, all siblings will
+be returned in a single request as sections of the `multipart/mixed` response
+body.  Otherwise, a list of "vtags" will be given in a simple text format. You
+can request individual siblings by adding the `vtag` query parameter. Scroll
+down to the 'manually requesting siblings' example below for more information.
 
-<p>To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
-given in the response.</p>
-</div>
+To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
+given in the response.
+{{% /note %}}
 
 ## Simple Example
 

--- a/content/riak/kv/2.0.5/developing/api/http/link-walking.md
+++ b/content/riak/kv/2.0.5/developing/api/http/link-walking.md
@@ -26,22 +26,19 @@ is a special case of [MapReduce](/riak/kv/2.0.5/developing/usage/mapreduce), and
 GET /buckets/bucket/keys/key/[bucket],[tag],[keep]
 ```
 
-<div class="info"><div class="title">Link filters</div>
-<p>A link filter within the request URL is made of three parts, separated by
-commas:</p>
+{{% note title="Link filters" %}}
+A link filter within the request URL is made of three parts, separated by
+commas:
 
-<ul>
-<li>Bucket - a bucket name to limit the links to</li>
-<li>Tag - a "riaktag" to limit the links to</li>
-<li>Keep - 0 or 1, whether to return results from this phase</li>
-</ul>
+* Bucket - a bucket name to limit the links to
+* Tag - a "riaktag" to limit the links to
+* Keep - 0 or 1, whether to return results from this phase
 
-<p>Any of the three parts may be replaced with <code>_</code> (underscore),
-signifying that any value is valid. Multiple phases of links can be followed by
-adding additional path segments to the URL, separating the link filters by
-slashes. The final phase in the link-walking query implicitly returns its
-results.</p>
-</div>
+Any of the three parts may be replaced with `_` (underscore), signifying that
+any value is valid. Multiple phases of links can be followed by adding
+additional path segments to the URL, separating the link filters by slashes.
+The final phase in the link-walking query implicitly returns its results.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.0.5/developing/api/http/list-buckets.md
+++ b/content/riak/kv/2.0.5/developing/api/http/list-buckets.md
@@ -17,10 +17,10 @@ aliases:
 
 Lists all known buckets (ones that have keys stored in them).
 
-<div class="note"><div class="title">Not for production use</div>
+{{% note title="Not for production use" %}}
 Similar to the list keys operation, this requires traversing all keys stored
 in the cluster and should not be used in production.
-</div>
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.5/developing/api/http/list-keys.md
+++ b/content/riak/kv/2.0.5/developing/api/http/list-keys.md
@@ -17,12 +17,10 @@ aliases:
 
 Lists keys in a bucket.
 
-<div class="note">
-<div class="title">Not for production use</div>
-
-This operation requires traversing all keys stored in the cluster and should not be used in production.
-
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.5/developing/api/http/set-bucket-props.md
+++ b/content/riak/kv/2.0.5/developing/api/http/set-bucket-props.md
@@ -50,14 +50,12 @@ the bucket
 
 Other properties do exist but are not commonly modified.
 
-<div class="note">
-<div class="title">Property types</div>
-<p>Make sure you use the proper types for attributes like <strong>n_val</strong>
-and <strong>allow_mult</strong>. If you use strings instead of integers and
-booleans respectively, you may see some odd errors in your logs, saying
-something like
-<code>"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"</code>.</p>
-</div>
+{{% note title="Property types" %}}
+Make sure you use the proper types for attributes like **n_val** and
+**allow_mult**. If you use strings instead of integers and booleans
+respectively, you may see some odd errors in your logs, saying something like
+`"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"`.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.0.5/developing/api/protocol-buffers.md
+++ b/content/riak/kv/2.0.5/developing/api/protocol-buffers.md
@@ -106,12 +106,11 @@ Code | Message |
 254 | `RpbAuthResp` |
 255 | `RpbStartTls` |
 
-<div class="info">
-<div class="title">Message Definitions</div>
-All Protocol Buffers messages are defined in the <code>riak.proto</code>
-and other <code>.proto</code> files in the <code>/src</code> directory
-of the <a href="https://github.com/basho/riak_pb">RiakPB</a> project.
-</div>
+{{% note title="Message Definitions" %}}
+All Protocol Buffers messages are defined in the `riak.proto` and other
+`.proto` files in the `/src` directory of the
+<a href="https://github.com/basho/riak_pb">RiakPB</a> project.
+{{% /note %}}
 
 ### Error Response
 

--- a/content/riak/kv/2.0.5/developing/api/protocol-buffers/fetch-object.md
+++ b/content/riak/kv/2.0.5/developing/api/protocol-buffers/fetch-object.md
@@ -137,14 +137,12 @@ of the following optional parameters:
 * `deleted` --- Whether the object has been deleted (i.e. whether a
   tombstone for the object has been found under the specified key)
 
-<div class="note">
-<div class="title">Note on missing keys</div>
-Remember: if a key is not stored in Riak, an <code>RpbGetResp</code>
-response without the <code>content</code> and <code>vclock</code> fields
-will be returned. This should be mapped to whatever convention the
-client language uses to return not found. The Erlang client, for
-example, returns the atom <code>{error, notfound}</code>.
-</div>
+{{% note title="Note on missing keys" %}}
+Remember: if a key is not stored in Riak, an `RpbGetResp` response without the
+`content` and `vclock` fields will be returned. This should be mapped to
+whatever convention the client language uses to return not found. The Erlang
+client, for example, returns the atom `{error, notfound}`.
+{{% /note %}}
 
 ## Example
 

--- a/content/riak/kv/2.0.5/developing/api/protocol-buffers/get-client-id.md
+++ b/content/riak/kv/2.0.5/developing/api/protocol-buffers/get-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.0.5/dev/references/protocol-buffers/get-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Get the client id used for this connection. Client ids are used for
 conflict resolution and each unique actor in the system should be

--- a/content/riak/kv/2.0.5/developing/api/protocol-buffers/list-buckets.md
+++ b/content/riak/kv/2.0.5/developing/api/protocol-buffers/list-buckets.md
@@ -17,12 +17,10 @@ aliases:
 
 List all of the bucket names available.
 
-<div class="note">
-<div class="title">Caution</div>
-
-This call can be expensive for the server. Do not use in
-performance-sensitive code.
-</div>
+{{% note title="Caution" %}}
+This call can be expensive for the server. Do not use in performance-sensitive
+code.
+{{% /note %}}
 
 
 ## Request

--- a/content/riak/kv/2.0.5/developing/api/protocol-buffers/list-keys.md
+++ b/content/riak/kv/2.0.5/developing/api/protocol-buffers/list-keys.md
@@ -18,11 +18,10 @@ aliases:
 List all of the keys in a bucket. This is a streaming call, with
 multiple response messages sent for each request.
 
-<div class="note">
-<div class="title">Not for production use</div>
-This operation requires traversing all keys stored in the cluster and
-should not be used in production.
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.5/developing/api/protocol-buffers/set-client-id.md
+++ b/content/riak/kv/2.0.5/developing/api/protocol-buffers/set-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.0.5/dev/references/protocol-buffers/set-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Set the client ID for this connection. A library may want to set the
 client ID if it has a good way to uniquely identify actors across

--- a/content/riak/kv/2.0.5/developing/app-guide/advanced-mapreduce.md
+++ b/content/riak/kv/2.0.5/developing/app-guide/advanced-mapreduce.md
@@ -253,10 +253,10 @@ curl -XPOST localhost:8098/mapred \
 
 The result should be a JSON map of bucket and key names expressed as key/value pairs.
 
-<div class="info">
-Be sure to install the MapReduce function as described above on all of
-the nodes in your cluster to ensure proper operation.
-</div>
+{{% note %}}
+Be sure to install the MapReduce function as described above on all of the
+nodes in your cluster to ensure proper operation.
+{{% /note %}}
 
 
 ## Phase functions
@@ -481,27 +481,25 @@ takes any of the following forms:
 * `{jsanon, {Bucket, Key}}` where the object at `{Bucket, Key}` contains
   the source for an anonymous Javascript function
 
-<div class="info">
-<div class="title">qfun Note</div>
-Using `qfun` in compiled applications can be a fragile
-operation. Please keep the following points in mind.
+{{% note title="qfun Note" %}}
+Using `qfun` in compiled applications can be a fragile operation. Please keep
+the following points in mind.
 
-1. The module in which the function is defined must be present and
-**exactly the same version** on both the client and Riak nodes.
+1. The module in which the function is defined must be present and **exactly
+   the same version** on both the client and Riak nodes.
 
-2. Any modules and functions used by this function (or any function in
-the resulting call stack) must also be present on the Riak nodes.
+2. Any modules and functions used by this function (or any function in the
+   resulting call stack) must also be present on the Riak nodes.
 
-Errors about failures to ensure both 1 and 2 are often surprising,
-usually seen as opaque **missing-function** or **function-clause**
-errors. Especially in the case of differing module versions, this can be
-difficult to diagnose without expecting the issue and knowing of
-`Module:info/0`.
+Errors about failures to ensure both 1 and 2 are often surprising, usually
+seen as opaque **missing-function** or **function-clause** errors. Especially
+in the case of differing module versions, this can be difficult to diagnose
+without expecting the issue and knowing of `Module:info/0`.
 
-When using the Erlang shell, anonymous MapReduce functions can be
-defined and sent to Riak instead of deploying them to all servers in
-advance, but condition #2 above still holds.
-</div>
+When using the Erlang shell, anonymous MapReduce functions can be defined and
+sent to Riak instead of deploying them to all servers in advance, but
+condition #2 above still holds.
+{{% /note %}}
 
 Link phases are expressed in the following form:
 

--- a/content/riak/kv/2.0.5/developing/app-guide/replication-properties.md
+++ b/content/riak/kv/2.0.5/developing/app-guide/replication-properties.md
@@ -154,15 +154,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -330,15 +328,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -355,14 +352,12 @@ documentation on [Bitcask](/riak/kv/2.0.5/setup/planning/backend/bitcask), [Leve
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.0.5/developing/client-libraries.md
+++ b/content/riak/kv/2.0.5/developing/client-libraries.md
@@ -49,12 +49,11 @@ developing something that you wish to see added to this list, please
 fork the [Riak Docs repo on GitHub](https://github.com/basho/basho_docs)
 and send us a pull request.
 
-<div class="note">
-<div class="title">Note on community-produced libraries</div>
-All of these projects and libraries are at various stages of
-completeness and may not suit your application's needs based on their
-level of maturity and activity.
-</div>
+{{% note title="Note on community-produced libraries" %}}
+All of these projects and libraries are at various stages of completeness and
+may not suit your application's needs based on their level of maturity and
+activity.
+{{% /note %}}
 
 ### Client Libraries and Frameworks
 

--- a/content/riak/kv/2.0.5/developing/getting-started/csharp.md
+++ b/content/riak/kv/2.0.5/developing/getting-started/csharp.md
@@ -25,10 +25,12 @@ To try this flavor of Riak, a working installation of the .NET Framework or Mono
 
 Install [the Riak .NET Client](https://github.com/basho/riak-dotnet-client/wiki/Installation) through [NuGet](http://nuget.org/packages/RiakClient) or the Visual Studio NuGet package manager.
 
-<div class="note">
-<div class="title">Configuring for a remote cluster</div>
-By default, the Riak .NET Client will add a section to your `app.config` file for a four node local cluster. If you are using a remote cluster, open up `app.config` and change the `hostAddress` values to point to nodes in your remote cluster.
-</div>
+{{% note title="Configuring for a remote cluster" %}}
+By default, the Riak .NET Client will add a section to your `app.config` file
+for a four node local cluster. If you are using a remote cluster, open up
+`app.config` and change the `hostAddress` values to point to nodes in your
+remote cluster.
+{{% /note %}}
 
 ### Connecting to Riak
 

--- a/content/riak/kv/2.0.5/developing/getting-started/csharp/object-modeling.md
+++ b/content/riak/kv/2.0.5/developing/getting-started/csharp/object-modeling.md
@@ -64,12 +64,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially when many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially when many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.5/developing/getting-started/erlang/object-modeling.md
+++ b/content/riak/kv/2.0.5/developing/getting-started/erlang/object-modeling.md
@@ -18,14 +18,13 @@ aliases:
 
 To get started, let's create the records that we'll be using.
 
-<div class="note">
-<div class="title">Code Download</div>
+{{% note title="Code Download" %}}
 You can also download the code for this chapter at
 [Github](https://github.com/basho/taste-of-riak/tree/am-dem-erlang-modules/erlang/Ch03-Msgy-Schema).
 
-The Github version includes Erlang type specifications which have been
-omitted here for brevity.
-</div>
+The Github version includes Erlang type specifications which have been omitted
+here for brevity.
+{{% /note %}}
 
 
 ```erlang
@@ -91,13 +90,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.5/developing/getting-started/golang/object-modeling.md
+++ b/content/riak/kv/2.0.5/developing/getting-started/golang/object-modeling.md
@@ -182,13 +182,11 @@ users and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.5/developing/getting-started/java.md
+++ b/content/riak/kv/2.0.5/developing/getting-started/java.md
@@ -40,13 +40,11 @@ Next, download
 [`TasteOfRiak.java`](https://github.com/basho/basho_docs/raw/master/extras/code-examples/TasteOfRiak.java)
 source code for this tutorial, and save it to your working directory.
 
-<div class="note">
-<div class="title">Configuring for a local cluster</div>
-The `TasteOfRiak.java` file that you downloaded is set up to communicate
-with a 1-node Riak cluster listening on `localhost` port 10017. We
-recommend modifying the connection info directly within the
-`setUpCluster()` method.
-</div>
+{{% note title="Configuring for a local cluster" %}}
+The `TasteOfRiak.java` file that you downloaded is set up to communicate with
+a 1-node Riak cluster listening on `localhost` port 10017. We recommend
+modifying the connection info directly within the `setUpCluster()` method.
+{{% /note %}}
 
 If you execute the `TasteOfRiak.java` file within your IDE, you should
 see the following:

--- a/content/riak/kv/2.0.5/developing/getting-started/java/object-modeling.md
+++ b/content/riak/kv/2.0.5/developing/getting-started/java/object-modeling.md
@@ -157,12 +157,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.5/developing/getting-started/nodejs/object-modeling.md
+++ b/content/riak/kv/2.0.5/developing/getting-started/nodejs/object-modeling.md
@@ -73,12 +73,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_SENT_2014-03-06` or `marketing_group_INBOX_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.5/developing/getting-started/python/object-modeling.md
+++ b/content/riak/kv/2.0.5/developing/getting-started/python/object-modeling.md
@@ -83,13 +83,11 @@ users, and `<groupname>_<type>_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-06`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.5/developing/getting-started/ruby/object-modeling.md
+++ b/content/riak/kv/2.0.5/developing/getting-started/ruby/object-modeling.md
@@ -94,13 +94,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.5/developing/usage/conflict-resolution.md
+++ b/content/riak/kv/2.0.5/developing/usage/conflict-resolution.md
@@ -25,16 +25,15 @@ If you are using Riak in an [eventually consistent](/riak/kv/2.0.5/learn/concept
 unavoidable. Often, Riak can resolve these conflicts on its own
 internally if you use causal context, i.e. [vector clocks](/riak/kv/2.0.5/learn/concepts/causal-context#vector-clocks) or [dotted version vectors](/riak/kv/2.0.5/learn/concepts/causal-context#dotted-version-vectors), when updating objects. Instructions on this can be found in the section [below](#siblings).
 
-<div class="note">
-<div class="title">Important note on terminology</div>
-In versions of Riak prior to 2.0, vector clocks were the only causal
-context mechanism available in Riak, which changed with the introduction
-of dotted version vectors in 2.0. Please note that you may frequent find
-terminology in client library APIs, internal Basho documentation, and
-more that uses the term "vector clock" interchangeably with causal
-context in general. Riak's HTTP API still uses a `X-Riak-Vclock` header,
-for example, even if you are using dotted version vectors.
-</div>
+{{% note title="Important note on terminology" %}}
+In versions of Riak prior to 2.0, vector clocks were the only causal context
+mechanism available in Riak, which changed with the introduction of dotted
+version vectors in 2.0. Please note that you may frequent find terminology in
+client library APIs, internal Basho documentation, and more that uses the term
+"vector clock" interchangeably with causal context in general. Riak's HTTP API
+still uses a `X-Riak-Vclock` header, for example, even if you are using dotted
+version vectors.
+{{% /note %}}
 
 But even when you use causal context, Riak cannot always decide which
 value is most causally recent, especially in cases involving concurrent
@@ -118,12 +117,10 @@ will be no concurrent updates. If you are storing immutable data in
 which each object is guaranteed to have its own key or engaging in
 operations related to bulk loading, you should consider LWW.
 
-<div class="note">
-<div class="title">Undefined behavior warning</div>
-Setting both <code>allow_mult</code> and <code>last_write_wins</code> to
-<code>true</code> necessarily leads to unpredictable behavior and should
-always be avoided.
-</div>
+{{% note title="Undefined behavior warning" %}}
+Setting both `allow_mult` and `last_write_wins` to `true` necessarily leads to
+unpredictable behavior and should always be avoided.
+{{% /note %}}
 
 ### Resolve Conflicts on the Application Side
 
@@ -602,13 +599,12 @@ X-Riak-Vclock: a85hYGBgzGDKBVIcR4M2cgczH7HPYEpkzGNlsP/VfYYvCwA=
 # accompany the write for Riak to be able to use the vector clock
 ```
 
-<div class="note">
-<div class="title">Concurrent conflict resolution</div>
+{{% note title="Concurrent conflict resolution" %}}
 It should be noted that it is possible to have two clients that are
 simultaneously engaging in conflict resolution. To avoid a pathological
-divergence, you should be sure to limit the number of reconciliations
-and fail once that limit has been exceeded.
-</div>
+divergence, you should be sure to limit the number of reconciliations and fail
+once that limit has been exceeded.
+{{% /note %}}
 
 ### Sibling Explosion
 
@@ -650,13 +646,10 @@ better performance. Some use cases where you might want to use
 `last_write_wins` include caching, session storage, and insert-only
 (no updates).
 
-<div class="note">
-<div class="title">Note on combining <code>allow_mult</code> and
-<code>last_write_wins</code></div>
-The combination of setting both the <code>allow_mult</code> and
-<code>last_write_wins</code> properties to <code>true</code> leads to
-undefined behavior and should not be used.
-</div>
+{{% note title="Note on combining `allow_mult` and `last_write_wins`" %}}
+The combination of setting both the `allow_mult` and `last_write_wins`
+properties to `true` leads to undefined behavior and should not be used.
+{{% /note %}}
 
 ## Vector Clock Pruning
 

--- a/content/riak/kv/2.0.5/developing/usage/mapreduce.md
+++ b/content/riak/kv/2.0.5/developing/usage/mapreduce.md
@@ -15,16 +15,14 @@ aliases:
   - /riak/kv/2.0.5/dev/using/mapreduce
 ---
 
-<div class="note">
-<div class="title">Use MapReduce sparingly</div>
-In Riak, MapReduce is the primary method for non-primary-key-based
-querying. Although useful for a limited range of purposes, such as batch
-processing jobs, MapReduce operations can be very computationally
-expensive, sometimes to the extent that they can degrade performance in
-production clusters operating under load. Thus, we recommend running
-MapReduce operations in a controlled, rate-limited fashion and never for
-realtime querying purposes.
-</div>
+{{% note title="Use MapReduce sparingly" %}}
+In Riak, MapReduce is the primary method for non-primary-key-based querying.
+Although useful for a limited range of purposes, such as batch processing
+jobs, MapReduce operations can be very computationally expensive, sometimes to
+the extent that they can degrade performance in production clusters operating
+under load. Thus, we recommend running MapReduce operations in a controlled,
+rate-limited fashion and never for realtime querying purposes.
+{{% /note %}}
 
 MapReduce (M/R) is a technique for dividing data processing work across
 a distributed system. It takes advantage of the parallel processing

--- a/content/riak/kv/2.0.5/developing/usage/reading-objects.md
+++ b/content/riak/kv/2.0.5/developing/usage/reading-objects.md
@@ -197,12 +197,10 @@ The most common error code:
 
 * `404 Not Found`
 
-<div class="note">
-<div class="title">Note</div>
-If you're using a Riak client instead of HTTP, these responses will vary
-a great deal, so make sure to check the documentation for your specific
-client.
-</div>
+{{% note title="Note" %}}
+If you're using a Riak client instead of HTTP, these responses will vary a
+great deal, so make sure to check the documentation for your specific client.
+{{% /note %}}
 
 ## No Object Stored
 

--- a/content/riak/kv/2.0.5/developing/usage/replication.md
+++ b/content/riak/kv/2.0.5/developing/usage/replication.md
@@ -45,18 +45,17 @@ is one of the features that differentiates Riak from other databases.
 At the bottom of the page, you'll find a [screencast](/riak/kv/2.0.5/developing/app-guide/replication-properties#screencast) that briefly explains how to adjust your
 replication levels to match your application and business needs.
 
-<div class="note">
-<div class="title">Note on strong consistency</div>
+{{% note title="Note on strong consistency" %}}
 An option introduced in Riak version 2.0 is to use Riak as a
-<a href="/riak/kv/2.0.5/using/reference/strong-consistency/">strongly consistent</a>
-system for data in specified buckets. Using Riak in this way is
-fundamentally different from adjusting replication properties and
-fine-tuning the availability/consistency trade-off, as it sacrifices
-<em>all</em> availability guarantees when necessary. Therefore, you
-should consult the <a href="/riak/kv/2.0.5/developing/app-guide/strong-consistency">Using
-Strong Consistency</a> documentation, as this option will not be covered
-in this tutorial.
-</div>
+<a href="/riak/kv/2.0.5/using/reference/strong-consistency/">strongly
+consistent</a> system for data in specified buckets. Using Riak in this way is
+fundamentally different from adjusting replication properties and fine-tuning
+the availability/consistency trade-off, as it sacrifices _all_ availability
+guarantees when necessary. Therefore, you should consult the
+<a href="/riak/kv/2.0.5/developing/app-guide/strong-consistency">Using Strong
+Consistency</a> documentation, as this option will not be covered in this
+tutorial.
+{{% /note %}}
 
 ## How Replication Properties Work
 
@@ -163,15 +162,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -339,15 +336,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -364,14 +360,12 @@ documentation on [Bitcask][plan backend bitcask], [LevelDB][plan backend leveldb
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.0.5/developing/usage/security/erlang.md
+++ b/content/riak/kv/2.0.5/developing/usage/security/erlang.md
@@ -24,13 +24,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.0.5/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Erlang Client Basics
 

--- a/content/riak/kv/2.0.5/developing/usage/security/java.md
+++ b/content/riak/kv/2.0.5/developing/usage/security/java.md
@@ -23,13 +23,11 @@ If you are using [trust-](/riak/kv/2.0.5/using/security/managing-sources/#trust-
 security setup described [below](#java-client-basics). [Certificate](/riak/kv/2.0.5/using/security/managing-sources/#certificate-based-authentication)-based authentication is not
 yet supported in the Java client.
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Java Client Basics
 

--- a/content/riak/kv/2.0.5/developing/usage/security/python.md
+++ b/content/riak/kv/2.0.5/developing/usage/security/python.md
@@ -25,13 +25,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.0.5/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## OpenSSL Versions
 

--- a/content/riak/kv/2.0.5/developing/usage/security/ruby.md
+++ b/content/riak/kv/2.0.5/developing/usage/security/ruby.md
@@ -25,13 +25,11 @@ can use the security setup described in the [Ruby Client Basics](#ruby-client-ba
 in a [later section](#password-based-authentication), while [certificate](/riak/kv/2.0.5/using/security/managing-sources/#certificate-based-authentication)-based authentication
 is covered [further down](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Ruby Client Basics
 

--- a/content/riak/kv/2.0.5/introduction.md
+++ b/content/riak/kv/2.0.5/introduction.md
@@ -185,14 +185,12 @@ Based on Basho's [Cuttlefish](https://github.com/basho/cuttlefish)
 project, the new system is much simpler, leaving behind the Erlang
 syntax required in `app.config`.
 
-<div class="note">
-<div class="title">Note on upgrading</div>
-Version 2.0 will support both the old and the new configuration system,
-in case you're upgrading. Please note, however, that if you use both
-systems side by side, all settings from the older,
-`app.config`/`vm.args`-based system will override any settings from the
-new system.
-</div>
+{{% note title="Note on upgrading" %}}
+Version 2.0 will support both the old and the new configuration system, in
+case you're upgrading. Please note, however, that if you use both systems side
+by side, all settings from the older, `app.config`/`vm.args`-based system will
+override any settings from the new system.
+{{% /note %}}
 
 #### Relevant Docs
 

--- a/content/riak/kv/2.0.5/learn/concepts/strong-consistency.md
+++ b/content/riak/kv/2.0.5/learn/concepts/strong-consistency.md
@@ -18,10 +18,14 @@ aliases:
 [usage bucket types]: /riak/kv/2.0.5/developing/usage/bucket-types
 [concept eventual consistency]: /riak/kv/2.0.5/learn/concepts/eventual-consistency
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 Riak was originally designed as an [eventually consistent](/riak/kv/2.0.5/learn/concepts/eventual-consistency) system, fundamentally geared toward providing partition
 (i.e. fault) tolerance and high read and write availability.

--- a/content/riak/kv/2.0.5/setup/downgrade.md
+++ b/content/riak/kv/2.0.5/setup/downgrade.md
@@ -37,13 +37,13 @@ additional steps to be performed before, during, and after the upgrade
 on on each node.  These steps are related to changes or new features
 that are not present in the downgraded version.
 
-<div class="note">
-<div class="title">A Note About the Following Instructions</div>
-The below instructions describe the procedures required for a single
-feature release version downgrade. In a downgrade between two feature
-release versions, the steps for the in-between version must also be
-performed. For example, a downgrade from 1.4 to 1.2 requires that the
-downgrade steps for both 1.4 and 1.3 are performed.  </div>
+{{% note title="A Note About the Following Instructions" %}}
+The below instructions describe the procedures required for a single feature
+release version downgrade. In a downgrade between two feature release
+versions, the steps for the in-between version must also be performed. For
+example, a downgrade from 1.4 to 1.2 requires that the downgrade steps for
+both 1.4 and 1.3 are performed.
+{{% /note %}}
 
 ## General Guidelines
 

--- a/content/riak/kv/2.0.5/setup/installing/amazon-web-services.md
+++ b/content/riak/kv/2.0.5/setup/installing/amazon-web-services.md
@@ -62,10 +62,10 @@ You will need need to launch at least 3 instances to form a Riak cluster.  When 
 
 You can find more information on connecting to an instance on the official [Amazon EC2 instance guide](http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/AccessingInstances.html).
 
-<div class="note">
-<div class="title">Note</div>
-The following clustering setup will <em>not</em> be resilient to instance restarts unless deployed in Amazon VPC.
-</div>
+{{% note title="Note" %}}
+The following clustering setup will _not_ be resilient to instance restarts
+unless deployed in Amazon VPC.
+{{% /note %}}
 
 1. On the first node, obtain the internal IP address:
 

--- a/content/riak/kv/2.0.5/setup/installing/mac-osx.md
+++ b/content/riak/kv/2.0.5/setup/installing/mac-osx.md
@@ -52,13 +52,12 @@ directory and execute `bin/riak start` to start the Riak node.
 
 ## Homebrew
 
-<div class="note">
-<div class="title">Warning: Homebrew not always up to date</div>
-Homebrew's Riak recipe is community supported, and thus is not always up
-to date with the latest Riak package. Please ensure that the current
-recipe is using the latest supported code (and don't be afraid to update
-it if it's not).
-</div>
+{{% note title="Warning: Homebrew not always up to date" %}}
+Homebrew's Riak recipe is community supported, and thus is not always up to
+date with the latest Riak package. Please ensure that the current recipe is
+using the latest supported code (and don't be afraid to update it if it's
+not).
+{{% /note %}}
 
 Installing Riak 2.0 with [Homebrew](http://brew.sh/) is easy:
 
@@ -92,11 +91,10 @@ the Riak installation directory via environment variables.
 You must have Xcode tools installed from [Apple's Developer
 website](http://developer.apple.com/).
 
-<div class="note">
-<div class="title">Note on Clang</div>
-Riak will not compile with Clang. Please make sure that your default
-C/C++ compiler is [GCC](https://gcc.gnu.org/).
-</div>
+{{% note title="Note on Clang" %}}
+Riak will not compile with Clang. Please make sure that your default C/C++
+compiler is [GCC](https://gcc.gnu.org/).
+{{% /note %}}
 
 Riak requires [Erlang](http://www.erlang.org/) R16B02+.
 

--- a/content/riak/kv/2.0.5/using/admin/riak-admin.md
+++ b/content/riak/kv/2.0.5/using/admin/riak-admin.md
@@ -185,11 +185,10 @@ rename the nodes of a cluster. For more information, visit the
 riak-admin reip <old nodename> <new nodename>
 ```
 
-<div class="note">
-<div class="title">Note about reip prior to Riak 2.0</title></div>
-Several bugs have been fixed related to reip in Riak 2.0. We recommend
-against using reip prior to 2.0, if possible.
-</div>
+{{% note title="Note about reip prior to Riak 2.0" %}}
+Several bugs have been fixed related to reip in Riak 2.0. We recommend against
+using reip prior to 2.0, if possible.
+{{% /note %}}
 
 
 ## js-reload
@@ -389,12 +388,10 @@ entropy tree building, and key repairs which were triggered by AAE.
  * The *Max* column shows the maximum number of keys repaired during all
    key exchanges since the last node restart.
 
-<div class="note">
-<div class="title">Note in AAE status information</div>
-All AAE status information is in-memory and is reset across a node
-restart. Only tree build times are persistent (since trees themselves
-are persistent)
-</div>
+{{% note title="Note in AAE status information" %}}
+All AAE status information is in-memory and is reset across a node restart.
+Only tree build times are persistent (since trees themselves are persistent)
+{{% /note %}}
 
 More details on the `aae-status` command are available in the [Riak
 version 1.3 release notes](https://github.com/basho/riak/blob/1.3/RELEASE-NOTES.md#active-anti-entropy).
@@ -628,11 +625,10 @@ repaired for a given exchange round since the node has started.
 
 ### switch-to-new-search
 
-<div class="info">
-<div class="title">Only For Legacy Migration</div>
-This is only needed when migrating from legacy riak search to the new
-Search (Yokozuna).
-</div>
+{{% note title="Only For Legacy Migration" %}}
+This is only needed when migrating from legacy riak search to the new Search
+(Yokozuna).
+{{% /note %}}
 
 ```bash
 riak-admin search switch-to-new-search

--- a/content/riak/kv/2.0.5/using/admin/riak-control.md
+++ b/content/riak/kv/2.0.5/using/admin/riak-control.md
@@ -57,12 +57,11 @@ listener.https.<name> = 127.0.0.1:8096
 %%     the `riak_api` tuple's value list.
 ```
 
-<div class="note">
-<div class="title">Note on SSL</div>
-We strongly recommend that you enable SSL for Riak Control. It is
-disabled by default, and if you wish to enable it you must do so
-explicitly. More information can be found in the document below.
-</div>
+{{% note title="Note on SSL" %}}
+We strongly recommend that you enable SSL for Riak Control. It is disabled by
+default, and if you wish to enable it you must do so explicitly. More
+information can be found in the document below.
+{{% /note %}}
 
 ## Enabling and Disabling Riak Control
 
@@ -168,16 +167,15 @@ be because you are using self-signed certificates. If you have
 authentication enabled in your configuration, you will next be asked to
 authenticate. Enter an appropriate username and password now.
 
-<div class="note">
-<div class="title">Note on browser TLS</div>
-Your browser needs to be support TLS v1.2 to use Riak Control over
-HTTPS. A list of browsers that support TLS v1.2 can be found
+{{% note title="Note on browser TLS" %}}
+Your browser needs to be support TLS v1.2 to use Riak Control over HTTPS. A
+list of browsers that support TLS v1.2 can be found
 [here](https://en.wikipedia.org/wiki/Transport_Layer_Security#Web_browsers).
-TLS v1.2 may be disabled by default on your browser, for example if you
-are using Firefox versions earlier than 27, Safari versions earlier than
-7, Chrome versions earlier than 30, or Internet Explorer versions
-earlier than 11.  To enable it, follow browser-specific instructions.
-</div>
+TLS v1.2 may be disabled by default on your browser, for example if you are
+using Firefox versions earlier than 27, Safari versions earlier than 7, Chrome
+versions earlier than 30, or Internet Explorer versions earlier than 11.  To
+enable it, follow browser-specific instructions.
+{{% /note %}}
 
 ### Snapshot View
 

--- a/content/riak/kv/2.0.5/using/cluster-operations/adding-removing-nodes.md
+++ b/content/riak/kv/2.0.5/using/cluster-operations/adding-removing-nodes.md
@@ -136,15 +136,14 @@ Transfers resulting from cluster changes: 51
 If the plan is to your liking, submit the changes by running `riak-admin
 cluster commit`.
 
-<div class="note">
-<div class="title">Note on ring changes</div>
-The algorithm that distributes partitions across the cluster
-during membership changes is non-deterministic. As a result, there is no
-optimal ring. In the event that a plan results in a slightly uneven
-distribution of partitions, the plan can be cleared. Clearing a cluster
-plan with `riak-admin cluster clear` and running `riak-admin cluster
-plan` again will produce a slightly different ring.
-</div>
+{{% note title="Note on ring changes" %}}
+The algorithm that distributes partitions across the cluster during membership
+changes is non-deterministic. As a result, there is no optimal ring. In the
+event that a plan results in a slightly uneven distribution of partitions, the
+plan can be cleared. Clearing a cluster plan with `riak-admin cluster clear`
+and running `riak-admin cluster plan` again will produce a slightly different
+ring.
+{{% /note %}}
 
 ## Removing a Node From a Cluster
 

--- a/content/riak/kv/2.0.5/using/cluster-operations/bucket-types.md
+++ b/content/riak/kv/2.0.5/using/cluster-operations/bucket-types.md
@@ -16,14 +16,13 @@ Buckets are essentially a flat namespace in Riak. They allow the same
 key name to exist in multiple buckets and enable you to apply
 configurations across keys.
 
-<div class="info">
-<div class="title">How Many Buckets Can I Have?</div>
-Buckets come with virtually no cost <em>except for when you modify the
-default bucket properties</em>. Modified bucket properties are gossiped
-around the cluster and therefore add to the amount of data sent around
-the network. In other words, buckets using the <tt>default</tt> bucket
-type are free. More on that in the next section.
-</div>
+{{% note title="How Many Buckets Can I Have?" %}}
+Buckets come with virtually no cost _except for when you modify the default
+bucket properties_. Modified bucket properties are gossiped around the cluster
+and therefore add to the amount of data sent around the network. In other
+words, buckets using the `default` bucket type are free. More on that in the
+next section.
+{{% /note %}}
 
 In Riak versions 2.0 and later, Basho suggests that you [use bucket types](/riak/kv/2.0.5/developing/usage/bucket-types) to namespace and configure all buckets you use. Bucket types have a lower overhead within the cluster than the
 default bucket namespace but require an additional setup step on the

--- a/content/riak/kv/2.0.5/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.0.5/using/cluster-operations/changing-cluster-info.md
@@ -302,9 +302,12 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
-<div class="note"><div class="title">Note</div>
-When using the `riak-admin cluster force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
-</div>
+{{% note title="Note" %}}
+When using the `riak-admin cluster force-replace` command, you will always get
+a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be
+lost`. Since we didn't delete any data files and we are replacing the node
+with itself under a new name, we will not lose any replicas.
+{{% /note %}}
 
 <a id="repeat"></a>
 #### Repeat previous steps on each node

--- a/content/riak/kv/2.0.5/using/cluster-operations/replacing-node.md
+++ b/content/riak/kv/2.0.5/using/cluster-operations/replacing-node.md
@@ -86,12 +86,10 @@ with the [`riak-admin ringready`](/riak/kv/2.0.5/using/admin/riak-admin/#ringrea
 and [`riak-admin member-status`](/riak/kv/2.0.5/using/admin/riak-admin/#member-status)
 commands.
 
-<div class="info">
-<div class="title">Ring Settling</div>
-You'll need to make sure that no other ring changes occur between the
-time when you start the new node and the ring settles with the new IP
-info.
+{{% note title="Ring Settling" %}}
+You'll need to make sure that no other ring changes occur between the time
+when you start the new node and the ring settles with the new IP info.
 
-The ring is considered settled when the new node reports `true` when you
-run the `riak-admin ringready` command.
-</div>
+The ring is considered settled when the new node reports `true` when you run
+the `riak-admin ringready` command.
+{{% /note %}}

--- a/content/riak/kv/2.0.5/using/cluster-operations/strong-consistency.md
+++ b/content/riak/kv/2.0.5/using/cluster-operations/strong-consistency.md
@@ -12,10 +12,14 @@ menu:
 toc: true
 ---
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 ## Monitoring Strong Consistency
 

--- a/content/riak/kv/2.0.5/using/performance.md
+++ b/content/riak/kv/2.0.5/using/performance.md
@@ -26,13 +26,12 @@ changes.
 For performance and tuning recommendations specific to running Riak
 clusters on the Amazon Web Services EC2 environment, see [AWS Performance Tuning](/riak/kv/2.0.5/using/performance/amazon-web-services).
 
-<div class="note">
-<div class="title">Note on other operating systems</div>
+{{% note title="Note on other operating systems" %}}
 Unless otherwise specified, the tunings recommended below are for Linux
-distributions. Users implementing Riak on BSD and Solaris distributions
-can use these tuning recommendations to make analogous changes in those
-operating systems.
-</div>
+distributions. Users implementing Riak on BSD and Solaris distributions can
+use these tuning recommendations to make analogous changes in those operating
+systems.
+{{% /note %}}
 
 ## Storage and File System Tuning
 
@@ -171,12 +170,11 @@ net.ipv4.tcp_tw_reuse = 1
 net.ipv4.tcp_moderate_rcvbuf = 1
 ```
 
-<div class="note">
-<div class="title">Note on system default</div>
+{{% note title="Note on system default" %}}
 In general, these recommended values should be compared with the system
-defaults and only changed if benchmarks or other performance metrics
-indicate that networking is the bottleneck.
-</div>
+defaults and only changed if benchmarks or other performance metrics indicate
+that networking is the bottleneck.
+{{% /note %}}
 
 The following settings are optional, but may improve performance on a
 10Gb network:
@@ -211,11 +209,10 @@ ethtool -K eth0 tso off
 `ethtool` settings can be persisted across reboots by adding the above
 command to the `/etc/rc.local` script.
 
-<div class="info">
-<div class="title">Pro tip</div>
-Tuning these values will be required if they are changed, as they affect
-all network operations.
-</div>
+{{% note title="Pro tip" %}}
+Tuning these values will be required if they are changed, as they affect all
+network operations.
+{{% /note %}}
 
 ## Optional I/O Settings
 

--- a/content/riak/kv/2.0.5/using/performance/amazon-web-services.md
+++ b/content/riak/kv/2.0.5/using/performance/amazon-web-services.md
@@ -54,14 +54,13 @@ indexes are not needed for the application.
 In any case, proper benchmarking and tuning are needed to achieve the
 desired performance.
 
-<div class="info">
-<div class="title">Tip</div>
-Most successful AWS cluster deployments use more EC2 instances than they
-would the same number of physical nodes to compensate for the
-performance variability caused by shared, virtualized resources. Plan to
-have more EC2 instance based nodes than physical server nodes when
-estimating cluster size with respect to node count.
-</div>
+{{% note title="Tip" %}}
+Most successful AWS cluster deployments use more EC2 instances than they would
+the same number of physical nodes to compensate for the performance
+variability caused by shared, virtualized resources. Plan to have more EC2
+instance based nodes than physical server nodes when estimating cluster size
+with respect to node count.
+{{% /note %}}
 
 ## Operating System
 

--- a/content/riak/kv/2.0.5/using/performance/erlang.md
+++ b/content/riak/kv/2.0.5/using/performance/erlang.md
@@ -44,16 +44,15 @@ Erlang parameter | Riak parameter
 [`-env ERL_MAX_ETS_TABLES`](http://learnyousomeerlang.com/ets) | `erlang.max_ets_tables`
 `-name` | `nodename`
 
-<div class="note">
-<div class="title">Note on upgrading to 2.0</div>
-In versions of Riak prior to 2.0, Erlang VM-related parameters were
-specified in a `vm.args` configuration file; in versions 2.0 and later,
-all Erlang-VM-specific parameters are set in the `riak.conf` file. If
-you're upgrading to 2.0 from an earlier version, you can still use your
-old `vm.args` if you wish.  Please note, however, that if you set one or
-more parameters in both `vm.args` and in `riak.conf`, the settings in
-`vm.args` will override those in `riak.conf`.
-</div>
+{{% note title="Note on upgrading to 2.0" %}}
+In versions of Riak prior to 2.0, Erlang VM-related parameters were specified
+in a `vm.args` configuration file; in versions 2.0 and later, all
+Erlang-VM-specific parameters are set in the `riak.conf` file. If you're
+upgrading to 2.0 from an earlier version, you can still use your old `vm.args`
+if you wish.  Please note, however, that if you set one or more parameters in
+both `vm.args` and in `riak.conf`, the settings in `vm.args` will override
+those in `riak.conf`.
+{{% /note %}}
 
 ## SMP
 

--- a/content/riak/kv/2.0.5/using/reference/bucket-types.md
+++ b/content/riak/kv/2.0.5/using/reference/bucket-types.md
@@ -16,14 +16,12 @@ Bucket types allow groups of buckets to share configuration details and
 for Riak users to manage bucket properties more efficiently than in the
 older configuration system based on [bucket properties](/riak/kv/2.0.5/developing/usage/bucket-types/#bucket-properties-and-operations).
 
-<div class="note">
-<div class="title">Important note on cluster downgrades</div>
-If you upgrade a Riak to version 2.0 or later, you can still downgrade
-the cluster to a pre-2.0 version <em>as long as you have not created and
-activated a bucket type in the cluster</em>. Once any bucket type has
-been created and activated, you can no longer downgrade the cluster to a
-pre-2.0 version.
-</div>
+{{% note title="Important note on cluster downgrades" %}}
+If you upgrade a Riak to version 2.0 or later, you can still downgrade the
+cluster to a pre-2.0 version _as long as you have not created and activated a
+bucket type in the cluster_. Once any bucket type has been created and
+activated, you can no longer downgrade the cluster to a pre-2.0 version.
+{{% /note %}}
 
 ## How Bucket Types Work
 
@@ -129,11 +127,11 @@ If creation is successful, you should see the following output:
 type_using_defaults created
 ```
 
-<div class="note">
+{{% note %}}
 The `create` command can be run multiple times prior to a bucket type being
 activated. Riak will persist only those properties contained in the final call
 of the command.
-</div>
+{{% /note %}}
 
 Creating bucket types that assign properties _always_ involves passing
 stringified JSON to the `create` command. One way to do that is to pass
@@ -243,11 +241,22 @@ of the type:
 riak-admin bucket-type update type_to_update '{"props":{ ... }}'
 ```
 
-> **Note**
->
-> Any bucket properties associated with a type can be modified after a bucket is created, with two important exceptions: `consistent` and `datatype`. If a bucket type entails strong consistency (requiring that `consistent` be set to `true`) or is set up as a `map`, `set`, or `counter`, then this will be true of the bucket type once and for all.
->
-> If you need to change one of these properties, it is recommended that you simply create and activate a new bucket type.
+{{% note title="Immutable Configurations" %}}
+Any bucket properties associated with a type can be modified after a bucket is
+created, with three important exceptions:
+
+* `consistent`
+* `datatype`
+* `write_once`
+
+If a bucket type entails strong consistency (requiring that `consistent` be
+set to `true`), is set up as a `map`, `set`, or `counter`, or is defined as a
+write-once  bucket (requiring `write_once` be set to `true`), then this will
+be true of the bucket types.
+
+If you need to change one of these properties, we recommend that you simply
+create and activate a new bucket type.
+{{% /note %}}
 
 ## Buckets as Namespaces
 
@@ -375,12 +384,11 @@ curl http://localhost:8098/types/type1/buckets/my_bucket/keys/my_key
 curl http://localhost:8098/types/type2/buckets/my_bucket/keys/my_key
 ```
 
-<div class="note">
-<div class="title">Note on object location</div>
-In Riak 2.x, <em>all requests</em> must be made to a location specified
-by a bucket type, bucket, and key rather than to a bucket/key pair, as
-in previous versions.
-</div>
+{{% note title="Note on object location" %}}
+In Riak 2.x, _all requests_ must be made to a location specified by a bucket
+type, bucket, and key rather than to a bucket/key pair, as in previous
+versions.
+{{% /note %}}
 
 If requests are made to a bucket/key pair without a specified bucket
 type, `default` will be used in place of a bucket type. The following

--- a/content/riak/kv/2.0.5/using/reference/custom-code.md
+++ b/content/riak/kv/2.0.5/using/reference/custom-code.md
@@ -31,13 +31,13 @@ name must have the same name the module. So if you are given a file named
 If you have been given Erlang code and are expected to compile it for
 your developers, keep the following notes in mind.
 
-<div class="info"><div class="title">Note on the Erlang Compiler</div> You
-must use the Erlang compiler (<tt>erlc</tt>) associated with the Riak
+{{% note title="Note on the Erlang Compiler" %}}
+You must use the Erlang compiler (`erlc`) associated with the Riak
 installation or the version of Erlang used when compiling Riak from source.
-For packaged Riak installations, you can consult Table 1 below for the
-default location of Riak's <tt>erlc</tt> for each supported platform.
-If you compiled from source, use the <tt>erlc</tt> from the Erlang version
-you used to compile Riak.</div>
+For packaged Riak installations, you can consult Table 1 below for the default
+location of Riak's `erlc` for each supported platform. If you compiled from
+source, use the `erlc` from the Erlang version you used to compile Riak.
+{{% /note %}}
 
 <table style="width: 100%; border-spacing: 0px;">
 <tbody>
@@ -88,8 +88,9 @@ and loaded. For our example, we'll use a temporary directory `/tmp/beams`,
 but you should choose a directory for production functions based on your
 own requirements such that they will be available where and when needed.
 
-<div class="info">Ensure that the directory chosen above can be read by
-the <tt>riak</tt> user.</div>
+{{% note %}}
+Ensure that the directory chosen above can be read by the `riak` user.
+{{% /note %}}
 
 Successful compilation will result in a new `.beam` file,
 `validate_json.beam`.
@@ -124,5 +125,7 @@ value store has fully initialized and become available for use.
 This is done with the `riak-admin wait-for-service` command as detailed
 in the [Commands documentation](/riak/kv/2.0.5/using/admin/riak-admin/#wait-for-service).
 
-<div class="note">It is important that you ensure riak_kv is
-active before restarting the next node.</div>
+{{% note %}}
+It is important that you ensure riak_kv is active before restarting the next
+node.
+{{% /note %}}

--- a/content/riak/kv/2.0.5/using/reference/multi-datacenter/comparison.md
+++ b/content/riak/kv/2.0.5/using/reference/multi-datacenter/comparison.md
@@ -18,13 +18,12 @@ aliases:
 This document is a systematic comparison of [Version 2](/riak/kv/2.0.5/using/reference/v2-multi-datacenter) and [Version 3](/riak/kv/2.0.5/using/reference/v3-multi-datacenter) of Riak Enterprise's Multi-Datacenter
 Replication capabilities.
 
-<div class="note">
-<div class="title">Important note on mixing versions</div>
+{{% note title="Important note on mixing versions" %}}
 If you are installing Riak Enterprise anew, you should use version 3
-replication. Under no circumstances should you mix version 2 and version
-3 replication. This comparison is meant only to list improvements
-introduced in version 3.
-</div>
+replication. Under no circumstances should you mix version 2 and version 3
+replication. This comparison is meant only to list improvements introduced in
+version 3.
+{{% /note %}}
 
 ## Version 2
 

--- a/content/riak/kv/2.0.5/using/reference/multi-datacenter/monitoring.md
+++ b/content/riak/kv/2.0.5/using/reference/multi-datacenter/monitoring.md
@@ -34,14 +34,12 @@ replication:
 * Use canary (test) objects to test replication and establish trip times
   from source to sink clusters
 
-<div class="note">
-<div class="title">Note on querying and time windows</div>
-Riak's statistics are calculated over a sliding 60-second window. Each
-time you query the stats interface, each sliding statistic shown is a
-sum or histogram value calculated from the previous 60 seconds of data.
-Because of this, the stats interface should not be queried more than
-once per minute.
-</div>
+{{% note title="Note on querying and time windows" %}}
+Riak's statistics are calculated over a sliding 60-second window. Each time
+you query the stats interface, each sliding statistic shown is a sum or
+histogram value calculated from the previous 60 seconds of data. Because of
+this, the stats interface should not be queried more than once per minute.
+{{% /note %}}
 
 ## Statistics
 

--- a/content/riak/kv/2.0.5/using/reference/statistics-monitoring.md
+++ b/content/riak/kv/2.0.5/using/reference/statistics-monitoring.md
@@ -92,15 +92,13 @@ As with the throughput metrics, keeping an eye on average (and max)
 latency times will help detect usage patterns, and provide advanced
 warnings for potential problems.
 
-<div class="note">
-<div class="title">Note on FSM Time Stats</div>
-FSM Time Stats represent the amount of time in microseconds required
-to traverse the GET or PUT Finite State Machine code, offering a
-picture of general node health. From your application's perspective,
-FSM Time effectively represents experienced latency. Mean, Median, and
-95th-, 99th-, and 100th-percentile (Max) counters are displayed. These
-are one-minute stats.
-</div>
+{{% note title="Note on FSM Time Stats" %}}
+FSM Time Stats represent the amount of time in microseconds required to
+traverse the GET or PUT Finite State Machine code, offering a picture of
+general node health. From your application's perspective, FSM Time effectively
+represents experienced latency. Mean, Median, and 95th-, 99th-, and
+100th-percentile (Max) counters are displayed. These are one-minute stats.
+{{% /note %}}
 
 Metric | Also | Relevance | Latency (in microseconds)
 :------|:-----|:----------|:-------------------------
@@ -191,19 +189,21 @@ reported success with when used for monitoring the operational status of
 their Riak clusters. Community and open source projects are presented
 along with commercial and hosted services.
 
-<div class="note">
-<div class="title">Note on Riak 2.x Statistics Support</div>
-Many of the below tools were either created by third-parties or Basho engineers
-for general usage, and have been passed to the community for further updates. As
-such, many of the below only aggregate the statistics and messages that were
-output by Riak 1.4.x.</br>
+{{% note title="Note on Riak 2.x Statistics Support" %}}
+Many of the below tools were either created by third-parties or Basho
+engineers for general usage, and have been passed to the community for further
+updates. As such, many of the below only aggregate the statistics and messages
+that were output by Riak 1.4.x.
+
 Like all code under [Basho Labs](https://github.com/basho-labs/), the below
-tools are "best effort" and have no dedicated Basho support. We both appreciate
-and need your contribution to keep these tools stable and up to date. Please
-open up a GitHub issue on the repository if you'd like to be a maintainer.</br>
-Look for banners calling out the tools we've verified that support the latest Riak 2.x
-statistics!
-</div>
+tools are "best effort" and have no dedicated Basho support. We both
+appreciate and need your contribution to keep these tools stable and up to
+date. Please open up a GitHub issue on the repository if you'd like to be a
+maintainer.
+
+Look for banners calling out the tools we've verified that support the latest
+Riak 2.x statistics!
+{{% /note %}}
 
 ### Self-Hosted Monitoring Tools
 
@@ -250,9 +250,9 @@ the Riak HTTP [`/stats`](/riak/kv/2.0.5/developing/api/http/status) endpoint is 
 
 #### Nagios
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x.**
+{{% /note %}}
 
 [Nagios](http://www.nagios.org) is a monitoring and alerting solution
 that can provide information on the status of Riak cluster nodes, in
@@ -286,9 +286,9 @@ module specifically designed to read Riak statistics.
 
 #### Zabbix
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [Zabbix](http://www.zabbix.com) is an open-source performance monitoring,
 alerting, and graphing solution that can provide information on the state of
@@ -312,9 +312,9 @@ capacity planning in a Riak cluster environment.
 
 #### New Relic
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [New Relic](http://newrelic.com) is a data analytics and visualization platform
 that can provide information on the current and past states of Riak nodes and

--- a/content/riak/kv/2.0.5/using/reference/v3-multi-datacenter/cascading-writes.md
+++ b/content/riak/kv/2.0.5/using/reference/v3-multi-datacenter/cascading-writes.md
@@ -28,13 +28,11 @@ Riak Enterprise. It will need to be manually enabled on new clusters.
 Cascading realtime requires the `{riak_repl, rtq_meta}` capability to
 function.
 
-<div class="note">
-<div class="title">Note on cascading tracking</div>
-Cascading tracking is a simple list of where an object has been written.
-This works well for most common configurations. Larger installations,
-however, may have writes cascade to clusters to which other clusters
-have already written.
-</div>
+{{% note title="Note on cascading tracking" %}}
+Cascading tracking is a simple list of where an object has been written. This
+works well for most common configurations. Larger installations, however, may
+have writes cascade to clusters to which other clusters have already written.
+{{% /note %}}
 
 
 ```

--- a/content/riak/kv/2.0.5/using/repair-recovery/errors.md
+++ b/content/riak/kv/2.0.5/using/repair-recovery/errors.md
@@ -135,11 +135,10 @@ Riak to explain the correct course of action. For example, the
 `map/reduce` `parse_input` phase will respond like this when it
 encounters an invalid input:
 
-<div class="note">
-<div class="title">Note on inputs</div>
-Inputs must be a binary bucket, a tuple of bucket and key-filters, a
-list of target tuples, a search index, or modfun tuple: `INPUT`.
-</div>
+{{% note title="Note on inputs" %}}
+Inputs must be a binary bucket, a tuple of bucket and key-filters, a list of
+target tuples, a search index, or modfun tuple: `INPUT`.
+{{% /note %}}
 
 For the remaining common error codes, they are often marked by Erlang
 atoms (and quite often wrapped within an `{error,{badmatch,{...` tuple,

--- a/content/riak/kv/2.0.5/using/repair-recovery/failure-recovery.md
+++ b/content/riak/kv/2.0.5/using/repair-recovery/failure-recovery.md
@@ -117,6 +117,8 @@ spreading load and increasing available CPU and IOPS.
 
 See [Changing Cluster Information](/riak/kv/2.1.4/using/cluster-operations/changing-cluster-info/#clusters-from-backups) for instructions on cluster recovery.
 
-<div class="info">
-<div class="title">Tip</div> If you are a licensed Riak Enterprise or CS customer and require assistance or further advice with a cluster recovery, please file a ticket with the <a href="https://help.basho.com">Basho Helpdesk</a>.
-</div>
+{{% note title="Tip" %}}
+If you are a licensed Riak Enterprise or CS customer and require assistance or
+further advice with a cluster recovery, please file a ticket with the
+<a href="https://help.basho.com">Basho Helpdesk</a>.
+{{% /note %}}

--- a/content/riak/kv/2.0.5/using/repair-recovery/repairs.md
+++ b/content/riak/kv/2.0.5/using/repair-recovery/repairs.md
@@ -169,10 +169,11 @@ If there are compaction errors in any of your vnodes, those will be listed in th
 ./442446784738847563128068650529343492278651453440/LOG 
 ```
 
-<div class="note">
-<div class="title">Note</div>
-While corruption on one vnode is not uncommon, corruption in several vnodes very likely means that there is a deeper problem that needs to be address, perhaps on the OS or hardware level.
-</div>
+{{% note title="Note" %}}
+While corruption on one vnode is not uncommon, corruption in several vnodes
+very likely means that there is a deeper problem that needs to be address,
+perhaps on the OS or hardware level.
+{{% /note %}}
 
 ## Healing Corrupted LevelDBs
 

--- a/content/riak/kv/2.0.5/using/running-a-cluster.md
+++ b/content/riak/kv/2.0.5/using/running-a-cluster.md
@@ -171,14 +171,13 @@ the node's ring file.
 riak-admin cluster replace riak@127.0.0.1 riak@192.168.1.10
 ```
 
-<div class="note">
-<div class="title">Note on single nodes</div>
-If a node is started singly using default settings, as you might do when
-you are building your first test environment, you will need to remove
-the ring files from the data directory after you edit your configuration
-files. `riak-admin cluster replace` will not work since the node has not
-been joined to a cluster.
-</div>
+{{% note title="Note on single nodes" %}}
+If a node is started singly using default settings, as you might do when you
+are building your first test environment, you will need to remove the ring
+files from the data directory after you edit your configuration files.
+`riak-admin cluster replace` will not work since the node has not been joined
+to a cluster.
+{{% /note %}}
 
 As with all cluster changes, you need to view the planned changes by
 running `riak-admin cluster plan` and then running `riak-admin cluster

--- a/content/riak/kv/2.0.5/using/security/basics.md
+++ b/content/riak/kv/2.0.5/using/security/basics.md
@@ -444,13 +444,11 @@ Permission | Operation |
 `riak_kv.list_keys` | List all of the keys in a bucket
 `riak_kv.list_buckets` | List all buckets
 
-<div class="note">
-<div class="title">Note on Listing Keys and Buckets</div>
-<code>riak_kv.list_keys</code> and <code>riak_kv.list_buckets</code> are
-both very expensive operations that should be performed very rarely and
-never in production. Access to this functionality should be granted very
-carefully.
-</div>
+{{% note title="Note on Listing Keys and Buckets" %}}
+`riak_kv.list_keys` and `riak_kv.list_buckets` are both very expensive
+operations that should be performed very rarely and never in production.
+Access to this functionality should be granted very carefully.
+{{% /note %}}
 
 If you'd like to create, for example, a `client` account that is
 allowed only to run `GET` and `PUT` requests on all buckets:
@@ -631,23 +629,20 @@ The following command would remove the source for `riakuser` on
 riak-admin security del-source riakuser 127.0.0.1/32
 ```
 
-<div class="note">
-<div class="title">Note on Removing Sources</div>
-If you apply a security source both to <code>all</code> and to specific
-users and then wish to remove that source, you will need to do so in
-separate steps. The <code>riak-admin security del-source all ...</code>
-command by itself is not sufficient.
+{{% note title="Note on Removing Sources" %}}
+If you apply a security source both to `all` and to specific users and then
+wish to remove that source, you will need to do so in separate steps. The
+`riak-admin security del-source all ...` command by itself is not sufficient.
 
-For example, if you have assigned the source <code>password</code> to
-both <code>all</code> and to the user <code>riakuser</code> on the
-network <code>127.0.0.1/32</code>, the following two-step process would
-be required to fully remove the source:
+For example, if you have assigned the source `password` to both `all` and to
+the user `riakuser` on the network `127.0.0.1/32`, the following two-step
+process would be required to fully remove the source:
 
 ```bash
 riak-admin security del-source all 127.0.0.1/32 password
 riak-admin security del-source riakuser 127.0.0.1/32 password
 ```
-</div>
+{{% /note %}}
 
 ### More Usage Examples
 

--- a/content/riak/kv/2.0.5/using/security/managing-sources.md
+++ b/content/riak/kv/2.0.5/using/security/managing-sources.md
@@ -29,11 +29,10 @@ The examples below will assume that the network in question is
 [created](/riak/kv/2.0.5/using/security/basics/#user-management) and that
 security has been [enabled](/riak/kv/2.0.5/using/security/basics/#the-basics).
 
-<div class="note">
-<div class="title">Note on SSL connections</div>
-If you use <em>any</em> of the aforementioned security sources, even
-<code>trust</code>, you will need to do so via a secure SSL connection.
-</div>
+{{% note title="Note on SSL connections" %}}
+If you use _any_ of the aforementioned security sources, even `trust`, you
+will need to do so via a secure SSL connection.
+{{% /note %}}
 
 ## Trust-based Authentication
 

--- a/content/riak/kv/2.0.6/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.0.6/configuring/load-balancing-proxy.md
@@ -184,15 +184,13 @@ act as a front-end proxy to a 5-node Riak cluster.
 This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
-<div class="note">
-<div class="title">Nginx version notes</div>
-This example configuration was verified on <strong>Nginx version
-1.2.3</strong>. Please be aware that earlier versions of Nginx did not
-support any HTTP 1.1 semantics for upstream communication to backends.
-You should carefully examine this configuration and make changes
-appropriate to your specific environment before attempting to use
-it
-</div>
+{{% note title="Nginx version notes" %}}
+This example configuration was verified on **Nginx version 1.2.3**. Please be
+aware that earlier versions of Nginx did not support any HTTP 1.1 semantics
+for upstream communication to backends. You should carefully examine this
+configuration and make changes appropriate to your specific environment before
+attempting to use it
+{{% /note %}}
 
 Here is an example `nginx.conf` file:
 
@@ -250,13 +248,12 @@ server {
 }
 ```
 
-<div class="note">
-<div class="title">Note on access controls</div>
-Even when filtering and limiting requests to GETs only as done in the
-example, you should strongly consider additional access controls beyond
-what Nginx can provide directly, such as specific firewall rules to
-limit inbound connections to trusted sources.
-</div>
+{{% note title="Note on access controls" %}}
+Even when filtering and limiting requests to GETs only as done in the example,
+you should strongly consider additional access controls beyond what Nginx can
+provide directly, such as specific firewall rules to limit inbound connections
+to trusted sources.
+{{% /note %}}
 
 ### Querying Secondary Indexes Over HTTP
 

--- a/content/riak/kv/2.0.6/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.0.6/configuring/load-balancing-proxy.md
@@ -185,7 +185,7 @@ This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
 <div class="note">
-<div class="title">Nginx version notes</div
+<div class="title">Nginx version notes</div>
 This example configuration was verified on <strong>Nginx version
 1.2.3</strong>. Please be aware that earlier versions of Nginx did not
 support any HTTP 1.1 semantics for upstream communication to backends.

--- a/content/riak/kv/2.0.6/configuring/v2-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.0.6/configuring/v2-multi-datacenter/ssl.md
@@ -64,8 +64,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -73,7 +72,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.0.6/configuring/v3-multi-datacenter/quick-start.md
+++ b/content/riak/kv/2.0.6/configuring/v3-multi-datacenter/quick-start.md
@@ -137,13 +137,11 @@ Sink             Cluster Name         <Ctrl-Pid>      [Members]
 Cluster1          Cluster1            <0.4456.0>      ["10.60.67.149:9080"] (via 10.60.67.149:9080)
 ```
 
-<div class="note">
-<div class="title">Note on connections</div>
-At this point, if you do not have connections, replication will not
-work. Check your IP bindings by running <code>netstat -a</code> on all
-nodes. You should see <code>*:9080 LISTENING</code>. If not, you have
-configuration problems.
-</div>
+{{% note title="Note on connections" %}}
+At this point, if you do not have connections, replication will not work.
+Check your IP bindings by running `netstat -a` on all nodes. You should see
+`*:9080 LISTENING`. If not, you have configuration problems.
+{{% /note %}}
 
 ### Enable Realtime Replication
 

--- a/content/riak/kv/2.0.6/configuring/v3-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.0.6/configuring/v3-multi-datacenter/ssl.md
@@ -54,12 +54,11 @@ the `riak-core` section of [`advanced.confg`][config reference#advanced.config]:
 The `cacertsdir` is a directory containing all the CA certificates
 needed to verify the CA chain back to the root.
 
-<div class="note">
-<div class="title">Note on configuration</div>
+{{% note title="Note on configuration" %}}
 In Version 3 replication, the SSL settings need to be placed in the
-<code>riak-core</code> section of <code>advanced.config</code> as opposed to
-the <code>riak-repl</code> section used by Version 2 replication.
-</div>
+`riak-core` section of `advanced.config` as opposed to the `riak-repl` section
+used by Version 2 replication.
+{{% /note %}}
 
 ## Verifying Peer Certificates
 
@@ -80,8 +79,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -89,7 +87,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.0.6/developing/api/http/fetch-object.md
+++ b/content/riak/kv/2.0.6/developing/api/http/fetch-object.md
@@ -79,22 +79,23 @@ datetime format
 The body of the response will be the contents of the object except when siblings
 are present.
 
-<div class="note"><div class="title">Siblings</div>
-<p>When `allow_mult` is set to true in the bucket properties, concurrent updates
-are allowed to create "sibling" objects, meaning that the object has any number
-of different values that are related to one another by the vector clock.  This
-allows your application to use its own conflict resolution technique.</p>
+{{% note title="Siblings" %}}
+When `allow_mult` is set to true in the bucket properties, concurrent updates
+are allowed to create "sibling" objects, meaning that the object has any
+number of different values that are related to one another by the vector
+clock.  This allows your application to use its own conflict resolution
+technique.
 
-<p>An object with multiple sibling values will result in a `300 Multiple
-Choices` response.  If the `Accept` header prefers `multipart/mixed`, all
-siblings will be returned in a single request as sections of the
-`multipart/mixed` response body.  Otherwise, a list of "vtags" will be given in
-a simple text format. You can request individual siblings by adding the `vtag`
-query parameter. Scroll down to the 'manually requesting siblings' example below for more information.</p>
+An object with multiple sibling values will result in a `300 Multiple Choices`
+response.  If the `Accept` header prefers `multipart/mixed`, all siblings will
+be returned in a single request as sections of the `multipart/mixed` response
+body.  Otherwise, a list of "vtags" will be given in a simple text format. You
+can request individual siblings by adding the `vtag` query parameter. Scroll
+down to the 'manually requesting siblings' example below for more information.
 
-<p>To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
-given in the response.</p>
-</div>
+To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
+given in the response.
+{{% /note %}}
 
 ## Simple Example
 

--- a/content/riak/kv/2.0.6/developing/api/http/link-walking.md
+++ b/content/riak/kv/2.0.6/developing/api/http/link-walking.md
@@ -26,22 +26,19 @@ is a special case of [MapReduce](/riak/kv/2.0.6/developing/usage/mapreduce), and
 GET /buckets/bucket/keys/key/[bucket],[tag],[keep]
 ```
 
-<div class="info"><div class="title">Link filters</div>
-<p>A link filter within the request URL is made of three parts, separated by
-commas:</p>
+{{% note title="Link filters" %}}
+A link filter within the request URL is made of three parts, separated by
+commas:
 
-<ul>
-<li>Bucket - a bucket name to limit the links to</li>
-<li>Tag - a "riaktag" to limit the links to</li>
-<li>Keep - 0 or 1, whether to return results from this phase</li>
-</ul>
+* Bucket - a bucket name to limit the links to
+* Tag - a "riaktag" to limit the links to
+* Keep - 0 or 1, whether to return results from this phase
 
-<p>Any of the three parts may be replaced with <code>_</code> (underscore),
-signifying that any value is valid. Multiple phases of links can be followed by
-adding additional path segments to the URL, separating the link filters by
-slashes. The final phase in the link-walking query implicitly returns its
-results.</p>
-</div>
+Any of the three parts may be replaced with `_` (underscore), signifying that
+any value is valid. Multiple phases of links can be followed by adding
+additional path segments to the URL, separating the link filters by slashes.
+The final phase in the link-walking query implicitly returns its results.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.0.6/developing/api/http/list-buckets.md
+++ b/content/riak/kv/2.0.6/developing/api/http/list-buckets.md
@@ -17,10 +17,10 @@ aliases:
 
 Lists all known buckets (ones that have keys stored in them).
 
-<div class="note"><div class="title">Not for production use</div>
+{{% note title="Not for production use" %}}
 Similar to the list keys operation, this requires traversing all keys stored
 in the cluster and should not be used in production.
-</div>
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.6/developing/api/http/list-keys.md
+++ b/content/riak/kv/2.0.6/developing/api/http/list-keys.md
@@ -17,12 +17,10 @@ aliases:
 
 Lists keys in a bucket.
 
-<div class="note">
-<div class="title">Not for production use</div>
-
-This operation requires traversing all keys stored in the cluster and should not be used in production.
-
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.6/developing/api/http/set-bucket-props.md
+++ b/content/riak/kv/2.0.6/developing/api/http/set-bucket-props.md
@@ -50,14 +50,12 @@ the bucket
 
 Other properties do exist but are not commonly modified.
 
-<div class="note">
-<div class="title">Property types</div>
-<p>Make sure you use the proper types for attributes like <strong>n_val</strong>
-and <strong>allow_mult</strong>. If you use strings instead of integers and
-booleans respectively, you may see some odd errors in your logs, saying
-something like
-<code>"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"</code>.</p>
-</div>
+{{% note title="Property types" %}}
+Make sure you use the proper types for attributes like **n_val** and
+**allow_mult**. If you use strings instead of integers and booleans
+respectively, you may see some odd errors in your logs, saying something like
+`"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"`.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.0.6/developing/api/protocol-buffers.md
+++ b/content/riak/kv/2.0.6/developing/api/protocol-buffers.md
@@ -106,12 +106,11 @@ Code | Message |
 254 | `RpbAuthResp` |
 255 | `RpbStartTls` |
 
-<div class="info">
-<div class="title">Message Definitions</div>
-All Protocol Buffers messages are defined in the <code>riak.proto</code>
-and other <code>.proto</code> files in the <code>/src</code> directory
-of the <a href="https://github.com/basho/riak_pb">RiakPB</a> project.
-</div>
+{{% note title="Message Definitions" %}}
+All Protocol Buffers messages are defined in the `riak.proto` and other
+`.proto` files in the `/src` directory of the
+<a href="https://github.com/basho/riak_pb">RiakPB</a> project.
+{{% /note %}}
 
 ### Error Response
 

--- a/content/riak/kv/2.0.6/developing/api/protocol-buffers/fetch-object.md
+++ b/content/riak/kv/2.0.6/developing/api/protocol-buffers/fetch-object.md
@@ -137,14 +137,12 @@ of the following optional parameters:
 * `deleted` --- Whether the object has been deleted (i.e. whether a
   tombstone for the object has been found under the specified key)
 
-<div class="note">
-<div class="title">Note on missing keys</div>
-Remember: if a key is not stored in Riak, an <code>RpbGetResp</code>
-response without the <code>content</code> and <code>vclock</code> fields
-will be returned. This should be mapped to whatever convention the
-client language uses to return not found. The Erlang client, for
-example, returns the atom <code>{error, notfound}</code>.
-</div>
+{{% note title="Note on missing keys" %}}
+Remember: if a key is not stored in Riak, an `RpbGetResp` response without the
+`content` and `vclock` fields will be returned. This should be mapped to
+whatever convention the client language uses to return not found. The Erlang
+client, for example, returns the atom `{error, notfound}`.
+{{% /note %}}
 
 ## Example
 

--- a/content/riak/kv/2.0.6/developing/api/protocol-buffers/get-client-id.md
+++ b/content/riak/kv/2.0.6/developing/api/protocol-buffers/get-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.0.6/dev/references/protocol-buffers/get-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Get the client id used for this connection. Client ids are used for
 conflict resolution and each unique actor in the system should be

--- a/content/riak/kv/2.0.6/developing/api/protocol-buffers/list-buckets.md
+++ b/content/riak/kv/2.0.6/developing/api/protocol-buffers/list-buckets.md
@@ -17,12 +17,10 @@ aliases:
 
 List all of the bucket names available.
 
-<div class="note">
-<div class="title">Caution</div>
-
-This call can be expensive for the server. Do not use in
-performance-sensitive code.
-</div>
+{{% note title="Caution" %}}
+This call can be expensive for the server. Do not use in performance-sensitive
+code.
+{{% /note %}}
 
 
 ## Request

--- a/content/riak/kv/2.0.6/developing/api/protocol-buffers/list-keys.md
+++ b/content/riak/kv/2.0.6/developing/api/protocol-buffers/list-keys.md
@@ -18,11 +18,10 @@ aliases:
 List all of the keys in a bucket. This is a streaming call, with
 multiple response messages sent for each request.
 
-<div class="note">
-<div class="title">Not for production use</div>
-This operation requires traversing all keys stored in the cluster and
-should not be used in production.
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.6/developing/api/protocol-buffers/set-client-id.md
+++ b/content/riak/kv/2.0.6/developing/api/protocol-buffers/set-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.0.6/dev/references/protocol-buffers/set-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Set the client ID for this connection. A library may want to set the
 client ID if it has a good way to uniquely identify actors across

--- a/content/riak/kv/2.0.6/developing/app-guide/advanced-mapreduce.md
+++ b/content/riak/kv/2.0.6/developing/app-guide/advanced-mapreduce.md
@@ -253,10 +253,10 @@ curl -XPOST localhost:8098/mapred \
 
 The result should be a JSON map of bucket and key names expressed as key/value pairs.
 
-<div class="info">
-Be sure to install the MapReduce function as described above on all of
-the nodes in your cluster to ensure proper operation.
-</div>
+{{% note %}}
+Be sure to install the MapReduce function as described above on all of the
+nodes in your cluster to ensure proper operation.
+{{% /note %}}
 
 
 ## Phase functions
@@ -481,27 +481,25 @@ takes any of the following forms:
 * `{jsanon, {Bucket, Key}}` where the object at `{Bucket, Key}` contains
   the source for an anonymous Javascript function
 
-<div class="info">
-<div class="title">qfun Note</div>
-Using `qfun` in compiled applications can be a fragile
-operation. Please keep the following points in mind.
+{{% note title="qfun Note" %}}
+Using `qfun` in compiled applications can be a fragile operation. Please keep
+the following points in mind.
 
-1. The module in which the function is defined must be present and
-**exactly the same version** on both the client and Riak nodes.
+1. The module in which the function is defined must be present and **exactly
+   the same version** on both the client and Riak nodes.
 
-2. Any modules and functions used by this function (or any function in
-the resulting call stack) must also be present on the Riak nodes.
+2. Any modules and functions used by this function (or any function in the
+   resulting call stack) must also be present on the Riak nodes.
 
-Errors about failures to ensure both 1 and 2 are often surprising,
-usually seen as opaque **missing-function** or **function-clause**
-errors. Especially in the case of differing module versions, this can be
-difficult to diagnose without expecting the issue and knowing of
-`Module:info/0`.
+Errors about failures to ensure both 1 and 2 are often surprising, usually
+seen as opaque **missing-function** or **function-clause** errors. Especially
+in the case of differing module versions, this can be difficult to diagnose
+without expecting the issue and knowing of `Module:info/0`.
 
-When using the Erlang shell, anonymous MapReduce functions can be
-defined and sent to Riak instead of deploying them to all servers in
-advance, but condition #2 above still holds.
-</div>
+When using the Erlang shell, anonymous MapReduce functions can be defined and
+sent to Riak instead of deploying them to all servers in advance, but
+condition #2 above still holds.
+{{% /note %}}
 
 Link phases are expressed in the following form:
 

--- a/content/riak/kv/2.0.6/developing/app-guide/replication-properties.md
+++ b/content/riak/kv/2.0.6/developing/app-guide/replication-properties.md
@@ -154,15 +154,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -330,15 +328,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -355,14 +352,12 @@ documentation on [Bitcask](/riak/kv/2.0.6/setup/planning/backend/bitcask), [Leve
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.0.6/developing/client-libraries.md
+++ b/content/riak/kv/2.0.6/developing/client-libraries.md
@@ -49,12 +49,11 @@ developing something that you wish to see added to this list, please
 fork the [Riak Docs repo on GitHub](https://github.com/basho/basho_docs)
 and send us a pull request.
 
-<div class="note">
-<div class="title">Note on community-produced libraries</div>
-All of these projects and libraries are at various stages of
-completeness and may not suit your application's needs based on their
-level of maturity and activity.
-</div>
+{{% note title="Note on community-produced libraries" %}}
+All of these projects and libraries are at various stages of completeness and
+may not suit your application's needs based on their level of maturity and
+activity.
+{{% /note %}}
 
 ### Client Libraries and Frameworks
 

--- a/content/riak/kv/2.0.6/developing/getting-started/csharp.md
+++ b/content/riak/kv/2.0.6/developing/getting-started/csharp.md
@@ -25,10 +25,12 @@ To try this flavor of Riak, a working installation of the .NET Framework or Mono
 
 Install [the Riak .NET Client](https://github.com/basho/riak-dotnet-client/wiki/Installation) through [NuGet](http://nuget.org/packages/RiakClient) or the Visual Studio NuGet package manager.
 
-<div class="note">
-<div class="title">Configuring for a remote cluster</div>
-By default, the Riak .NET Client will add a section to your `app.config` file for a four node local cluster. If you are using a remote cluster, open up `app.config` and change the `hostAddress` values to point to nodes in your remote cluster.
-</div>
+{{% note title="Configuring for a remote cluster" %}}
+By default, the Riak .NET Client will add a section to your `app.config` file
+for a four node local cluster. If you are using a remote cluster, open up
+`app.config` and change the `hostAddress` values to point to nodes in your
+remote cluster.
+{{% /note %}}
 
 ### Connecting to Riak
 

--- a/content/riak/kv/2.0.6/developing/getting-started/csharp/object-modeling.md
+++ b/content/riak/kv/2.0.6/developing/getting-started/csharp/object-modeling.md
@@ -64,12 +64,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially when many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially when many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.6/developing/getting-started/erlang/object-modeling.md
+++ b/content/riak/kv/2.0.6/developing/getting-started/erlang/object-modeling.md
@@ -18,14 +18,13 @@ aliases:
 
 To get started, let's create the records that we'll be using.
 
-<div class="note">
-<div class="title">Code Download</div>
+{{% note title="Code Download" %}}
 You can also download the code for this chapter at
 [Github](https://github.com/basho/taste-of-riak/tree/am-dem-erlang-modules/erlang/Ch03-Msgy-Schema).
 
-The Github version includes Erlang type specifications which have been
-omitted here for brevity.
-</div>
+The Github version includes Erlang type specifications which have been omitted
+here for brevity.
+{{% /note %}}
 
 
 ```erlang
@@ -91,13 +90,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.6/developing/getting-started/golang/object-modeling.md
+++ b/content/riak/kv/2.0.6/developing/getting-started/golang/object-modeling.md
@@ -182,13 +182,11 @@ users and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.6/developing/getting-started/java.md
+++ b/content/riak/kv/2.0.6/developing/getting-started/java.md
@@ -40,13 +40,11 @@ Next, download
 [`TasteOfRiak.java`](https://github.com/basho/basho_docs/raw/master/extras/code-examples/TasteOfRiak.java)
 source code for this tutorial, and save it to your working directory.
 
-<div class="note">
-<div class="title">Configuring for a local cluster</div>
-The `TasteOfRiak.java` file that you downloaded is set up to communicate
-with a 1-node Riak cluster listening on `localhost` port 10017. We
-recommend modifying the connection info directly within the
-`setUpCluster()` method.
-</div>
+{{% note title="Configuring for a local cluster" %}}
+The `TasteOfRiak.java` file that you downloaded is set up to communicate with
+a 1-node Riak cluster listening on `localhost` port 10017. We recommend
+modifying the connection info directly within the `setUpCluster()` method.
+{{% /note %}}
 
 If you execute the `TasteOfRiak.java` file within your IDE, you should
 see the following:

--- a/content/riak/kv/2.0.6/developing/getting-started/java/object-modeling.md
+++ b/content/riak/kv/2.0.6/developing/getting-started/java/object-modeling.md
@@ -157,12 +157,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.6/developing/getting-started/nodejs/object-modeling.md
+++ b/content/riak/kv/2.0.6/developing/getting-started/nodejs/object-modeling.md
@@ -73,12 +73,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_SENT_2014-03-06` or `marketing_group_INBOX_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.6/developing/getting-started/python/object-modeling.md
+++ b/content/riak/kv/2.0.6/developing/getting-started/python/object-modeling.md
@@ -83,13 +83,11 @@ users, and `<groupname>_<type>_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-06`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.6/developing/getting-started/ruby/object-modeling.md
+++ b/content/riak/kv/2.0.6/developing/getting-started/ruby/object-modeling.md
@@ -94,13 +94,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.6/developing/usage/conflict-resolution.md
+++ b/content/riak/kv/2.0.6/developing/usage/conflict-resolution.md
@@ -25,16 +25,15 @@ If you are using Riak in an [eventually consistent](/riak/kv/2.0.6/learn/concept
 unavoidable. Often, Riak can resolve these conflicts on its own
 internally if you use causal context, i.e. [vector clocks](/riak/kv/2.0.6/learn/concepts/causal-context#vector-clocks) or [dotted version vectors](/riak/kv/2.0.6/learn/concepts/causal-context#dotted-version-vectors), when updating objects. Instructions on this can be found in the section [below](#siblings).
 
-<div class="note">
-<div class="title">Important note on terminology</div>
-In versions of Riak prior to 2.0, vector clocks were the only causal
-context mechanism available in Riak, which changed with the introduction
-of dotted version vectors in 2.0. Please note that you may frequent find
-terminology in client library APIs, internal Basho documentation, and
-more that uses the term "vector clock" interchangeably with causal
-context in general. Riak's HTTP API still uses a `X-Riak-Vclock` header,
-for example, even if you are using dotted version vectors.
-</div>
+{{% note title="Important note on terminology" %}}
+In versions of Riak prior to 2.0, vector clocks were the only causal context
+mechanism available in Riak, which changed with the introduction of dotted
+version vectors in 2.0. Please note that you may frequent find terminology in
+client library APIs, internal Basho documentation, and more that uses the term
+"vector clock" interchangeably with causal context in general. Riak's HTTP API
+still uses a `X-Riak-Vclock` header, for example, even if you are using dotted
+version vectors.
+{{% /note %}}
 
 But even when you use causal context, Riak cannot always decide which
 value is most causally recent, especially in cases involving concurrent
@@ -118,12 +117,10 @@ will be no concurrent updates. If you are storing immutable data in
 which each object is guaranteed to have its own key or engaging in
 operations related to bulk loading, you should consider LWW.
 
-<div class="note">
-<div class="title">Undefined behavior warning</div>
-Setting both <code>allow_mult</code> and <code>last_write_wins</code> to
-<code>true</code> necessarily leads to unpredictable behavior and should
-always be avoided.
-</div>
+{{% note title="Undefined behavior warning" %}}
+Setting both `allow_mult` and `last_write_wins` to `true` necessarily leads to
+unpredictable behavior and should always be avoided.
+{{% /note %}}
 
 ### Resolve Conflicts on the Application Side
 
@@ -602,13 +599,12 @@ X-Riak-Vclock: a85hYGBgzGDKBVIcR4M2cgczH7HPYEpkzGNlsP/VfYYvCwA=
 # accompany the write for Riak to be able to use the vector clock
 ```
 
-<div class="note">
-<div class="title">Concurrent conflict resolution</div>
+{{% note title="Concurrent conflict resolution" %}}
 It should be noted that it is possible to have two clients that are
 simultaneously engaging in conflict resolution. To avoid a pathological
-divergence, you should be sure to limit the number of reconciliations
-and fail once that limit has been exceeded.
-</div>
+divergence, you should be sure to limit the number of reconciliations and fail
+once that limit has been exceeded.
+{{% /note %}}
 
 ### Sibling Explosion
 
@@ -650,13 +646,10 @@ better performance. Some use cases where you might want to use
 `last_write_wins` include caching, session storage, and insert-only
 (no updates).
 
-<div class="note">
-<div class="title">Note on combining <code>allow_mult</code> and
-<code>last_write_wins</code></div>
-The combination of setting both the <code>allow_mult</code> and
-<code>last_write_wins</code> properties to <code>true</code> leads to
-undefined behavior and should not be used.
-</div>
+{{% note title="Note on combining `allow_mult` and `last_write_wins`" %}}
+The combination of setting both the `allow_mult` and `last_write_wins`
+properties to `true` leads to undefined behavior and should not be used.
+{{% /note %}}
 
 ## Vector Clock Pruning
 

--- a/content/riak/kv/2.0.6/developing/usage/mapreduce.md
+++ b/content/riak/kv/2.0.6/developing/usage/mapreduce.md
@@ -15,16 +15,14 @@ aliases:
   - /riak/kv/2.0.6/dev/using/mapreduce
 ---
 
-<div class="note">
-<div class="title">Use MapReduce sparingly</div>
-In Riak, MapReduce is the primary method for non-primary-key-based
-querying. Although useful for a limited range of purposes, such as batch
-processing jobs, MapReduce operations can be very computationally
-expensive, sometimes to the extent that they can degrade performance in
-production clusters operating under load. Thus, we recommend running
-MapReduce operations in a controlled, rate-limited fashion and never for
-realtime querying purposes.
-</div>
+{{% note title="Use MapReduce sparingly" %}}
+In Riak, MapReduce is the primary method for non-primary-key-based querying.
+Although useful for a limited range of purposes, such as batch processing
+jobs, MapReduce operations can be very computationally expensive, sometimes to
+the extent that they can degrade performance in production clusters operating
+under load. Thus, we recommend running MapReduce operations in a controlled,
+rate-limited fashion and never for realtime querying purposes.
+{{% /note %}}
 
 MapReduce (M/R) is a technique for dividing data processing work across
 a distributed system. It takes advantage of the parallel processing

--- a/content/riak/kv/2.0.6/developing/usage/reading-objects.md
+++ b/content/riak/kv/2.0.6/developing/usage/reading-objects.md
@@ -197,12 +197,10 @@ The most common error code:
 
 * `404 Not Found`
 
-<div class="note">
-<div class="title">Note</div>
-If you're using a Riak client instead of HTTP, these responses will vary
-a great deal, so make sure to check the documentation for your specific
-client.
-</div>
+{{% note title="Note" %}}
+If you're using a Riak client instead of HTTP, these responses will vary a
+great deal, so make sure to check the documentation for your specific client.
+{{% /note %}}
 
 ## No Object Stored
 

--- a/content/riak/kv/2.0.6/developing/usage/replication.md
+++ b/content/riak/kv/2.0.6/developing/usage/replication.md
@@ -45,18 +45,17 @@ is one of the features that differentiates Riak from other databases.
 At the bottom of the page, you'll find a [screencast](/riak/kv/2.0.6/developing/app-guide/replication-properties#screencast) that briefly explains how to adjust your
 replication levels to match your application and business needs.
 
-<div class="note">
-<div class="title">Note on strong consistency</div>
+{{% note title="Note on strong consistency" %}}
 An option introduced in Riak version 2.0 is to use Riak as a
-<a href="/riak/kv/2.0.6/using/reference/strong-consistency/">strongly consistent</a>
-system for data in specified buckets. Using Riak in this way is
-fundamentally different from adjusting replication properties and
-fine-tuning the availability/consistency trade-off, as it sacrifices
-<em>all</em> availability guarantees when necessary. Therefore, you
-should consult the <a href="/riak/kv/2.0.6/developing/app-guide/strong-consistency">Using
-Strong Consistency</a> documentation, as this option will not be covered
-in this tutorial.
-</div>
+<a href="/riak/kv/2.0.6/using/reference/strong-consistency/">strongly
+consistent</a> system for data in specified buckets. Using Riak in this way is
+fundamentally different from adjusting replication properties and fine-tuning
+the availability/consistency trade-off, as it sacrifices _all_ availability
+guarantees when necessary. Therefore, you should consult the
+<a href="/riak/kv/2.0.6/developing/app-guide/strong-consistency">Using Strong
+Consistency</a> documentation, as this option will not be covered in this
+tutorial.
+{{% /note %}}
 
 ## How Replication Properties Work
 
@@ -163,15 +162,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -339,15 +336,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -364,14 +360,12 @@ documentation on [Bitcask][plan backend bitcask], [LevelDB][plan backend leveldb
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.0.6/developing/usage/security/erlang.md
+++ b/content/riak/kv/2.0.6/developing/usage/security/erlang.md
@@ -24,13 +24,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.0.6/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Erlang Client Basics
 

--- a/content/riak/kv/2.0.6/developing/usage/security/java.md
+++ b/content/riak/kv/2.0.6/developing/usage/security/java.md
@@ -23,13 +23,11 @@ If you are using [trust-](/riak/kv/2.0.6/using/security/managing-sources/#trust-
 security setup described [below](#java-client-basics). [Certificate](/riak/kv/2.0.6/using/security/managing-sources/#certificate-based-authentication)-based authentication is not
 yet supported in the Java client.
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Java Client Basics
 

--- a/content/riak/kv/2.0.6/developing/usage/security/python.md
+++ b/content/riak/kv/2.0.6/developing/usage/security/python.md
@@ -25,13 +25,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.0.6/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## OpenSSL Versions
 

--- a/content/riak/kv/2.0.6/developing/usage/security/ruby.md
+++ b/content/riak/kv/2.0.6/developing/usage/security/ruby.md
@@ -25,13 +25,11 @@ can use the security setup described in the [Ruby Client Basics](#ruby-client-ba
 in a [later section](#password-based-authentication), while [certificate](/riak/kv/2.0.6/using/security/managing-sources/#certificate-based-authentication)-based authentication
 is covered [further down](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Ruby Client Basics
 

--- a/content/riak/kv/2.0.6/introduction.md
+++ b/content/riak/kv/2.0.6/introduction.md
@@ -185,14 +185,12 @@ Based on Basho's [Cuttlefish](https://github.com/basho/cuttlefish)
 project, the new system is much simpler, leaving behind the Erlang
 syntax required in `app.config`.
 
-<div class="note">
-<div class="title">Note on upgrading</div>
-Version 2.0 will support both the old and the new configuration system,
-in case you're upgrading. Please note, however, that if you use both
-systems side by side, all settings from the older,
-`app.config`/`vm.args`-based system will override any settings from the
-new system.
-</div>
+{{% note title="Note on upgrading" %}}
+Version 2.0 will support both the old and the new configuration system, in
+case you're upgrading. Please note, however, that if you use both systems side
+by side, all settings from the older, `app.config`/`vm.args`-based system will
+override any settings from the new system.
+{{% /note %}}
 
 #### Relevant Docs
 

--- a/content/riak/kv/2.0.6/learn/concepts/strong-consistency.md
+++ b/content/riak/kv/2.0.6/learn/concepts/strong-consistency.md
@@ -18,10 +18,14 @@ aliases:
 [usage bucket types]: /riak/kv/2.0.6/developing/usage/bucket-types
 [concept eventual consistency]: /riak/kv/2.0.6/learn/concepts/eventual-consistency
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 Riak was originally designed as an [eventually consistent](/riak/kv/2.0.6/learn/concepts/eventual-consistency) system, fundamentally geared toward providing partition
 (i.e. fault) tolerance and high read and write availability.

--- a/content/riak/kv/2.0.6/setup/downgrade.md
+++ b/content/riak/kv/2.0.6/setup/downgrade.md
@@ -38,13 +38,13 @@ additional steps to be performed before, during, and after the upgrade
 on on each node.  These steps are related to changes or new features
 that are not present in the downgraded version.
 
-<div class="note">
-<div class="title">A Note About the Following Instructions</div>
-The below instructions describe the procedures required for a single
-feature release version downgrade. In a downgrade between two feature
-release versions, the steps for the in-between version must also be
-performed. For example, a downgrade from 1.4 to 1.2 requires that the
-downgrade steps for both 1.4 and 1.3 are performed.  </div>
+{{% note title="A Note About the Following Instructions" %}}
+The below instructions describe the procedures required for a single feature
+release version downgrade. In a downgrade between two feature release
+versions, the steps for the in-between version must also be performed. For
+example, a downgrade from 1.4 to 1.2 requires that the downgrade steps for
+both 1.4 and 1.3 are performed.
+{{% /note %}}
 
 ## General Guidelines
 

--- a/content/riak/kv/2.0.6/setup/installing/amazon-web-services.md
+++ b/content/riak/kv/2.0.6/setup/installing/amazon-web-services.md
@@ -62,10 +62,10 @@ You will need need to launch at least 3 instances to form a Riak cluster.  When 
 
 You can find more information on connecting to an instance on the official [Amazon EC2 instance guide](http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/AccessingInstances.html).
 
-<div class="note">
-<div class="title">Note</div>
-The following clustering setup will <em>not</em> be resilient to instance restarts unless deployed in Amazon VPC.
-</div>
+{{% note title="Note" %}}
+The following clustering setup will _not_ be resilient to instance restarts
+unless deployed in Amazon VPC.
+{{% /note %}}
 
 1. On the first node, obtain the internal IP address:
 

--- a/content/riak/kv/2.0.6/setup/installing/mac-osx.md
+++ b/content/riak/kv/2.0.6/setup/installing/mac-osx.md
@@ -52,13 +52,12 @@ directory and execute `bin/riak start` to start the Riak node.
 
 ## Homebrew
 
-<div class="note">
-<div class="title">Warning: Homebrew not always up to date</div>
-Homebrew's Riak recipe is community supported, and thus is not always up
-to date with the latest Riak package. Please ensure that the current
-recipe is using the latest supported code (and don't be afraid to update
-it if it's not).
-</div>
+{{% note title="Warning: Homebrew not always up to date" %}}
+Homebrew's Riak recipe is community supported, and thus is not always up to
+date with the latest Riak package. Please ensure that the current recipe is
+using the latest supported code (and don't be afraid to update it if it's
+not).
+{{% /note %}}
 
 Installing Riak 2.0 with [Homebrew](http://brew.sh/) is easy:
 
@@ -92,11 +91,10 @@ the Riak installation directory via environment variables.
 You must have Xcode tools installed from [Apple's Developer
 website](http://developer.apple.com/).
 
-<div class="note">
-<div class="title">Note on Clang</div>
-Riak will not compile with Clang. Please make sure that your default
-C/C++ compiler is [GCC](https://gcc.gnu.org/).
-</div>
+{{% note title="Note on Clang" %}}
+Riak will not compile with Clang. Please make sure that your default C/C++
+compiler is [GCC](https://gcc.gnu.org/).
+{{% /note %}}
 
 Riak requires [Erlang](http://www.erlang.org/) R16B02+.
 

--- a/content/riak/kv/2.0.6/using/admin/riak-admin.md
+++ b/content/riak/kv/2.0.6/using/admin/riak-admin.md
@@ -185,11 +185,10 @@ rename the nodes of a cluster. For more information, visit the
 riak-admin reip <old nodename> <new nodename>
 ```
 
-<div class="note">
-<div class="title">Note about reip prior to Riak 2.0</title></div>
-Several bugs have been fixed related to reip in Riak 2.0. We recommend
-against using reip prior to 2.0, if possible.
-</div>
+{{% note title="Note about reip prior to Riak 2.0" %}}
+Several bugs have been fixed related to reip in Riak 2.0. We recommend against
+using reip prior to 2.0, if possible.
+{{% /note %}}
 
 
 ## js-reload
@@ -389,12 +388,10 @@ entropy tree building, and key repairs which were triggered by AAE.
  * The *Max* column shows the maximum number of keys repaired during all
    key exchanges since the last node restart.
 
-<div class="note">
-<div class="title">Note in AAE status information</div>
-All AAE status information is in-memory and is reset across a node
-restart. Only tree build times are persistent (since trees themselves
-are persistent)
-</div>
+{{% note title="Note in AAE status information" %}}
+All AAE status information is in-memory and is reset across a node restart.
+Only tree build times are persistent (since trees themselves are persistent)
+{{% /note %}}
 
 More details on the `aae-status` command are available in the [Riak
 version 1.3 release notes](https://github.com/basho/riak/blob/1.3/RELEASE-NOTES.md#active-anti-entropy).
@@ -628,11 +625,10 @@ repaired for a given exchange round since the node has started.
 
 ### switch-to-new-search
 
-<div class="info">
-<div class="title">Only For Legacy Migration</div>
-This is only needed when migrating from legacy riak search to the new
-Search (Yokozuna).
-</div>
+{{% note title="Only For Legacy Migration" %}}
+This is only needed when migrating from legacy riak search to the new Search
+(Yokozuna).
+{{% /note %}}
 
 ```bash
 riak-admin search switch-to-new-search

--- a/content/riak/kv/2.0.6/using/admin/riak-control.md
+++ b/content/riak/kv/2.0.6/using/admin/riak-control.md
@@ -57,12 +57,11 @@ listener.https.<name> = 127.0.0.1:8096
 %%     the `riak_api` tuple's value list.
 ```
 
-<div class="note">
-<div class="title">Note on SSL</div>
-We strongly recommend that you enable SSL for Riak Control. It is
-disabled by default, and if you wish to enable it you must do so
-explicitly. More information can be found in the document below.
-</div>
+{{% note title="Note on SSL" %}}
+We strongly recommend that you enable SSL for Riak Control. It is disabled by
+default, and if you wish to enable it you must do so explicitly. More
+information can be found in the document below.
+{{% /note %}}
 
 ## Enabling and Disabling Riak Control
 
@@ -168,16 +167,15 @@ be because you are using self-signed certificates. If you have
 authentication enabled in your configuration, you will next be asked to
 authenticate. Enter an appropriate username and password now.
 
-<div class="note">
-<div class="title">Note on browser TLS</div>
-Your browser needs to be support TLS v1.2 to use Riak Control over
-HTTPS. A list of browsers that support TLS v1.2 can be found
+{{% note title="Note on browser TLS" %}}
+Your browser needs to be support TLS v1.2 to use Riak Control over HTTPS. A
+list of browsers that support TLS v1.2 can be found
 [here](https://en.wikipedia.org/wiki/Transport_Layer_Security#Web_browsers).
-TLS v1.2 may be disabled by default on your browser, for example if you
-are using Firefox versions earlier than 27, Safari versions earlier than
-7, Chrome versions earlier than 30, or Internet Explorer versions
-earlier than 11.  To enable it, follow browser-specific instructions.
-</div>
+TLS v1.2 may be disabled by default on your browser, for example if you are
+using Firefox versions earlier than 27, Safari versions earlier than 7, Chrome
+versions earlier than 30, or Internet Explorer versions earlier than 11.  To
+enable it, follow browser-specific instructions.
+{{% /note %}}
 
 ### Snapshot View
 

--- a/content/riak/kv/2.0.6/using/cluster-operations/adding-removing-nodes.md
+++ b/content/riak/kv/2.0.6/using/cluster-operations/adding-removing-nodes.md
@@ -136,15 +136,14 @@ Transfers resulting from cluster changes: 51
 If the plan is to your liking, submit the changes by running `riak-admin
 cluster commit`.
 
-<div class="note">
-<div class="title">Note on ring changes</div>
-The algorithm that distributes partitions across the cluster
-during membership changes is non-deterministic. As a result, there is no
-optimal ring. In the event that a plan results in a slightly uneven
-distribution of partitions, the plan can be cleared. Clearing a cluster
-plan with `riak-admin cluster clear` and running `riak-admin cluster
-plan` again will produce a slightly different ring.
-</div>
+{{% note title="Note on ring changes" %}}
+The algorithm that distributes partitions across the cluster during membership
+changes is non-deterministic. As a result, there is no optimal ring. In the
+event that a plan results in a slightly uneven distribution of partitions, the
+plan can be cleared. Clearing a cluster plan with `riak-admin cluster clear`
+and running `riak-admin cluster plan` again will produce a slightly different
+ring.
+{{% /note %}}
 
 ## Removing a Node From a Cluster
 

--- a/content/riak/kv/2.0.6/using/cluster-operations/bucket-types.md
+++ b/content/riak/kv/2.0.6/using/cluster-operations/bucket-types.md
@@ -16,14 +16,13 @@ Buckets are essentially a flat namespace in Riak. They allow the same
 key name to exist in multiple buckets and enable you to apply
 configurations across keys.
 
-<div class="info">
-<div class="title">How Many Buckets Can I Have?</div>
-Buckets come with virtually no cost <em>except for when you modify the
-default bucket properties</em>. Modified bucket properties are gossiped
-around the cluster and therefore add to the amount of data sent around
-the network. In other words, buckets using the <tt>default</tt> bucket
-type are free. More on that in the next section.
-</div>
+{{% note title="How Many Buckets Can I Have?" %}}
+Buckets come with virtually no cost _except for when you modify the default
+bucket properties_. Modified bucket properties are gossiped around the cluster
+and therefore add to the amount of data sent around the network. In other
+words, buckets using the `default` bucket type are free. More on that in the
+next section.
+{{% /note %}}
 
 In Riak versions 2.0 and later, Basho suggests that you [use bucket types](/riak/kv/2.0.6/developing/usage/bucket-types) to namespace and configure all buckets you use. Bucket types have a lower overhead within the cluster than the
 default bucket namespace but require an additional setup step on the

--- a/content/riak/kv/2.0.6/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.0.6/using/cluster-operations/changing-cluster-info.md
@@ -302,9 +302,12 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
-<div class="note"><div class="title">Note</div>
-When using the `riak-admin cluster force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
-</div>
+{{% note title="Note" %}}
+When using the `riak-admin cluster force-replace` command, you will always get
+a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be
+lost`. Since we didn't delete any data files and we are replacing the node
+with itself under a new name, we will not lose any replicas.
+{{% /note %}}
 
 <a id="repeat"></a>
 #### Repeat previous steps on each node

--- a/content/riak/kv/2.0.6/using/cluster-operations/replacing-node.md
+++ b/content/riak/kv/2.0.6/using/cluster-operations/replacing-node.md
@@ -86,12 +86,10 @@ with the [`riak-admin ringready`](/riak/kv/2.0.6/using/admin/riak-admin/#ringrea
 and [`riak-admin member-status`](/riak/kv/2.0.6/using/admin/riak-admin/#member-status)
 commands.
 
-<div class="info">
-<div class="title">Ring Settling</div>
-You'll need to make sure that no other ring changes occur between the
-time when you start the new node and the ring settles with the new IP
-info.
+{{% note title="Ring Settling" %}}
+You'll need to make sure that no other ring changes occur between the time
+when you start the new node and the ring settles with the new IP info.
 
-The ring is considered settled when the new node reports `true` when you
-run the `riak-admin ringready` command.
-</div>
+The ring is considered settled when the new node reports `true` when you run
+the `riak-admin ringready` command.
+{{% /note %}}

--- a/content/riak/kv/2.0.6/using/cluster-operations/strong-consistency.md
+++ b/content/riak/kv/2.0.6/using/cluster-operations/strong-consistency.md
@@ -12,10 +12,14 @@ menu:
 toc: true
 ---
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 ## Monitoring Strong Consistency
 

--- a/content/riak/kv/2.0.6/using/performance.md
+++ b/content/riak/kv/2.0.6/using/performance.md
@@ -26,13 +26,12 @@ changes.
 For performance and tuning recommendations specific to running Riak
 clusters on the Amazon Web Services EC2 environment, see [AWS Performance Tuning](/riak/kv/2.0.6/using/performance/amazon-web-services).
 
-<div class="note">
-<div class="title">Note on other operating systems</div>
+{{% note title="Note on other operating systems" %}}
 Unless otherwise specified, the tunings recommended below are for Linux
-distributions. Users implementing Riak on BSD and Solaris distributions
-can use these tuning recommendations to make analogous changes in those
-operating systems.
-</div>
+distributions. Users implementing Riak on BSD and Solaris distributions can
+use these tuning recommendations to make analogous changes in those operating
+systems.
+{{% /note %}}
 
 ## Storage and File System Tuning
 
@@ -171,12 +170,11 @@ net.ipv4.tcp_tw_reuse = 1
 net.ipv4.tcp_moderate_rcvbuf = 1
 ```
 
-<div class="note">
-<div class="title">Note on system default</div>
+{{% note title="Note on system default" %}}
 In general, these recommended values should be compared with the system
-defaults and only changed if benchmarks or other performance metrics
-indicate that networking is the bottleneck.
-</div>
+defaults and only changed if benchmarks or other performance metrics indicate
+that networking is the bottleneck.
+{{% /note %}}
 
 The following settings are optional, but may improve performance on a
 10Gb network:
@@ -211,11 +209,10 @@ ethtool -K eth0 tso off
 `ethtool` settings can be persisted across reboots by adding the above
 command to the `/etc/rc.local` script.
 
-<div class="info">
-<div class="title">Pro tip</div>
-Tuning these values will be required if they are changed, as they affect
-all network operations.
-</div>
+{{% note title="Pro tip" %}}
+Tuning these values will be required if they are changed, as they affect all
+network operations.
+{{% /note %}}
 
 ## Optional I/O Settings
 

--- a/content/riak/kv/2.0.6/using/performance/amazon-web-services.md
+++ b/content/riak/kv/2.0.6/using/performance/amazon-web-services.md
@@ -54,14 +54,13 @@ indexes are not needed for the application.
 In any case, proper benchmarking and tuning are needed to achieve the
 desired performance.
 
-<div class="info">
-<div class="title">Tip</div>
-Most successful AWS cluster deployments use more EC2 instances than they
-would the same number of physical nodes to compensate for the
-performance variability caused by shared, virtualized resources. Plan to
-have more EC2 instance based nodes than physical server nodes when
-estimating cluster size with respect to node count.
-</div>
+{{% note title="Tip" %}}
+Most successful AWS cluster deployments use more EC2 instances than they would
+the same number of physical nodes to compensate for the performance
+variability caused by shared, virtualized resources. Plan to have more EC2
+instance based nodes than physical server nodes when estimating cluster size
+with respect to node count.
+{{% /note %}}
 
 ## Operating System
 

--- a/content/riak/kv/2.0.6/using/performance/erlang.md
+++ b/content/riak/kv/2.0.6/using/performance/erlang.md
@@ -44,16 +44,15 @@ Erlang parameter | Riak parameter
 [`-env ERL_MAX_ETS_TABLES`](http://learnyousomeerlang.com/ets) | `erlang.max_ets_tables`
 `-name` | `nodename`
 
-<div class="note">
-<div class="title">Note on upgrading to 2.0</div>
-In versions of Riak prior to 2.0, Erlang VM-related parameters were
-specified in a `vm.args` configuration file; in versions 2.0 and later,
-all Erlang-VM-specific parameters are set in the `riak.conf` file. If
-you're upgrading to 2.0 from an earlier version, you can still use your
-old `vm.args` if you wish.  Please note, however, that if you set one or
-more parameters in both `vm.args` and in `riak.conf`, the settings in
-`vm.args` will override those in `riak.conf`.
-</div>
+{{% note title="Note on upgrading to 2.0" %}}
+In versions of Riak prior to 2.0, Erlang VM-related parameters were specified
+in a `vm.args` configuration file; in versions 2.0 and later, all
+Erlang-VM-specific parameters are set in the `riak.conf` file. If you're
+upgrading to 2.0 from an earlier version, you can still use your old `vm.args`
+if you wish.  Please note, however, that if you set one or more parameters in
+both `vm.args` and in `riak.conf`, the settings in `vm.args` will override
+those in `riak.conf`.
+{{% /note %}}
 
 ## SMP
 

--- a/content/riak/kv/2.0.6/using/reference/bucket-types.md
+++ b/content/riak/kv/2.0.6/using/reference/bucket-types.md
@@ -16,14 +16,12 @@ Bucket types allow groups of buckets to share configuration details and
 for Riak users to manage bucket properties more efficiently than in the
 older configuration system based on [bucket properties](/riak/kv/2.0.6/developing/usage/bucket-types/#bucket-properties-and-operations).
 
-<div class="note">
-<div class="title">Important note on cluster downgrades</div>
-If you upgrade a Riak to version 2.0 or later, you can still downgrade
-the cluster to a pre-2.0 version <em>as long as you have not created and
-activated a bucket type in the cluster</em>. Once any bucket type has
-been created and activated, you can no longer downgrade the cluster to a
-pre-2.0 version.
-</div>
+{{% note title="Important note on cluster downgrades" %}}
+If you upgrade a Riak to version 2.0 or later, you can still downgrade the
+cluster to a pre-2.0 version _as long as you have not created and activated a
+bucket type in the cluster_. Once any bucket type has been created and
+activated, you can no longer downgrade the cluster to a pre-2.0 version.
+{{% /note %}}
 
 ## How Bucket Types Work
 
@@ -129,11 +127,11 @@ If creation is successful, you should see the following output:
 type_using_defaults created
 ```
 
-<div class="note">
+{{% note %}}
 The `create` command can be run multiple times prior to a bucket type being
 activated. Riak will persist only those properties contained in the final call
 of the command.
-</div>
+{{% /note %}}
 
 Creating bucket types that assign properties _always_ involves passing
 stringified JSON to the `create` command. One way to do that is to pass
@@ -243,11 +241,22 @@ of the type:
 riak-admin bucket-type update type_to_update '{"props":{ ... }}'
 ```
 
-> **Note**
->
-> Any bucket properties associated with a type can be modified after a bucket is created, with two important exceptions: `consistent` and `datatype`. If a bucket type entails strong consistency (requiring that `consistent` be set to `true`) or is set up as a `map`, `set`, or `counter`, then this will be true of the bucket type once and for all.
->
-> If you need to change one of these properties, it is recommended that you simply create and activate a new bucket type.
+{{% note title="Immutable Configurations" %}}
+Any bucket properties associated with a type can be modified after a bucket is
+created, with three important exceptions:
+
+* `consistent`
+* `datatype`
+* `write_once`
+
+If a bucket type entails strong consistency (requiring that `consistent` be
+set to `true`), is set up as a `map`, `set`, or `counter`, or is defined as a
+write-once  bucket (requiring `write_once` be set to `true`), then this will
+be true of the bucket types.
+
+If you need to change one of these properties, we recommend that you simply
+create and activate a new bucket type.
+{{% /note %}}
 
 ## Buckets as Namespaces
 
@@ -375,12 +384,11 @@ curl http://localhost:8098/types/type1/buckets/my_bucket/keys/my_key
 curl http://localhost:8098/types/type2/buckets/my_bucket/keys/my_key
 ```
 
-<div class="note">
-<div class="title">Note on object location</div>
-In Riak 2.x, <em>all requests</em> must be made to a location specified
-by a bucket type, bucket, and key rather than to a bucket/key pair, as
-in previous versions.
-</div>
+{{% note title="Note on object location" %}}
+In Riak 2.x, _all requests_ must be made to a location specified by a bucket
+type, bucket, and key rather than to a bucket/key pair, as in previous
+versions.
+{{% /note %}}
 
 If requests are made to a bucket/key pair without a specified bucket
 type, `default` will be used in place of a bucket type. The following

--- a/content/riak/kv/2.0.6/using/reference/custom-code.md
+++ b/content/riak/kv/2.0.6/using/reference/custom-code.md
@@ -31,13 +31,13 @@ name must have the same name the module. So if you are given a file named
 If you have been given Erlang code and are expected to compile it for
 your developers, keep the following notes in mind.
 
-<div class="info"><div class="title">Note on the Erlang Compiler</div> You
-must use the Erlang compiler (<tt>erlc</tt>) associated with the Riak
+{{% note title="Note on the Erlang Compiler" %}}
+You must use the Erlang compiler (`erlc`) associated with the Riak
 installation or the version of Erlang used when compiling Riak from source.
-For packaged Riak installations, you can consult Table 1 below for the
-default location of Riak's <tt>erlc</tt> for each supported platform.
-If you compiled from source, use the <tt>erlc</tt> from the Erlang version
-you used to compile Riak.</div>
+For packaged Riak installations, you can consult Table 1 below for the default
+location of Riak's `erlc` for each supported platform. If you compiled from
+source, use the `erlc` from the Erlang version you used to compile Riak.
+{{% /note %}}
 
 <table style="width: 100%; border-spacing: 0px;">
 <tbody>
@@ -88,8 +88,9 @@ and loaded. For our example, we'll use a temporary directory `/tmp/beams`,
 but you should choose a directory for production functions based on your
 own requirements such that they will be available where and when needed.
 
-<div class="info">Ensure that the directory chosen above can be read by
-the <tt>riak</tt> user.</div>
+{{% note %}}
+Ensure that the directory chosen above can be read by the `riak` user.
+{{% /note %}}
 
 Successful compilation will result in a new `.beam` file,
 `validate_json.beam`.
@@ -124,5 +125,7 @@ value store has fully initialized and become available for use.
 This is done with the `riak-admin wait-for-service` command as detailed
 in the [Commands documentation](/riak/kv/2.0.6/using/admin/riak-admin/#wait-for-service).
 
-<div class="note">It is important that you ensure riak_kv is
-active before restarting the next node.</div>
+{{% note %}}
+It is important that you ensure riak_kv is active before restarting the next
+node.
+{{% /note %}}

--- a/content/riak/kv/2.0.6/using/reference/multi-datacenter/comparison.md
+++ b/content/riak/kv/2.0.6/using/reference/multi-datacenter/comparison.md
@@ -18,13 +18,12 @@ aliases:
 This document is a systematic comparison of [Version 2](/riak/kv/2.0.6/using/reference/v2-multi-datacenter) and [Version 3](/riak/kv/2.0.6/using/reference/v3-multi-datacenter) of Riak Enterprise's Multi-Datacenter
 Replication capabilities.
 
-<div class="note">
-<div class="title">Important note on mixing versions</div>
+{{% note title="Important note on mixing versions" %}}
 If you are installing Riak Enterprise anew, you should use version 3
-replication. Under no circumstances should you mix version 2 and version
-3 replication. This comparison is meant only to list improvements
-introduced in version 3.
-</div>
+replication. Under no circumstances should you mix version 2 and version 3
+replication. This comparison is meant only to list improvements introduced in
+version 3.
+{{% /note %}}
 
 ## Version 2
 

--- a/content/riak/kv/2.0.6/using/reference/multi-datacenter/monitoring.md
+++ b/content/riak/kv/2.0.6/using/reference/multi-datacenter/monitoring.md
@@ -34,14 +34,12 @@ replication:
 * Use canary (test) objects to test replication and establish trip times
   from source to sink clusters
 
-<div class="note">
-<div class="title">Note on querying and time windows</div>
-Riak's statistics are calculated over a sliding 60-second window. Each
-time you query the stats interface, each sliding statistic shown is a
-sum or histogram value calculated from the previous 60 seconds of data.
-Because of this, the stats interface should not be queried more than
-once per minute.
-</div>
+{{% note title="Note on querying and time windows" %}}
+Riak's statistics are calculated over a sliding 60-second window. Each time
+you query the stats interface, each sliding statistic shown is a sum or
+histogram value calculated from the previous 60 seconds of data. Because of
+this, the stats interface should not be queried more than once per minute.
+{{% /note %}}
 
 ## Statistics
 

--- a/content/riak/kv/2.0.6/using/reference/statistics-monitoring.md
+++ b/content/riak/kv/2.0.6/using/reference/statistics-monitoring.md
@@ -92,15 +92,13 @@ As with the throughput metrics, keeping an eye on average (and max)
 latency times will help detect usage patterns, and provide advanced
 warnings for potential problems.
 
-<div class="note">
-<div class="title">Note on FSM Time Stats</div>
-FSM Time Stats represent the amount of time in microseconds required
-to traverse the GET or PUT Finite State Machine code, offering a
-picture of general node health. From your application's perspective,
-FSM Time effectively represents experienced latency. Mean, Median, and
-95th-, 99th-, and 100th-percentile (Max) counters are displayed. These
-are one-minute stats.
-</div>
+{{% note title="Note on FSM Time Stats" %}}
+FSM Time Stats represent the amount of time in microseconds required to
+traverse the GET or PUT Finite State Machine code, offering a picture of
+general node health. From your application's perspective, FSM Time effectively
+represents experienced latency. Mean, Median, and 95th-, 99th-, and
+100th-percentile (Max) counters are displayed. These are one-minute stats.
+{{% /note %}}
 
 Metric | Also | Relevance | Latency (in microseconds)
 :------|:-----|:----------|:-------------------------
@@ -191,19 +189,21 @@ reported success with when used for monitoring the operational status of
 their Riak clusters. Community and open source projects are presented
 along with commercial and hosted services.
 
-<div class="note">
-<div class="title">Note on Riak 2.x Statistics Support</div>
-Many of the below tools were either created by third-parties or Basho engineers
-for general usage, and have been passed to the community for further updates. As
-such, many of the below only aggregate the statistics and messages that were
-output by Riak 1.4.x.</br>
+{{% note title="Note on Riak 2.x Statistics Support" %}}
+Many of the below tools were either created by third-parties or Basho
+engineers for general usage, and have been passed to the community for further
+updates. As such, many of the below only aggregate the statistics and messages
+that were output by Riak 1.4.x.
+
 Like all code under [Basho Labs](https://github.com/basho-labs/), the below
-tools are "best effort" and have no dedicated Basho support. We both appreciate
-and need your contribution to keep these tools stable and up to date. Please
-open up a GitHub issue on the repository if you'd like to be a maintainer.</br>
-Look for banners calling out the tools we've verified that support the latest Riak 2.x
-statistics!
-</div>
+tools are "best effort" and have no dedicated Basho support. We both
+appreciate and need your contribution to keep these tools stable and up to
+date. Please open up a GitHub issue on the repository if you'd like to be a
+maintainer.
+
+Look for banners calling out the tools we've verified that support the latest
+Riak 2.x statistics!
+{{% /note %}}
 
 ### Self-Hosted Monitoring Tools
 
@@ -250,9 +250,9 @@ the Riak HTTP [`/stats`](/riak/kv/2.0.6/developing/api/http/status) endpoint is 
 
 #### Nagios
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x.**
+{{% /note %}}
 
 [Nagios](http://www.nagios.org) is a monitoring and alerting solution
 that can provide information on the status of Riak cluster nodes, in
@@ -286,9 +286,9 @@ module specifically designed to read Riak statistics.
 
 #### Zabbix
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [Zabbix](http://www.zabbix.com) is an open-source performance monitoring,
 alerting, and graphing solution that can provide information on the state of
@@ -312,9 +312,9 @@ capacity planning in a Riak cluster environment.
 
 #### New Relic
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [New Relic](http://newrelic.com) is a data analytics and visualization platform
 that can provide information on the current and past states of Riak nodes and

--- a/content/riak/kv/2.0.6/using/reference/v3-multi-datacenter/cascading-writes.md
+++ b/content/riak/kv/2.0.6/using/reference/v3-multi-datacenter/cascading-writes.md
@@ -28,13 +28,11 @@ Riak Enterprise. It will need to be manually enabled on new clusters.
 Cascading realtime requires the `{riak_repl, rtq_meta}` capability to
 function.
 
-<div class="note">
-<div class="title">Note on cascading tracking</div>
-Cascading tracking is a simple list of where an object has been written.
-This works well for most common configurations. Larger installations,
-however, may have writes cascade to clusters to which other clusters
-have already written.
-</div>
+{{% note title="Note on cascading tracking" %}}
+Cascading tracking is a simple list of where an object has been written. This
+works well for most common configurations. Larger installations, however, may
+have writes cascade to clusters to which other clusters have already written.
+{{% /note %}}
 
 
 ```

--- a/content/riak/kv/2.0.6/using/repair-recovery/errors.md
+++ b/content/riak/kv/2.0.6/using/repair-recovery/errors.md
@@ -135,11 +135,10 @@ Riak to explain the correct course of action. For example, the
 `map/reduce` `parse_input` phase will respond like this when it
 encounters an invalid input:
 
-<div class="note">
-<div class="title">Note on inputs</div>
-Inputs must be a binary bucket, a tuple of bucket and key-filters, a
-list of target tuples, a search index, or modfun tuple: `INPUT`.
-</div>
+{{% note title="Note on inputs" %}}
+Inputs must be a binary bucket, a tuple of bucket and key-filters, a list of
+target tuples, a search index, or modfun tuple: `INPUT`.
+{{% /note %}}
 
 For the remaining common error codes, they are often marked by Erlang
 atoms (and quite often wrapped within an `{error,{badmatch,{...` tuple,

--- a/content/riak/kv/2.0.6/using/repair-recovery/failure-recovery.md
+++ b/content/riak/kv/2.0.6/using/repair-recovery/failure-recovery.md
@@ -117,6 +117,8 @@ spreading load and increasing available CPU and IOPS.
 
 See [Changing Cluster Information](/riak/kv/2.1.4/using/cluster-operations/changing-cluster-info/#clusters-from-backups) for instructions on cluster recovery.
 
-<div class="info">
-<div class="title">Tip</div> If you are a licensed Riak Enterprise or CS customer and require assistance or further advice with a cluster recovery, please file a ticket with the <a href="https://help.basho.com">Basho Helpdesk</a>.
-</div>
+{{% note title="Tip" %}}
+If you are a licensed Riak Enterprise or CS customer and require assistance or
+further advice with a cluster recovery, please file a ticket with the
+<a href="https://help.basho.com">Basho Helpdesk</a>.
+{{% /note %}}

--- a/content/riak/kv/2.0.6/using/repair-recovery/repairs.md
+++ b/content/riak/kv/2.0.6/using/repair-recovery/repairs.md
@@ -169,10 +169,11 @@ If there are compaction errors in any of your vnodes, those will be listed in th
 ./442446784738847563128068650529343492278651453440/LOG 
 ```
 
-<div class="note">
-<div class="title">Note</div>
-While corruption on one vnode is not uncommon, corruption in several vnodes very likely means that there is a deeper problem that needs to be address, perhaps on the OS or hardware level.
-</div>
+{{% note title="Note" %}}
+While corruption on one vnode is not uncommon, corruption in several vnodes
+very likely means that there is a deeper problem that needs to be address,
+perhaps on the OS or hardware level.
+{{% /note %}}
 
 ## Healing Corrupted LevelDBs
 

--- a/content/riak/kv/2.0.6/using/running-a-cluster.md
+++ b/content/riak/kv/2.0.6/using/running-a-cluster.md
@@ -171,14 +171,13 @@ the node's ring file.
 riak-admin cluster replace riak@127.0.0.1 riak@192.168.1.10
 ```
 
-<div class="note">
-<div class="title">Note on single nodes</div>
-If a node is started singly using default settings, as you might do when
-you are building your first test environment, you will need to remove
-the ring files from the data directory after you edit your configuration
-files. `riak-admin cluster replace` will not work since the node has not
-been joined to a cluster.
-</div>
+{{% note title="Note on single nodes" %}}
+If a node is started singly using default settings, as you might do when you
+are building your first test environment, you will need to remove the ring
+files from the data directory after you edit your configuration files.
+`riak-admin cluster replace` will not work since the node has not been joined
+to a cluster.
+{{% /note %}}
 
 As with all cluster changes, you need to view the planned changes by
 running `riak-admin cluster plan` and then running `riak-admin cluster

--- a/content/riak/kv/2.0.6/using/security/basics.md
+++ b/content/riak/kv/2.0.6/using/security/basics.md
@@ -444,13 +444,11 @@ Permission | Operation |
 `riak_kv.list_keys` | List all of the keys in a bucket
 `riak_kv.list_buckets` | List all buckets
 
-<div class="note">
-<div class="title">Note on Listing Keys and Buckets</div>
-<code>riak_kv.list_keys</code> and <code>riak_kv.list_buckets</code> are
-both very expensive operations that should be performed very rarely and
-never in production. Access to this functionality should be granted very
-carefully.
-</div>
+{{% note title="Note on Listing Keys and Buckets" %}}
+`riak_kv.list_keys` and `riak_kv.list_buckets` are both very expensive
+operations that should be performed very rarely and never in production.
+Access to this functionality should be granted very carefully.
+{{% /note %}}
 
 If you'd like to create, for example, a `client` account that is
 allowed only to run `GET` and `PUT` requests on all buckets:
@@ -631,23 +629,20 @@ The following command would remove the source for `riakuser` on
 riak-admin security del-source riakuser 127.0.0.1/32
 ```
 
-<div class="note">
-<div class="title">Note on Removing Sources</div>
-If you apply a security source both to <code>all</code> and to specific
-users and then wish to remove that source, you will need to do so in
-separate steps. The <code>riak-admin security del-source all ...</code>
-command by itself is not sufficient.
+{{% note title="Note on Removing Sources" %}}
+If you apply a security source both to `all` and to specific users and then
+wish to remove that source, you will need to do so in separate steps. The
+`riak-admin security del-source all ...` command by itself is not sufficient.
 
-For example, if you have assigned the source <code>password</code> to
-both <code>all</code> and to the user <code>riakuser</code> on the
-network <code>127.0.0.1/32</code>, the following two-step process would
-be required to fully remove the source:
+For example, if you have assigned the source `password` to both `all` and to
+the user `riakuser` on the network `127.0.0.1/32`, the following two-step
+process would be required to fully remove the source:
 
 ```bash
 riak-admin security del-source all 127.0.0.1/32 password
 riak-admin security del-source riakuser 127.0.0.1/32 password
 ```
-</div>
+{{% /note %}}
 
 ### More Usage Examples
 

--- a/content/riak/kv/2.0.6/using/security/managing-sources.md
+++ b/content/riak/kv/2.0.6/using/security/managing-sources.md
@@ -29,11 +29,10 @@ The examples below will assume that the network in question is
 [created](/riak/kv/2.0.6/using/security/basics/#user-management) and that
 security has been [enabled](/riak/kv/2.0.6/using/security/basics/#the-basics).
 
-<div class="note">
-<div class="title">Note on SSL connections</div>
-If you use <em>any</em> of the aforementioned security sources, even
-<code>trust</code>, you will need to do so via a secure SSL connection.
-</div>
+{{% note title="Note on SSL connections" %}}
+If you use _any_ of the aforementioned security sources, even `trust`, you
+will need to do so via a secure SSL connection.
+{{% /note %}}
 
 ## Trust-based Authentication
 

--- a/content/riak/kv/2.0.7/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.0.7/configuring/load-balancing-proxy.md
@@ -184,15 +184,13 @@ act as a front-end proxy to a 5-node Riak cluster.
 This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
-<div class="note">
-<div class="title">Nginx version notes</div>
-This example configuration was verified on <strong>Nginx version
-1.2.3</strong>. Please be aware that earlier versions of Nginx did not
-support any HTTP 1.1 semantics for upstream communication to backends.
-You should carefully examine this configuration and make changes
-appropriate to your specific environment before attempting to use
-it
-</div>
+{{% note title="Nginx version notes" %}}
+This example configuration was verified on **Nginx version 1.2.3**. Please be
+aware that earlier versions of Nginx did not support any HTTP 1.1 semantics
+for upstream communication to backends. You should carefully examine this
+configuration and make changes appropriate to your specific environment before
+attempting to use it
+{{% /note %}}
 
 Here is an example `nginx.conf` file:
 
@@ -250,13 +248,12 @@ server {
 }
 ```
 
-<div class="note">
-<div class="title">Note on access controls</div>
-Even when filtering and limiting requests to GETs only as done in the
-example, you should strongly consider additional access controls beyond
-what Nginx can provide directly, such as specific firewall rules to
-limit inbound connections to trusted sources.
-</div>
+{{% note title="Note on access controls" %}}
+Even when filtering and limiting requests to GETs only as done in the example,
+you should strongly consider additional access controls beyond what Nginx can
+provide directly, such as specific firewall rules to limit inbound connections
+to trusted sources.
+{{% /note %}}
 
 ### Querying Secondary Indexes Over HTTP
 

--- a/content/riak/kv/2.0.7/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.0.7/configuring/load-balancing-proxy.md
@@ -185,7 +185,7 @@ This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
 <div class="note">
-<div class="title">Nginx version notes</div
+<div class="title">Nginx version notes</div>
 This example configuration was verified on <strong>Nginx version
 1.2.3</strong>. Please be aware that earlier versions of Nginx did not
 support any HTTP 1.1 semantics for upstream communication to backends.

--- a/content/riak/kv/2.0.7/configuring/v2-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.0.7/configuring/v2-multi-datacenter/ssl.md
@@ -64,8 +64,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -73,7 +72,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.0.7/configuring/v3-multi-datacenter/quick-start.md
+++ b/content/riak/kv/2.0.7/configuring/v3-multi-datacenter/quick-start.md
@@ -137,13 +137,11 @@ Sink             Cluster Name         <Ctrl-Pid>      [Members]
 Cluster1          Cluster1            <0.4456.0>      ["10.60.67.149:9080"] (via 10.60.67.149:9080)
 ```
 
-<div class="note">
-<div class="title">Note on connections</div>
-At this point, if you do not have connections, replication will not
-work. Check your IP bindings by running <code>netstat -a</code> on all
-nodes. You should see <code>*:9080 LISTENING</code>. If not, you have
-configuration problems.
-</div>
+{{% note title="Note on connections" %}}
+At this point, if you do not have connections, replication will not work.
+Check your IP bindings by running `netstat -a` on all nodes. You should see
+`*:9080 LISTENING`. If not, you have configuration problems.
+{{% /note %}}
 
 ### Enable Realtime Replication
 

--- a/content/riak/kv/2.0.7/configuring/v3-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.0.7/configuring/v3-multi-datacenter/ssl.md
@@ -54,12 +54,11 @@ the `riak-core` section of [`advanced.confg`][config reference#advanced.config]:
 The `cacertsdir` is a directory containing all the CA certificates
 needed to verify the CA chain back to the root.
 
-<div class="note">
-<div class="title">Note on configuration</div>
+{{% note title="Note on configuration" %}}
 In Version 3 replication, the SSL settings need to be placed in the
-<code>riak-core</code> section of <code>advanced.config</code> as opposed to
-the <code>riak-repl</code> section used by Version 2 replication.
-</div>
+`riak-core` section of `advanced.config` as opposed to the `riak-repl` section
+used by Version 2 replication.
+{{% /note %}}
 
 ## Verifying Peer Certificates
 
@@ -80,8 +79,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -89,7 +87,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.0.7/developing/api/http/fetch-object.md
+++ b/content/riak/kv/2.0.7/developing/api/http/fetch-object.md
@@ -79,22 +79,23 @@ datetime format
 The body of the response will be the contents of the object except when siblings
 are present.
 
-<div class="note"><div class="title">Siblings</div>
-<p>When `allow_mult` is set to true in the bucket properties, concurrent updates
-are allowed to create "sibling" objects, meaning that the object has any number
-of different values that are related to one another by the vector clock.  This
-allows your application to use its own conflict resolution technique.</p>
+{{% note title="Siblings" %}}
+When `allow_mult` is set to true in the bucket properties, concurrent updates
+are allowed to create "sibling" objects, meaning that the object has any
+number of different values that are related to one another by the vector
+clock.  This allows your application to use its own conflict resolution
+technique.
 
-<p>An object with multiple sibling values will result in a `300 Multiple
-Choices` response.  If the `Accept` header prefers `multipart/mixed`, all
-siblings will be returned in a single request as sections of the
-`multipart/mixed` response body.  Otherwise, a list of "vtags" will be given in
-a simple text format. You can request individual siblings by adding the `vtag`
-query parameter. Scroll down to the 'manually requesting siblings' example below for more information.</p>
+An object with multiple sibling values will result in a `300 Multiple Choices`
+response.  If the `Accept` header prefers `multipart/mixed`, all siblings will
+be returned in a single request as sections of the `multipart/mixed` response
+body.  Otherwise, a list of "vtags" will be given in a simple text format. You
+can request individual siblings by adding the `vtag` query parameter. Scroll
+down to the 'manually requesting siblings' example below for more information.
 
-<p>To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
-given in the response.</p>
-</div>
+To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
+given in the response.
+{{% /note %}}
 
 ## Simple Example
 

--- a/content/riak/kv/2.0.7/developing/api/http/link-walking.md
+++ b/content/riak/kv/2.0.7/developing/api/http/link-walking.md
@@ -26,22 +26,19 @@ is a special case of [MapReduce](/riak/kv/2.0.7/developing/usage/mapreduce), and
 GET /buckets/bucket/keys/key/[bucket],[tag],[keep]
 ```
 
-<div class="info"><div class="title">Link filters</div>
-<p>A link filter within the request URL is made of three parts, separated by
-commas:</p>
+{{% note title="Link filters" %}}
+A link filter within the request URL is made of three parts, separated by
+commas:
 
-<ul>
-<li>Bucket - a bucket name to limit the links to</li>
-<li>Tag - a "riaktag" to limit the links to</li>
-<li>Keep - 0 or 1, whether to return results from this phase</li>
-</ul>
+* Bucket - a bucket name to limit the links to
+* Tag - a "riaktag" to limit the links to
+* Keep - 0 or 1, whether to return results from this phase
 
-<p>Any of the three parts may be replaced with <code>_</code> (underscore),
-signifying that any value is valid. Multiple phases of links can be followed by
-adding additional path segments to the URL, separating the link filters by
-slashes. The final phase in the link-walking query implicitly returns its
-results.</p>
-</div>
+Any of the three parts may be replaced with `_` (underscore), signifying that
+any value is valid. Multiple phases of links can be followed by adding
+additional path segments to the URL, separating the link filters by slashes.
+The final phase in the link-walking query implicitly returns its results.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.0.7/developing/api/http/list-buckets.md
+++ b/content/riak/kv/2.0.7/developing/api/http/list-buckets.md
@@ -17,10 +17,10 @@ aliases:
 
 Lists all known buckets (ones that have keys stored in them).
 
-<div class="note"><div class="title">Not for production use</div>
+{{% note title="Not for production use" %}}
 Similar to the list keys operation, this requires traversing all keys stored
 in the cluster and should not be used in production.
-</div>
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.7/developing/api/http/list-keys.md
+++ b/content/riak/kv/2.0.7/developing/api/http/list-keys.md
@@ -17,12 +17,10 @@ aliases:
 
 Lists keys in a bucket.
 
-<div class="note">
-<div class="title">Not for production use</div>
-
-This operation requires traversing all keys stored in the cluster and should not be used in production.
-
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.7/developing/api/http/set-bucket-props.md
+++ b/content/riak/kv/2.0.7/developing/api/http/set-bucket-props.md
@@ -50,14 +50,12 @@ the bucket
 
 Other properties do exist but are not commonly modified.
 
-<div class="note">
-<div class="title">Property types</div>
-<p>Make sure you use the proper types for attributes like <strong>n_val</strong>
-and <strong>allow_mult</strong>. If you use strings instead of integers and
-booleans respectively, you may see some odd errors in your logs, saying
-something like
-<code>"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"</code>.</p>
-</div>
+{{% note title="Property types" %}}
+Make sure you use the proper types for attributes like **n_val** and
+**allow_mult**. If you use strings instead of integers and booleans
+respectively, you may see some odd errors in your logs, saying something like
+`"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"`.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.0.7/developing/api/protocol-buffers.md
+++ b/content/riak/kv/2.0.7/developing/api/protocol-buffers.md
@@ -106,12 +106,11 @@ Code | Message |
 254 | `RpbAuthResp` |
 255 | `RpbStartTls` |
 
-<div class="info">
-<div class="title">Message Definitions</div>
-All Protocol Buffers messages are defined in the <code>riak.proto</code>
-and other <code>.proto</code> files in the <code>/src</code> directory
-of the <a href="https://github.com/basho/riak_pb">RiakPB</a> project.
-</div>
+{{% note title="Message Definitions" %}}
+All Protocol Buffers messages are defined in the `riak.proto` and other
+`.proto` files in the `/src` directory of the
+<a href="https://github.com/basho/riak_pb">RiakPB</a> project.
+{{% /note %}}
 
 ### Error Response
 

--- a/content/riak/kv/2.0.7/developing/api/protocol-buffers/fetch-object.md
+++ b/content/riak/kv/2.0.7/developing/api/protocol-buffers/fetch-object.md
@@ -137,14 +137,12 @@ of the following optional parameters:
 * `deleted` --- Whether the object has been deleted (i.e. whether a
   tombstone for the object has been found under the specified key)
 
-<div class="note">
-<div class="title">Note on missing keys</div>
-Remember: if a key is not stored in Riak, an <code>RpbGetResp</code>
-response without the <code>content</code> and <code>vclock</code> fields
-will be returned. This should be mapped to whatever convention the
-client language uses to return not found. The Erlang client, for
-example, returns the atom <code>{error, notfound}</code>.
-</div>
+{{% note title="Note on missing keys" %}}
+Remember: if a key is not stored in Riak, an `RpbGetResp` response without the
+`content` and `vclock` fields will be returned. This should be mapped to
+whatever convention the client language uses to return not found. The Erlang
+client, for example, returns the atom `{error, notfound}`.
+{{% /note %}}
 
 ## Example
 

--- a/content/riak/kv/2.0.7/developing/api/protocol-buffers/get-client-id.md
+++ b/content/riak/kv/2.0.7/developing/api/protocol-buffers/get-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.0.7/dev/references/protocol-buffers/get-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Get the client id used for this connection. Client ids are used for
 conflict resolution and each unique actor in the system should be

--- a/content/riak/kv/2.0.7/developing/api/protocol-buffers/list-buckets.md
+++ b/content/riak/kv/2.0.7/developing/api/protocol-buffers/list-buckets.md
@@ -17,12 +17,10 @@ aliases:
 
 List all of the bucket names available.
 
-<div class="note">
-<div class="title">Caution</div>
-
-This call can be expensive for the server. Do not use in
-performance-sensitive code.
-</div>
+{{% note title="Caution" %}}
+This call can be expensive for the server. Do not use in performance-sensitive
+code.
+{{% /note %}}
 
 
 ## Request

--- a/content/riak/kv/2.0.7/developing/api/protocol-buffers/list-keys.md
+++ b/content/riak/kv/2.0.7/developing/api/protocol-buffers/list-keys.md
@@ -18,11 +18,10 @@ aliases:
 List all of the keys in a bucket. This is a streaming call, with
 multiple response messages sent for each request.
 
-<div class="note">
-<div class="title">Not for production use</div>
-This operation requires traversing all keys stored in the cluster and
-should not be used in production.
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.7/developing/api/protocol-buffers/set-client-id.md
+++ b/content/riak/kv/2.0.7/developing/api/protocol-buffers/set-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.0.7/dev/references/protocol-buffers/set-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Set the client ID for this connection. A library may want to set the
 client ID if it has a good way to uniquely identify actors across

--- a/content/riak/kv/2.0.7/developing/app-guide/advanced-mapreduce.md
+++ b/content/riak/kv/2.0.7/developing/app-guide/advanced-mapreduce.md
@@ -253,10 +253,10 @@ curl -XPOST localhost:8098/mapred \
 
 The result should be a JSON map of bucket and key names expressed as key/value pairs.
 
-<div class="info">
-Be sure to install the MapReduce function as described above on all of
-the nodes in your cluster to ensure proper operation.
-</div>
+{{% note %}}
+Be sure to install the MapReduce function as described above on all of the
+nodes in your cluster to ensure proper operation.
+{{% /note %}}
 
 
 ## Phase functions
@@ -481,27 +481,25 @@ takes any of the following forms:
 * `{jsanon, {Bucket, Key}}` where the object at `{Bucket, Key}` contains
   the source for an anonymous Javascript function
 
-<div class="info">
-<div class="title">qfun Note</div>
-Using `qfun` in compiled applications can be a fragile
-operation. Please keep the following points in mind.
+{{% note title="qfun Note" %}}
+Using `qfun` in compiled applications can be a fragile operation. Please keep
+the following points in mind.
 
-1. The module in which the function is defined must be present and
-**exactly the same version** on both the client and Riak nodes.
+1. The module in which the function is defined must be present and **exactly
+   the same version** on both the client and Riak nodes.
 
-2. Any modules and functions used by this function (or any function in
-the resulting call stack) must also be present on the Riak nodes.
+2. Any modules and functions used by this function (or any function in the
+   resulting call stack) must also be present on the Riak nodes.
 
-Errors about failures to ensure both 1 and 2 are often surprising,
-usually seen as opaque **missing-function** or **function-clause**
-errors. Especially in the case of differing module versions, this can be
-difficult to diagnose without expecting the issue and knowing of
-`Module:info/0`.
+Errors about failures to ensure both 1 and 2 are often surprising, usually
+seen as opaque **missing-function** or **function-clause** errors. Especially
+in the case of differing module versions, this can be difficult to diagnose
+without expecting the issue and knowing of `Module:info/0`.
 
-When using the Erlang shell, anonymous MapReduce functions can be
-defined and sent to Riak instead of deploying them to all servers in
-advance, but condition #2 above still holds.
-</div>
+When using the Erlang shell, anonymous MapReduce functions can be defined and
+sent to Riak instead of deploying them to all servers in advance, but
+condition #2 above still holds.
+{{% /note %}}
 
 Link phases are expressed in the following form:
 

--- a/content/riak/kv/2.0.7/developing/app-guide/replication-properties.md
+++ b/content/riak/kv/2.0.7/developing/app-guide/replication-properties.md
@@ -154,15 +154,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -330,15 +328,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -355,14 +352,12 @@ documentation on [Bitcask](/riak/kv/2.0.7/setup/planning/backend/bitcask), [Leve
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.0.7/developing/client-libraries.md
+++ b/content/riak/kv/2.0.7/developing/client-libraries.md
@@ -49,12 +49,11 @@ developing something that you wish to see added to this list, please
 fork the [Riak Docs repo on GitHub](https://github.com/basho/basho_docs)
 and send us a pull request.
 
-<div class="note">
-<div class="title">Note on community-produced libraries</div>
-All of these projects and libraries are at various stages of
-completeness and may not suit your application's needs based on their
-level of maturity and activity.
-</div>
+{{% note title="Note on community-produced libraries" %}}
+All of these projects and libraries are at various stages of completeness and
+may not suit your application's needs based on their level of maturity and
+activity.
+{{% /note %}}
 
 ### Client Libraries and Frameworks
 

--- a/content/riak/kv/2.0.7/developing/getting-started/csharp.md
+++ b/content/riak/kv/2.0.7/developing/getting-started/csharp.md
@@ -25,10 +25,12 @@ To try this flavor of Riak, a working installation of the .NET Framework or Mono
 
 Install [the Riak .NET Client](https://github.com/basho/riak-dotnet-client/wiki/Installation) through [NuGet](http://nuget.org/packages/RiakClient) or the Visual Studio NuGet package manager.
 
-<div class="note">
-<div class="title">Configuring for a remote cluster</div>
-By default, the Riak .NET Client will add a section to your `app.config` file for a four node local cluster. If you are using a remote cluster, open up `app.config` and change the `hostAddress` values to point to nodes in your remote cluster.
-</div>
+{{% note title="Configuring for a remote cluster" %}}
+By default, the Riak .NET Client will add a section to your `app.config` file
+for a four node local cluster. If you are using a remote cluster, open up
+`app.config` and change the `hostAddress` values to point to nodes in your
+remote cluster.
+{{% /note %}}
 
 ### Connecting to Riak
 

--- a/content/riak/kv/2.0.7/developing/getting-started/csharp/object-modeling.md
+++ b/content/riak/kv/2.0.7/developing/getting-started/csharp/object-modeling.md
@@ -64,12 +64,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially when many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially when many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.7/developing/getting-started/erlang/object-modeling.md
+++ b/content/riak/kv/2.0.7/developing/getting-started/erlang/object-modeling.md
@@ -18,14 +18,13 @@ aliases:
 
 To get started, let's create the records that we'll be using.
 
-<div class="note">
-<div class="title">Code Download</div>
+{{% note title="Code Download" %}}
 You can also download the code for this chapter at
 [Github](https://github.com/basho/taste-of-riak/tree/am-dem-erlang-modules/erlang/Ch03-Msgy-Schema).
 
-The Github version includes Erlang type specifications which have been
-omitted here for brevity.
-</div>
+The Github version includes Erlang type specifications which have been omitted
+here for brevity.
+{{% /note %}}
 
 
 ```erlang
@@ -91,13 +90,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.7/developing/getting-started/golang/object-modeling.md
+++ b/content/riak/kv/2.0.7/developing/getting-started/golang/object-modeling.md
@@ -182,13 +182,11 @@ users and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.7/developing/getting-started/java.md
+++ b/content/riak/kv/2.0.7/developing/getting-started/java.md
@@ -40,13 +40,11 @@ Next, download
 [`TasteOfRiak.java`](https://github.com/basho/basho_docs/raw/master/extras/code-examples/TasteOfRiak.java)
 source code for this tutorial, and save it to your working directory.
 
-<div class="note">
-<div class="title">Configuring for a local cluster</div>
-The `TasteOfRiak.java` file that you downloaded is set up to communicate
-with a 1-node Riak cluster listening on `localhost` port 10017. We
-recommend modifying the connection info directly within the
-`setUpCluster()` method.
-</div>
+{{% note title="Configuring for a local cluster" %}}
+The `TasteOfRiak.java` file that you downloaded is set up to communicate with
+a 1-node Riak cluster listening on `localhost` port 10017. We recommend
+modifying the connection info directly within the `setUpCluster()` method.
+{{% /note %}}
 
 If you execute the `TasteOfRiak.java` file within your IDE, you should
 see the following:

--- a/content/riak/kv/2.0.7/developing/getting-started/java/object-modeling.md
+++ b/content/riak/kv/2.0.7/developing/getting-started/java/object-modeling.md
@@ -157,12 +157,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.7/developing/getting-started/nodejs/object-modeling.md
+++ b/content/riak/kv/2.0.7/developing/getting-started/nodejs/object-modeling.md
@@ -73,12 +73,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_SENT_2014-03-06` or `marketing_group_INBOX_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.7/developing/getting-started/python/object-modeling.md
+++ b/content/riak/kv/2.0.7/developing/getting-started/python/object-modeling.md
@@ -83,13 +83,11 @@ users, and `<groupname>_<type>_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-06`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.7/developing/getting-started/ruby/object-modeling.md
+++ b/content/riak/kv/2.0.7/developing/getting-started/ruby/object-modeling.md
@@ -94,13 +94,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.7/developing/usage/conflict-resolution.md
+++ b/content/riak/kv/2.0.7/developing/usage/conflict-resolution.md
@@ -25,16 +25,15 @@ If you are using Riak in an [eventually consistent](/riak/kv/2.0.7/learn/concept
 unavoidable. Often, Riak can resolve these conflicts on its own
 internally if you use causal context, i.e. [vector clocks](/riak/kv/2.0.7/learn/concepts/causal-context#vector-clocks) or [dotted version vectors](/riak/kv/2.0.7/learn/concepts/causal-context#dotted-version-vectors), when updating objects. Instructions on this can be found in the section [below](#siblings).
 
-<div class="note">
-<div class="title">Important note on terminology</div>
-In versions of Riak prior to 2.0, vector clocks were the only causal
-context mechanism available in Riak, which changed with the introduction
-of dotted version vectors in 2.0. Please note that you may frequent find
-terminology in client library APIs, internal Basho documentation, and
-more that uses the term "vector clock" interchangeably with causal
-context in general. Riak's HTTP API still uses a `X-Riak-Vclock` header,
-for example, even if you are using dotted version vectors.
-</div>
+{{% note title="Important note on terminology" %}}
+In versions of Riak prior to 2.0, vector clocks were the only causal context
+mechanism available in Riak, which changed with the introduction of dotted
+version vectors in 2.0. Please note that you may frequent find terminology in
+client library APIs, internal Basho documentation, and more that uses the term
+"vector clock" interchangeably with causal context in general. Riak's HTTP API
+still uses a `X-Riak-Vclock` header, for example, even if you are using dotted
+version vectors.
+{{% /note %}}
 
 But even when you use causal context, Riak cannot always decide which
 value is most causally recent, especially in cases involving concurrent
@@ -118,12 +117,10 @@ will be no concurrent updates. If you are storing immutable data in
 which each object is guaranteed to have its own key or engaging in
 operations related to bulk loading, you should consider LWW.
 
-<div class="note">
-<div class="title">Undefined behavior warning</div>
-Setting both <code>allow_mult</code> and <code>last_write_wins</code> to
-<code>true</code> necessarily leads to unpredictable behavior and should
-always be avoided.
-</div>
+{{% note title="Undefined behavior warning" %}}
+Setting both `allow_mult` and `last_write_wins` to `true` necessarily leads to
+unpredictable behavior and should always be avoided.
+{{% /note %}}
 
 ### Resolve Conflicts on the Application Side
 
@@ -601,13 +598,12 @@ X-Riak-Vclock: a85hYGBgzGDKBVIcR4M2cgczH7HPYEpkzGNlsP/VfYYvCwA=
 # accompany the write for Riak to be able to use the vector clock
 ```
 
-<div class="note">
-<div class="title">Concurrent conflict resolution</div>
+{{% note title="Concurrent conflict resolution" %}}
 It should be noted that it is possible to have two clients that are
 simultaneously engaging in conflict resolution. To avoid a pathological
-divergence, you should be sure to limit the number of reconciliations
-and fail once that limit has been exceeded.
-</div>
+divergence, you should be sure to limit the number of reconciliations and fail
+once that limit has been exceeded.
+{{% /note %}}
 
 ### Sibling Explosion
 
@@ -649,13 +645,10 @@ better performance. Some use cases where you might want to use
 `last_write_wins` include caching, session storage, and insert-only
 (no updates).
 
-<div class="note">
-<div class="title">Note on combining <code>allow_mult</code> and
-<code>last_write_wins</code></div>
-The combination of setting both the <code>allow_mult</code> and
-<code>last_write_wins</code> properties to <code>true</code> leads to
-undefined behavior and should not be used.
-</div>
+{{% note title="Note on combining `allow_mult` and `last_write_wins`" %}}
+The combination of setting both the `allow_mult` and `last_write_wins`
+properties to `true` leads to undefined behavior and should not be used.
+{{% /note %}}
 
 ## Vector Clock Pruning
 

--- a/content/riak/kv/2.0.7/developing/usage/mapreduce.md
+++ b/content/riak/kv/2.0.7/developing/usage/mapreduce.md
@@ -15,16 +15,14 @@ aliases:
   - /riak/kv/2.0.7/dev/using/mapreduce
 ---
 
-<div class="note">
-<div class="title">Use MapReduce sparingly</div>
-In Riak, MapReduce is the primary method for non-primary-key-based
-querying. Although useful for a limited range of purposes, such as batch
-processing jobs, MapReduce operations can be very computationally
-expensive, sometimes to the extent that they can degrade performance in
-production clusters operating under load. Thus, we recommend running
-MapReduce operations in a controlled, rate-limited fashion and never for
-realtime querying purposes.
-</div>
+{{% note title="Use MapReduce sparingly" %}}
+In Riak, MapReduce is the primary method for non-primary-key-based querying.
+Although useful for a limited range of purposes, such as batch processing
+jobs, MapReduce operations can be very computationally expensive, sometimes to
+the extent that they can degrade performance in production clusters operating
+under load. Thus, we recommend running MapReduce operations in a controlled,
+rate-limited fashion and never for realtime querying purposes.
+{{% /note %}}
 
 MapReduce (M/R) is a technique for dividing data processing work across
 a distributed system. It takes advantage of the parallel processing

--- a/content/riak/kv/2.0.7/developing/usage/reading-objects.md
+++ b/content/riak/kv/2.0.7/developing/usage/reading-objects.md
@@ -197,12 +197,10 @@ The most common error code:
 
 * `404 Not Found`
 
-<div class="note">
-<div class="title">Note</div>
-If you're using a Riak client instead of HTTP, these responses will vary
-a great deal, so make sure to check the documentation for your specific
-client.
-</div>
+{{% note title="Note" %}}
+If you're using a Riak client instead of HTTP, these responses will vary a
+great deal, so make sure to check the documentation for your specific client.
+{{% /note %}}
 
 ## No Object Stored
 

--- a/content/riak/kv/2.0.7/developing/usage/replication.md
+++ b/content/riak/kv/2.0.7/developing/usage/replication.md
@@ -45,18 +45,17 @@ is one of the features that differentiates Riak from other databases.
 At the bottom of the page, you'll find a [screencast](/riak/kv/2.0.7/developing/app-guide/replication-properties#screencast) that briefly explains how to adjust your
 replication levels to match your application and business needs.
 
-<div class="note">
-<div class="title">Note on strong consistency</div>
+{{% note title="Note on strong consistency" %}}
 An option introduced in Riak version 2.0 is to use Riak as a
-<a href="http://docs.basho.com/riak/kv/2.0.7/using/reference/strong-consistency/">strongly consistent</a>
-system for data in specified buckets. Using Riak in this way is
-fundamentally different from adjusting replication properties and
-fine-tuning the availability/consistency trade-off, as it sacrifices
-<em>all</em> availability guarantees when necessary. Therefore, you
-should consult the <a href="http://docs.basho.com/riak/kv/2.0.7/developing/app-guide/strong-consistency/">Using
-Strong Consistency</a> documentation, as this option will not be covered
-in this tutorial.
-</div>
+<a href="http://docs.basho.com/riak/kv/2.0.7/using/reference/strong-consistency/">strongly
+consistent</a> system for data in specified buckets. Using Riak in this way is
+fundamentally different from adjusting replication properties and fine-tuning
+the availability/consistency trade-off, as it sacrifices _all_ availability
+guarantees when necessary. Therefore, you should consult the
+<a href="http://docs.basho.com/riak/kv/2.0.7/developing/app-guide/strong-consistency/">Using
+Strong Consistency</a> documentation, as this option will not be covered in
+this tutorial.
+{{% /note %}}
 
 ## How Replication Properties Work
 
@@ -163,15 +162,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -339,15 +336,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -364,14 +360,12 @@ documentation on [Bitcask][plan backend bitcask], [LevelDB][plan backend leveldb
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.0.7/developing/usage/security/erlang.md
+++ b/content/riak/kv/2.0.7/developing/usage/security/erlang.md
@@ -24,13 +24,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.0.7/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Erlang Client Basics
 

--- a/content/riak/kv/2.0.7/developing/usage/security/java.md
+++ b/content/riak/kv/2.0.7/developing/usage/security/java.md
@@ -23,13 +23,11 @@ If you are using [trust-](/riak/kv/2.0.7/using/security/managing-sources/#trust-
 security setup described [below](#java-client-basics). [Certificate](/riak/kv/2.0.7/using/security/managing-sources/#certificate-based-authentication)-based authentication is not
 yet supported in the Java client.
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Java Client Basics
 

--- a/content/riak/kv/2.0.7/developing/usage/security/python.md
+++ b/content/riak/kv/2.0.7/developing/usage/security/python.md
@@ -25,13 +25,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.0.7/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## OpenSSL Versions
 

--- a/content/riak/kv/2.0.7/developing/usage/security/ruby.md
+++ b/content/riak/kv/2.0.7/developing/usage/security/ruby.md
@@ -25,13 +25,11 @@ can use the security setup described in the [Ruby Client Basics](#ruby-client-ba
 in a [later section](#password-based-authentication), while [certificate](/riak/kv/2.0.7/using/security/managing-sources/#certificate-based-authentication)-based authentication
 is covered [further down](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Ruby Client Basics
 

--- a/content/riak/kv/2.0.7/introduction.md
+++ b/content/riak/kv/2.0.7/introduction.md
@@ -185,14 +185,12 @@ Based on Basho's [Cuttlefish](https://github.com/basho/cuttlefish)
 project, the new system is much simpler, leaving behind the Erlang
 syntax required in `app.config`.
 
-<div class="note">
-<div class="title">Note on upgrading</div>
-Version 2.0 will support both the old and the new configuration system,
-in case you're upgrading. Please note, however, that if you use both
-systems side by side, all settings from the older,
-`app.config`/`vm.args`-based system will override any settings from the
-new system.
-</div>
+{{% note title="Note on upgrading" %}}
+Version 2.0 will support both the old and the new configuration system, in
+case you're upgrading. Please note, however, that if you use both systems side
+by side, all settings from the older, `app.config`/`vm.args`-based system will
+override any settings from the new system.
+{{% /note %}}
 
 #### Relevant Docs
 

--- a/content/riak/kv/2.0.7/learn/concepts/strong-consistency.md
+++ b/content/riak/kv/2.0.7/learn/concepts/strong-consistency.md
@@ -18,10 +18,14 @@ aliases:
 [usage bucket types]: /riak/kv/2.0.7/developing/usage/bucket-types
 [concept eventual consistency]: /riak/kv/2.0.7/learn/concepts/eventual-consistency
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 Riak was originally designed as an [eventually consistent](/riak/kv/2.0.7/learn/concepts/eventual-consistency) system, fundamentally geared toward providing partition
 (i.e. fault) tolerance and high read and write availability.

--- a/content/riak/kv/2.0.7/setup/downgrade.md
+++ b/content/riak/kv/2.0.7/setup/downgrade.md
@@ -33,13 +33,13 @@ additional steps to be performed before, during, and after the upgrade
 on on each node.  These steps are related to changes or new features
 that are not present in the downgraded version.
 
-<div class="note">
-<div class="title">A Note About the Following Instructions</div>
-The below instructions describe the procedures required for a single
-feature release version downgrade. In a downgrade between two feature
-release versions, the steps for the in-between version must also be
-performed. For example, a downgrade from 1.4 to 1.2 requires that the
-downgrade steps for both 1.4 and 1.3 are performed.  </div>
+{{% note title="A Note About the Following Instructions" %}}
+The below instructions describe the procedures required for a single feature
+release version downgrade. In a downgrade between two feature release
+versions, the steps for the in-between version must also be performed. For
+example, a downgrade from 1.4 to 1.2 requires that the downgrade steps for
+both 1.4 and 1.3 are performed.
+{{% /note %}}
 
 ## General Guidelines
 

--- a/content/riak/kv/2.0.7/setup/installing/amazon-web-services.md
+++ b/content/riak/kv/2.0.7/setup/installing/amazon-web-services.md
@@ -62,10 +62,10 @@ You will need need to launch at least 3 instances to form a Riak cluster.  When 
 
 You can find more information on connecting to an instance on the official [Amazon EC2 instance guide](http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/AccessingInstances.html).
 
-<div class="note">
-<div class="title">Note</div>
-The following clustering setup will <em>not</em> be resilient to instance restarts unless deployed in Amazon VPC.
-</div>
+{{% note title="Note" %}}
+The following clustering setup will _not_ be resilient to instance restarts
+unless deployed in Amazon VPC.
+{{% /note %}}
 
 1. On the first node, obtain the internal IP address:
 

--- a/content/riak/kv/2.0.7/setup/installing/mac-osx.md
+++ b/content/riak/kv/2.0.7/setup/installing/mac-osx.md
@@ -52,13 +52,12 @@ directory and execute `bin/riak start` to start the Riak node.
 
 ## Homebrew
 
-<div class="note">
-<div class="title">Warning: Homebrew not always up to date</div>
-Homebrew's Riak recipe is community supported, and thus is not always up
-to date with the latest Riak package. Please ensure that the current
-recipe is using the latest supported code (and don't be afraid to update
-it if it's not).
-</div>
+{{% note title="Warning: Homebrew not always up to date" %}}
+Homebrew's Riak recipe is community supported, and thus is not always up to
+date with the latest Riak package. Please ensure that the current recipe is
+using the latest supported code (and don't be afraid to update it if it's
+not).
+{{% /note %}}
 
 Installing Riak 2.0 with [Homebrew](http://brew.sh/) is easy:
 
@@ -92,11 +91,10 @@ the Riak installation directory via environment variables.
 You must have Xcode tools installed from [Apple's Developer
 website](http://developer.apple.com/).
 
-<div class="note">
-<div class="title">Note on Clang</div>
-Riak will not compile with Clang. Please make sure that your default
-C/C++ compiler is [GCC](https://gcc.gnu.org/).
-</div>
+{{% note title="Note on Clang" %}}
+Riak will not compile with Clang. Please make sure that your default C/C++
+compiler is [GCC](https://gcc.gnu.org/).
+{{% /note %}}
 
 Riak requires [Erlang](http://www.erlang.org/) R16B02+.
 

--- a/content/riak/kv/2.0.7/using/admin/riak-admin.md
+++ b/content/riak/kv/2.0.7/using/admin/riak-admin.md
@@ -185,11 +185,10 @@ rename the nodes of a cluster. For more information, visit the
 riak-admin reip <old nodename> <new nodename>
 ```
 
-<div class="note">
-<div class="title">Note about reip prior to Riak 2.0</title></div>
-Several bugs have been fixed related to reip in Riak 2.0. We recommend
-against using reip prior to 2.0, if possible.
-</div>
+{{% note title="Note about reip prior to Riak 2.0" %}}
+Several bugs have been fixed related to reip in Riak 2.0. We recommend against
+using reip prior to 2.0, if possible.
+{{% /note %}}
 
 
 ## js-reload
@@ -389,12 +388,10 @@ entropy tree building, and key repairs which were triggered by AAE.
  * The *Max* column shows the maximum number of keys repaired during all
    key exchanges since the last node restart.
 
-<div class="note">
-<div class="title">Note in AAE status information</div>
-All AAE status information is in-memory and is reset across a node
-restart. Only tree build times are persistent (since trees themselves
-are persistent)
-</div>
+{{% note title="Note in AAE status information" %}}
+All AAE status information is in-memory and is reset across a node restart.
+Only tree build times are persistent (since trees themselves are persistent)
+{{% /note %}}
 
 More details on the `aae-status` command are available in the [Riak
 version 1.3 release notes](https://github.com/basho/riak/blob/1.3/RELEASE-NOTES.md#active-anti-entropy).
@@ -628,11 +625,10 @@ repaired for a given exchange round since the node has started.
 
 ### switch-to-new-search
 
-<div class="info">
-<div class="title">Only For Legacy Migration</div>
-This is only needed when migrating from legacy riak search to the new
-Search (Yokozuna).
-</div>
+{{% note title="Only For Legacy Migration" %}}
+This is only needed when migrating from legacy riak search to the new Search
+(Yokozuna).
+{{% /note %}}
 
 ```bash
 riak-admin search switch-to-new-search

--- a/content/riak/kv/2.0.7/using/admin/riak-control.md
+++ b/content/riak/kv/2.0.7/using/admin/riak-control.md
@@ -57,12 +57,11 @@ listener.https.<name> = 127.0.0.1:8096
 %%     the `riak_api` tuple's value list.
 ```
 
-<div class="note">
-<div class="title">Note on SSL</div>
-We strongly recommend that you enable SSL for Riak Control. It is
-disabled by default, and if you wish to enable it you must do so
-explicitly. More information can be found in the document below.
-</div>
+{{% note title="Note on SSL" %}}
+We strongly recommend that you enable SSL for Riak Control. It is disabled by
+default, and if you wish to enable it you must do so explicitly. More
+information can be found in the document below.
+{{% /note %}}
 
 ## Enabling and Disabling Riak Control
 
@@ -168,16 +167,15 @@ be because you are using self-signed certificates. If you have
 authentication enabled in your configuration, you will next be asked to
 authenticate. Enter an appropriate username and password now.
 
-<div class="note">
-<div class="title">Note on browser TLS</div>
-Your browser needs to be support TLS v1.2 to use Riak Control over
-HTTPS. A list of browsers that support TLS v1.2 can be found
+{{% note title="Note on browser TLS" %}}
+Your browser needs to be support TLS v1.2 to use Riak Control over HTTPS. A
+list of browsers that support TLS v1.2 can be found
 [here](https://en.wikipedia.org/wiki/Transport_Layer_Security#Web_browsers).
-TLS v1.2 may be disabled by default on your browser, for example if you
-are using Firefox versions earlier than 27, Safari versions earlier than
-7, Chrome versions earlier than 30, or Internet Explorer versions
-earlier than 11.  To enable it, follow browser-specific instructions.
-</div>
+TLS v1.2 may be disabled by default on your browser, for example if you are
+using Firefox versions earlier than 27, Safari versions earlier than 7, Chrome
+versions earlier than 30, or Internet Explorer versions earlier than 11.  To
+enable it, follow browser-specific instructions.
+{{% /note %}}
 
 ### Snapshot View
 

--- a/content/riak/kv/2.0.7/using/cluster-operations/adding-removing-nodes.md
+++ b/content/riak/kv/2.0.7/using/cluster-operations/adding-removing-nodes.md
@@ -136,15 +136,14 @@ Transfers resulting from cluster changes: 51
 If the plan is to your liking, submit the changes by running `riak-admin
 cluster commit`.
 
-<div class="note">
-<div class="title">Note on ring changes</div>
-The algorithm that distributes partitions across the cluster
-during membership changes is non-deterministic. As a result, there is no
-optimal ring. In the event that a plan results in a slightly uneven
-distribution of partitions, the plan can be cleared. Clearing a cluster
-plan with `riak-admin cluster clear` and running `riak-admin cluster
-plan` again will produce a slightly different ring.
-</div>
+{{% note title="Note on ring changes" %}}
+The algorithm that distributes partitions across the cluster during membership
+changes is non-deterministic. As a result, there is no optimal ring. In the
+event that a plan results in a slightly uneven distribution of partitions, the
+plan can be cleared. Clearing a cluster plan with `riak-admin cluster clear`
+and running `riak-admin cluster plan` again will produce a slightly different
+ring.
+{{% /note %}}
 
 ## Removing a Node From a Cluster
 

--- a/content/riak/kv/2.0.7/using/cluster-operations/bucket-types.md
+++ b/content/riak/kv/2.0.7/using/cluster-operations/bucket-types.md
@@ -16,14 +16,13 @@ Buckets are essentially a flat namespace in Riak. They allow the same
 key name to exist in multiple buckets and enable you to apply
 configurations across keys.
 
-<div class="info">
-<div class="title">How Many Buckets Can I Have?</div>
-Buckets come with virtually no cost <em>except for when you modify the
-default bucket properties</em>. Modified bucket properties are gossiped
-around the cluster and therefore add to the amount of data sent around
-the network. In other words, buckets using the <tt>default</tt> bucket
-type are free. More on that in the next section.
-</div>
+{{% note title="How Many Buckets Can I Have?" %}}
+Buckets come with virtually no cost _except for when you modify the default
+bucket properties_. Modified bucket properties are gossiped around the cluster
+and therefore add to the amount of data sent around the network. In other
+words, buckets using the `default` bucket type are free. More on that in the
+next section.
+{{% /note %}}
 
 In Riak versions 2.0 and later, Basho suggests that you [use bucket types](/riak/kv/2.0.7/developing/usage/bucket-types) to namespace and configure all buckets you use. Bucket types have a lower overhead within the cluster than the
 default bucket namespace but require an additional setup step on the

--- a/content/riak/kv/2.0.7/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.0.7/using/cluster-operations/changing-cluster-info.md
@@ -302,9 +302,12 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
-<div class="note"><div class="title">Note</div>
-When using the `riak-admin cluster force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
-</div>
+{{% note title="Note" %}}
+When using the `riak-admin cluster force-replace` command, you will always get
+a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be
+lost`. Since we didn't delete any data files and we are replacing the node
+with itself under a new name, we will not lose any replicas.
+{{% /note %}}
 
 <a id="repeat"></a>
 #### Repeat previous steps on each node

--- a/content/riak/kv/2.0.7/using/cluster-operations/replacing-node.md
+++ b/content/riak/kv/2.0.7/using/cluster-operations/replacing-node.md
@@ -86,12 +86,10 @@ with the [`riak-admin ringready`](/riak/kv/2.0.7/using/admin/riak-admin/#ringrea
 and [`riak-admin member-status`](/riak/kv/2.0.7/using/admin/riak-admin/#member-status)
 commands.
 
-<div class="info">
-<div class="title">Ring Settling</div>
-You'll need to make sure that no other ring changes occur between the
-time when you start the new node and the ring settles with the new IP
-info.
+{{% note title="Ring Settling" %}}
+You'll need to make sure that no other ring changes occur between the time
+when you start the new node and the ring settles with the new IP info.
 
-The ring is considered settled when the new node reports `true` when you
-run the `riak-admin ringready` command.
-</div>
+The ring is considered settled when the new node reports `true` when you run
+the `riak-admin ringready` command.
+{{% /note %}}

--- a/content/riak/kv/2.0.7/using/cluster-operations/strong-consistency.md
+++ b/content/riak/kv/2.0.7/using/cluster-operations/strong-consistency.md
@@ -12,10 +12,14 @@ menu:
 toc: true
 ---
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 ## Monitoring Strong Consistency
 

--- a/content/riak/kv/2.0.7/using/performance.md
+++ b/content/riak/kv/2.0.7/using/performance.md
@@ -26,13 +26,12 @@ changes.
 For performance and tuning recommendations specific to running Riak
 clusters on the Amazon Web Services EC2 environment, see [AWS Performance Tuning](/riak/kv/2.0.7/using/performance/amazon-web-services).
 
-<div class="note">
-<div class="title">Note on other operating systems</div>
+{{% note title="Note on other operating systems" %}}
 Unless otherwise specified, the tunings recommended below are for Linux
-distributions. Users implementing Riak on BSD and Solaris distributions
-can use these tuning recommendations to make analogous changes in those
-operating systems.
-</div>
+distributions. Users implementing Riak on BSD and Solaris distributions can
+use these tuning recommendations to make analogous changes in those operating
+systems.
+{{% /note %}}
 
 ## Storage and File System Tuning
 
@@ -171,12 +170,11 @@ net.ipv4.tcp_tw_reuse = 1
 net.ipv4.tcp_moderate_rcvbuf = 1
 ```
 
-<div class="note">
-<div class="title">Note on system default</div>
+{{% note title="Note on system default" %}}
 In general, these recommended values should be compared with the system
-defaults and only changed if benchmarks or other performance metrics
-indicate that networking is the bottleneck.
-</div>
+defaults and only changed if benchmarks or other performance metrics indicate
+that networking is the bottleneck.
+{{% /note %}}
 
 The following settings are optional, but may improve performance on a
 10Gb network:
@@ -211,11 +209,10 @@ ethtool -K eth0 tso off
 `ethtool` settings can be persisted across reboots by adding the above
 command to the `/etc/rc.local` script.
 
-<div class="info">
-<div class="title">Pro tip</div>
-Tuning these values will be required if they are changed, as they affect
-all network operations.
-</div>
+{{% note title="Pro tip" %}}
+Tuning these values will be required if they are changed, as they affect all
+network operations.
+{{% /note %}}
 
 ## Optional I/O Settings
 

--- a/content/riak/kv/2.0.7/using/performance/amazon-web-services.md
+++ b/content/riak/kv/2.0.7/using/performance/amazon-web-services.md
@@ -54,14 +54,13 @@ indexes are not needed for the application.
 In any case, proper benchmarking and tuning are needed to achieve the
 desired performance.
 
-<div class="info">
-<div class="title">Tip</div>
-Most successful AWS cluster deployments use more EC2 instances than they
-would the same number of physical nodes to compensate for the
-performance variability caused by shared, virtualized resources. Plan to
-have more EC2 instance based nodes than physical server nodes when
-estimating cluster size with respect to node count.
-</div>
+{{% note title="Tip" %}}
+Most successful AWS cluster deployments use more EC2 instances than they would
+the same number of physical nodes to compensate for the performance
+variability caused by shared, virtualized resources. Plan to have more EC2
+instance based nodes than physical server nodes when estimating cluster size
+with respect to node count.
+{{% /note %}}
 
 ## Operating System
 

--- a/content/riak/kv/2.0.7/using/performance/erlang.md
+++ b/content/riak/kv/2.0.7/using/performance/erlang.md
@@ -44,16 +44,15 @@ Erlang parameter | Riak parameter
 [`-env ERL_MAX_ETS_TABLES`](http://learnyousomeerlang.com/ets) | `erlang.max_ets_tables`
 `-name` | `nodename`
 
-<div class="note">
-<div class="title">Note on upgrading to 2.0</div>
-In versions of Riak prior to 2.0, Erlang VM-related parameters were
-specified in a `vm.args` configuration file; in versions 2.0 and later,
-all Erlang-VM-specific parameters are set in the `riak.conf` file. If
-you're upgrading to 2.0 from an earlier version, you can still use your
-old `vm.args` if you wish.  Please note, however, that if you set one or
-more parameters in both `vm.args` and in `riak.conf`, the settings in
-`vm.args` will override those in `riak.conf`.
-</div>
+{{% note title="Note on upgrading to 2.0" %}}
+In versions of Riak prior to 2.0, Erlang VM-related parameters were specified
+in a `vm.args` configuration file; in versions 2.0 and later, all
+Erlang-VM-specific parameters are set in the `riak.conf` file. If you're
+upgrading to 2.0 from an earlier version, you can still use your old `vm.args`
+if you wish.  Please note, however, that if you set one or more parameters in
+both `vm.args` and in `riak.conf`, the settings in `vm.args` will override
+those in `riak.conf`.
+{{% /note %}}
 
 ## SMP
 

--- a/content/riak/kv/2.0.7/using/reference/bucket-types.md
+++ b/content/riak/kv/2.0.7/using/reference/bucket-types.md
@@ -16,14 +16,12 @@ Bucket types allow groups of buckets to share configuration details and
 for Riak users to manage bucket properties more efficiently than in the
 older configuration system based on [bucket properties](/riak/kv/2.0.7/developing/usage/bucket-types/#bucket-properties-and-operations).
 
-<div class="note">
-<div class="title">Important note on cluster downgrades</div>
-If you upgrade a Riak to version 2.0 or later, you can still downgrade
-the cluster to a pre-2.0 version <em>as long as you have not created and
-activated a bucket type in the cluster</em>. Once any bucket type has
-been created and activated, you can no longer downgrade the cluster to a
-pre-2.0 version.
-</div>
+{{% note title="Important note on cluster downgrades" %}}
+If you upgrade a Riak to version 2.0 or later, you can still downgrade the
+cluster to a pre-2.0 version _as long as you have not created and activated a
+bucket type in the cluster_. Once any bucket type has been created and
+activated, you can no longer downgrade the cluster to a pre-2.0 version.
+{{% /note %}}
 
 ## How Bucket Types Work
 
@@ -129,11 +127,11 @@ If creation is successful, you should see the following output:
 type_using_defaults created
 ```
 
-<div class="note">
+{{% note %}}
 The `create` command can be run multiple times prior to a bucket type being
 activated. Riak will persist only those properties contained in the final call
 of the command.
-</div>
+{{% /note %}}
 
 Creating bucket types that assign properties _always_ involves passing
 stringified JSON to the `create` command. One way to do that is to pass
@@ -243,11 +241,22 @@ of the type:
 riak-admin bucket-type update type_to_update '{"props":{ ... }}'
 ```
 
-> **Note**
->
-> Any bucket properties associated with a type can be modified after a bucket is created, with two important exceptions: `consistent` and `datatype`. If a bucket type entails strong consistency (requiring that `consistent` be set to `true`) or is set up as a `map`, `set`, or `counter`, then this will be true of the bucket type once and for all.
->
-> If you need to change one of these properties, it is recommended that you simply create and activate a new bucket type.
+{{% note title="Immutable Configurations" %}}
+Any bucket properties associated with a type can be modified after a bucket is
+created, with three important exceptions:
+
+* `consistent`
+* `datatype`
+* `write_once`
+
+If a bucket type entails strong consistency (requiring that `consistent` be
+set to `true`), is set up as a `map`, `set`, or `counter`, or is defined as a
+write-once  bucket (requiring `write_once` be set to `true`), then this will
+be true of the bucket types.
+
+If you need to change one of these properties, we recommend that you simply
+create and activate a new bucket type.
+{{% /note %}}
 
 ## Buckets as Namespaces
 
@@ -375,12 +384,11 @@ curl http://localhost:8098/types/type1/buckets/my_bucket/keys/my_key
 curl http://localhost:8098/types/type2/buckets/my_bucket/keys/my_key
 ```
 
-<div class="note">
-<div class="title">Note on object location</div>
-In Riak 2.x, <em>all requests</em> must be made to a location specified
-by a bucket type, bucket, and key rather than to a bucket/key pair, as
-in previous versions.
-</div>
+{{% note title="Note on object location" %}}
+In Riak 2.x, _all requests_ must be made to a location specified by a bucket
+type, bucket, and key rather than to a bucket/key pair, as in previous
+versions.
+{{% /note %}}
 
 If requests are made to a bucket/key pair without a specified bucket
 type, `default` will be used in place of a bucket type. The following

--- a/content/riak/kv/2.0.7/using/reference/custom-code.md
+++ b/content/riak/kv/2.0.7/using/reference/custom-code.md
@@ -31,13 +31,13 @@ name must have the same name the module. So if you are given a file named
 If you have been given Erlang code and are expected to compile it for
 your developers, keep the following notes in mind.
 
-<div class="info"><div class="title">Note on the Erlang Compiler</div> You
-must use the Erlang compiler (<tt>erlc</tt>) associated with the Riak
+{{% note title="Note on the Erlang Compiler" %}}
+You must use the Erlang compiler (`erlc`) associated with the Riak
 installation or the version of Erlang used when compiling Riak from source.
-For packaged Riak installations, you can consult Table 1 below for the
-default location of Riak's <tt>erlc</tt> for each supported platform.
-If you compiled from source, use the <tt>erlc</tt> from the Erlang version
-you used to compile Riak.</div>
+For packaged Riak installations, you can consult Table 1 below for the default
+location of Riak's `erlc` for each supported platform. If you compiled from
+source, use the `erlc` from the Erlang version you used to compile Riak.
+{{% /note %}}
 
 <table style="width: 100%; border-spacing: 0px;">
 <tbody>
@@ -88,8 +88,9 @@ and loaded. For our example, we'll use a temporary directory `/tmp/beams`,
 but you should choose a directory for production functions based on your
 own requirements such that they will be available where and when needed.
 
-<div class="info">Ensure that the directory chosen above can be read by
-the <tt>riak</tt> user.</div>
+{{% note %}}
+Ensure that the directory chosen above can be read by the `riak` user.
+{{% /note %}}
 
 Successful compilation will result in a new `.beam` file,
 `validate_json.beam`.
@@ -124,5 +125,7 @@ value store has fully initialized and become available for use.
 This is done with the `riak-admin wait-for-service` command as detailed
 in the [Commands documentation](/riak/kv/2.0.7/using/admin/riak-admin/#wait-for-service).
 
-<div class="note">It is important that you ensure riak_kv is
-active before restarting the next node.</div>
+{{% note %}}
+It is important that you ensure riak_kv is active before restarting the next
+node.
+{{% /note %}}

--- a/content/riak/kv/2.0.7/using/reference/multi-datacenter/comparison.md
+++ b/content/riak/kv/2.0.7/using/reference/multi-datacenter/comparison.md
@@ -18,13 +18,12 @@ aliases:
 This document is a systematic comparison of [Version 2](/riak/kv/2.0.7/using/reference/v2-multi-datacenter) and [Version 3](/riak/kv/2.0.7/using/reference/v3-multi-datacenter) of Riak Enterprise's Multi-Datacenter
 Replication capabilities.
 
-<div class="note">
-<div class="title">Important note on mixing versions</div>
+{{% note title="Important note on mixing versions" %}}
 If you are installing Riak Enterprise anew, you should use version 3
-replication. Under no circumstances should you mix version 2 and version
-3 replication. This comparison is meant only to list improvements
-introduced in version 3.
-</div>
+replication. Under no circumstances should you mix version 2 and version 3
+replication. This comparison is meant only to list improvements introduced in
+version 3.
+{{% /note %}}
 
 ## Version 2
 

--- a/content/riak/kv/2.0.7/using/reference/multi-datacenter/monitoring.md
+++ b/content/riak/kv/2.0.7/using/reference/multi-datacenter/monitoring.md
@@ -34,14 +34,12 @@ replication:
 * Use canary (test) objects to test replication and establish trip times
   from source to sink clusters
 
-<div class="note">
-<div class="title">Note on querying and time windows</div>
-Riak's statistics are calculated over a sliding 60-second window. Each
-time you query the stats interface, each sliding statistic shown is a
-sum or histogram value calculated from the previous 60 seconds of data.
-Because of this, the stats interface should not be queried more than
-once per minute.
-</div>
+{{% note title="Note on querying and time windows" %}}
+Riak's statistics are calculated over a sliding 60-second window. Each time
+you query the stats interface, each sliding statistic shown is a sum or
+histogram value calculated from the previous 60 seconds of data. Because of
+this, the stats interface should not be queried more than once per minute.
+{{% /note %}}
 
 ## Statistics
 

--- a/content/riak/kv/2.0.7/using/reference/statistics-monitoring.md
+++ b/content/riak/kv/2.0.7/using/reference/statistics-monitoring.md
@@ -92,15 +92,13 @@ As with the throughput metrics, keeping an eye on average (and max)
 latency times will help detect usage patterns, and provide advanced
 warnings for potential problems.
 
-<div class="note">
-<div class="title">Note on FSM Time Stats</div>
-FSM Time Stats represent the amount of time in microseconds required
-to traverse the GET or PUT Finite State Machine code, offering a
-picture of general node health. From your application's perspective,
-FSM Time effectively represents experienced latency. Mean, Median, and
-95th-, 99th-, and 100th-percentile (Max) counters are displayed. These
-are one-minute stats.
-</div>
+{{% note title="Note on FSM Time Stats" %}}
+FSM Time Stats represent the amount of time in microseconds required to
+traverse the GET or PUT Finite State Machine code, offering a picture of
+general node health. From your application's perspective, FSM Time effectively
+represents experienced latency. Mean, Median, and 95th-, 99th-, and
+100th-percentile (Max) counters are displayed. These are one-minute stats.
+{{% /note %}}
 
 Metric | Also | Relevance | Latency (in microseconds)
 :------|:-----|:----------|:-------------------------
@@ -191,19 +189,21 @@ reported success with when used for monitoring the operational status of
 their Riak clusters. Community and open source projects are presented
 along with commercial and hosted services.
 
-<div class="note">
-<div class="title">Note on Riak 2.x Statistics Support</div>
-Many of the below tools were either created by third-parties or Basho engineers
-for general usage, and have been passed to the community for further updates. As
-such, many of the below only aggregate the statistics and messages that were
-output by Riak 1.4.x.</br>
+{{% note title="Note on Riak 2.x Statistics Support" %}}
+Many of the below tools were either created by third-parties or Basho
+engineers for general usage, and have been passed to the community for further
+updates. As such, many of the below only aggregate the statistics and messages
+that were output by Riak 1.4.x.
+
 Like all code under [Basho Labs](https://github.com/basho-labs/), the below
-tools are "best effort" and have no dedicated Basho support. We both appreciate
-and need your contribution to keep these tools stable and up to date. Please
-open up a GitHub issue on the repository if you'd like to be a maintainer.</br>
-Look for banners calling out the tools we've verified that support the latest Riak 2.x
-statistics!
-</div>
+tools are "best effort" and have no dedicated Basho support. We both
+appreciate and need your contribution to keep these tools stable and up to
+date. Please open up a GitHub issue on the repository if you'd like to be a
+maintainer.
+
+Look for banners calling out the tools we've verified that support the latest
+Riak 2.x statistics!
+{{% /note %}}
 
 ### Self-Hosted Monitoring Tools
 
@@ -250,9 +250,9 @@ the Riak HTTP [`/stats`](/riak/kv/2.0.7/developing/api/http/status) endpoint is 
 
 #### Nagios
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x.**
+{{% /note %}}
 
 [Nagios](http://www.nagios.org) is a monitoring and alerting solution
 that can provide information on the status of Riak cluster nodes, in
@@ -286,9 +286,9 @@ module specifically designed to read Riak statistics.
 
 #### Zabbix
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [Zabbix](http://www.zabbix.com) is an open-source performance monitoring,
 alerting, and graphing solution that can provide information on the state of
@@ -312,9 +312,9 @@ capacity planning in a Riak cluster environment.
 
 #### New Relic
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [New Relic](http://newrelic.com) is a data analytics and visualization platform
 that can provide information on the current and past states of Riak nodes and

--- a/content/riak/kv/2.0.7/using/reference/v3-multi-datacenter/cascading-writes.md
+++ b/content/riak/kv/2.0.7/using/reference/v3-multi-datacenter/cascading-writes.md
@@ -28,13 +28,11 @@ Riak Enterprise. It will need to be manually enabled on new clusters.
 Cascading realtime requires the `{riak_repl, rtq_meta}` capability to
 function.
 
-<div class="note">
-<div class="title">Note on cascading tracking</div>
-Cascading tracking is a simple list of where an object has been written.
-This works well for most common configurations. Larger installations,
-however, may have writes cascade to clusters to which other clusters
-have already written.
-</div>
+{{% note title="Note on cascading tracking" %}}
+Cascading tracking is a simple list of where an object has been written. This
+works well for most common configurations. Larger installations, however, may
+have writes cascade to clusters to which other clusters have already written.
+{{% /note %}}
 
 
 ```

--- a/content/riak/kv/2.0.7/using/repair-recovery/errors.md
+++ b/content/riak/kv/2.0.7/using/repair-recovery/errors.md
@@ -135,11 +135,10 @@ Riak to explain the correct course of action. For example, the
 `map/reduce` `parse_input` phase will respond like this when it
 encounters an invalid input:
 
-<div class="note">
-<div class="title">Note on inputs</div>
-Inputs must be a binary bucket, a tuple of bucket and key-filters, a
-list of target tuples, a search index, or modfun tuple: `INPUT`.
-</div>
+{{% note title="Note on inputs" %}}
+Inputs must be a binary bucket, a tuple of bucket and key-filters, a list of
+target tuples, a search index, or modfun tuple: `INPUT`.
+{{% /note %}}
 
 For the remaining common error codes, they are often marked by Erlang
 atoms (and quite often wrapped within an `{error,{badmatch,{...` tuple,

--- a/content/riak/kv/2.0.7/using/repair-recovery/failure-recovery.md
+++ b/content/riak/kv/2.0.7/using/repair-recovery/failure-recovery.md
@@ -118,6 +118,8 @@ spreading load and increasing available CPU and IOPS.
 
 See [Changing Cluster Information](/riak/kv/2.1.4/using/cluster-operations/changing-cluster-info/#clusters-from-backups) for instructions on cluster recovery.
 
-<div class="info">
-<div class="title">Tip</div> If you are a licensed Riak Enterprise or CS customer and require assistance or further advice with a cluster recovery, please file a ticket with the <a href="https://help.basho.com">Basho Helpdesk</a>.
-</div>
+{{% note title="Tip" %}}
+If you are a licensed Riak Enterprise or CS customer and require assistance or
+further advice with a cluster recovery, please file a ticket with the
+<a href="https://help.basho.com">Basho Helpdesk</a>.
+{{% /note %}}

--- a/content/riak/kv/2.0.7/using/repair-recovery/repairs.md
+++ b/content/riak/kv/2.0.7/using/repair-recovery/repairs.md
@@ -169,10 +169,11 @@ If there are compaction errors in any of your vnodes, those will be listed in th
 ./442446784738847563128068650529343492278651453440/LOG 
 ```
 
-<div class="note">
-<div class="title">Note</div>
-While corruption on one vnode is not uncommon, corruption in several vnodes very likely means that there is a deeper problem that needs to be address, perhaps on the OS or hardware level.
-</div>
+{{% note title="Note" %}}
+While corruption on one vnode is not uncommon, corruption in several vnodes
+very likely means that there is a deeper problem that needs to be address,
+perhaps on the OS or hardware level.
+{{% /note %}}
 
 ## Healing Corrupted LevelDBs
 

--- a/content/riak/kv/2.0.7/using/running-a-cluster.md
+++ b/content/riak/kv/2.0.7/using/running-a-cluster.md
@@ -171,14 +171,13 @@ the node's ring file.
 riak-admin cluster replace riak@127.0.0.1 riak@192.168.1.10
 ```
 
-<div class="note">
-<div class="title">Note on single nodes</div>
-If a node is started singly using default settings, as you might do when
-you are building your first test environment, you will need to remove
-the ring files from the data directory after you edit your configuration
-files. `riak-admin cluster replace` will not work since the node has not
-been joined to a cluster.
-</div>
+{{% note title="Note on single nodes" %}}
+If a node is started singly using default settings, as you might do when you
+are building your first test environment, you will need to remove the ring
+files from the data directory after you edit your configuration files.
+`riak-admin cluster replace` will not work since the node has not been joined
+to a cluster.
+{{% /note %}}
 
 As with all cluster changes, you need to view the planned changes by
 running `riak-admin cluster plan` and then running `riak-admin cluster

--- a/content/riak/kv/2.0.7/using/security/basics.md
+++ b/content/riak/kv/2.0.7/using/security/basics.md
@@ -444,13 +444,11 @@ Permission | Operation |
 `riak_kv.list_keys` | List all of the keys in a bucket
 `riak_kv.list_buckets` | List all buckets
 
-<div class="note">
-<div class="title">Note on Listing Keys and Buckets</div>
-<code>riak_kv.list_keys</code> and <code>riak_kv.list_buckets</code> are
-both very expensive operations that should be performed very rarely and
-never in production. Access to this functionality should be granted very
-carefully.
-</div>
+{{% note title="Note on Listing Keys and Buckets" %}}
+`riak_kv.list_keys` and `riak_kv.list_buckets` are both very expensive
+operations that should be performed very rarely and never in production.
+Access to this functionality should be granted very carefully.
+{{% /note %}}
 
 If you'd like to create, for example, a `client` account that is
 allowed only to run `GET` and `PUT` requests on all buckets:
@@ -631,23 +629,20 @@ The following command would remove the source for `riakuser` on
 riak-admin security del-source riakuser 127.0.0.1/32
 ```
 
-<div class="note">
-<div class="title">Note on Removing Sources</div>
-If you apply a security source both to <code>all</code> and to specific
-users and then wish to remove that source, you will need to do so in
-separate steps. The <code>riak-admin security del-source all ...</code>
-command by itself is not sufficient.
+{{% note title="Note on Removing Sources" %}}
+If you apply a security source both to `all` and to specific users and then
+wish to remove that source, you will need to do so in separate steps. The
+`riak-admin security del-source all ...` command by itself is not sufficient.
 
-For example, if you have assigned the source <code>password</code> to
-both <code>all</code> and to the user <code>riakuser</code> on the
-network <code>127.0.0.1/32</code>, the following two-step process would
-be required to fully remove the source:
+For example, if you have assigned the source `password` to both `all` and to
+the user `riakuser` on the network `127.0.0.1/32`, the following two-step
+process would be required to fully remove the source:
 
 ```bash
 riak-admin security del-source all 127.0.0.1/32 password
 riak-admin security del-source riakuser 127.0.0.1/32 password
 ```
-</div>
+{{% /note %}}
 
 ### More Usage Examples
 

--- a/content/riak/kv/2.0.7/using/security/managing-sources.md
+++ b/content/riak/kv/2.0.7/using/security/managing-sources.md
@@ -29,11 +29,10 @@ The examples below will assume that the network in question is
 [created](/riak/kv/2.0.7/using/security/basics/#user-management) and that
 security has been [enabled](/riak/kv/2.0.7/using/security/basics/#the-basics).
 
-<div class="note">
-<div class="title">Note on SSL connections</div>
-If you use <em>any</em> of the aforementioned security sources, even
-<code>trust</code>, you will need to do so via a secure SSL connection.
-</div>
+{{% note title="Note on SSL connections" %}}
+If you use _any_ of the aforementioned security sources, even `trust`, you
+will need to do so via a secure SSL connection.
+{{% /note %}}
 
 ## Trust-based Authentication
 

--- a/content/riak/kv/2.0.8/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.0.8/configuring/load-balancing-proxy.md
@@ -184,15 +184,13 @@ act as a front-end proxy to a 5-node Riak cluster.
 This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
-<div class="note">
-<div class="title">Nginx version notes</div>
-This example configuration was verified on <strong>Nginx version
-1.2.3</strong>. Please be aware that earlier versions of Nginx did not
-support any HTTP 1.1 semantics for upstream communication to backends.
-You should carefully examine this configuration and make changes
-appropriate to your specific environment before attempting to use
-it
-</div>
+{{% note title="Nginx version notes" %}}
+This example configuration was verified on **Nginx version 1.2.3**. Please be
+aware that earlier versions of Nginx did not support any HTTP 1.1 semantics
+for upstream communication to backends. You should carefully examine this
+configuration and make changes appropriate to your specific environment before
+attempting to use it
+{{% /note %}}
 
 Here is an example `nginx.conf` file:
 
@@ -250,13 +248,12 @@ server {
 }
 ```
 
-<div class="note">
-<div class="title">Note on access controls</div>
-Even when filtering and limiting requests to GETs only as done in the
-example, you should strongly consider additional access controls beyond
-what Nginx can provide directly, such as specific firewall rules to
-limit inbound connections to trusted sources.
-</div>
+{{% note title="Note on access controls" %}}
+Even when filtering and limiting requests to GETs only as done in the example,
+you should strongly consider additional access controls beyond what Nginx can
+provide directly, such as specific firewall rules to limit inbound connections
+to trusted sources.
+{{% /note %}}
 
 ### Querying Secondary Indexes Over HTTP
 

--- a/content/riak/kv/2.0.8/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.0.8/configuring/load-balancing-proxy.md
@@ -185,7 +185,7 @@ This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
 <div class="note">
-<div class="title">Nginx version notes</div
+<div class="title">Nginx version notes</div>
 This example configuration was verified on <strong>Nginx version
 1.2.3</strong>. Please be aware that earlier versions of Nginx did not
 support any HTTP 1.1 semantics for upstream communication to backends.

--- a/content/riak/kv/2.0.8/configuring/v2-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.0.8/configuring/v2-multi-datacenter/ssl.md
@@ -68,8 +68,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -77,7 +76,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.0.8/configuring/v3-multi-datacenter/quick-start.md
+++ b/content/riak/kv/2.0.8/configuring/v3-multi-datacenter/quick-start.md
@@ -137,13 +137,11 @@ Sink             Cluster Name         <Ctrl-Pid>      [Members]
 Cluster1          Cluster1            <0.4456.0>      ["10.60.67.149:9080"] (via 10.60.67.149:9080)
 ```
 
-<div class="note">
-<div class="title">Note on connections</div>
-At this point, if you do not have connections, replication will not
-work. Check your IP bindings by running <code>netstat -a</code> on all
-nodes. You should see <code>*:9080 LISTENING</code>. If not, you have
-configuration problems.
-</div>
+{{% note title="Note on connections" %}}
+At this point, if you do not have connections, replication will not work.
+Check your IP bindings by running `netstat -a` on all nodes. You should see
+`*:9080 LISTENING`. If not, you have configuration problems.
+{{% /note %}}
 
 ### Enable Realtime Replication
 

--- a/content/riak/kv/2.0.8/configuring/v3-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.0.8/configuring/v3-multi-datacenter/ssl.md
@@ -54,12 +54,11 @@ the `riak-core` section of [`advanced.confg`][config reference#advanced.config]:
 The `cacertsdir` is a directory containing all the CA certificates
 needed to verify the CA chain back to the root.
 
-<div class="note">
-<div class="title">Note on configuration</div>
+{{% note title="Note on configuration" %}}
 In Version 3 replication, the SSL settings need to be placed in the
-<code>riak-core</code> section of <code>advanced.config</code> as opposed to
-the <code>riak-repl</code> section used by Version 2 replication.
-</div>
+`riak-core` section of `advanced.config` as opposed to the `riak-repl` section
+used by Version 2 replication.
+{{% /note %}}
 
 ## Verifying Peer Certificates
 
@@ -80,8 +79,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -89,7 +87,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.0.8/developing/api/http/fetch-object.md
+++ b/content/riak/kv/2.0.8/developing/api/http/fetch-object.md
@@ -79,22 +79,23 @@ datetime format
 The body of the response will be the contents of the object except when siblings
 are present.
 
-<div class="note"><div class="title">Siblings</div>
-<p>When `allow_mult` is set to true in the bucket properties, concurrent updates
-are allowed to create "sibling" objects, meaning that the object has any number
-of different values that are related to one another by the vector clock.  This
-allows your application to use its own conflict resolution technique.</p>
+{{% note title="Siblings" %}}
+When `allow_mult` is set to true in the bucket properties, concurrent updates
+are allowed to create "sibling" objects, meaning that the object has any
+number of different values that are related to one another by the vector
+clock.  This allows your application to use its own conflict resolution
+technique.
 
-<p>An object with multiple sibling values will result in a `300 Multiple
-Choices` response.  If the `Accept` header prefers `multipart/mixed`, all
-siblings will be returned in a single request as sections of the
-`multipart/mixed` response body.  Otherwise, a list of "vtags" will be given in
-a simple text format. You can request individual siblings by adding the `vtag`
-query parameter. Scroll down to the 'manually requesting siblings' example below for more information.</p>
+An object with multiple sibling values will result in a `300 Multiple Choices`
+response.  If the `Accept` header prefers `multipart/mixed`, all siblings will
+be returned in a single request as sections of the `multipart/mixed` response
+body.  Otherwise, a list of "vtags" will be given in a simple text format. You
+can request individual siblings by adding the `vtag` query parameter. Scroll
+down to the 'manually requesting siblings' example below for more information.
 
-<p>To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
-given in the response.</p>
-</div>
+To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
+given in the response.
+{{% /note %}}
 
 ## Simple Example
 

--- a/content/riak/kv/2.0.8/developing/api/http/link-walking.md
+++ b/content/riak/kv/2.0.8/developing/api/http/link-walking.md
@@ -30,22 +30,19 @@ is a special case of [MapReduce](/riak/kv/2.0.8/developing/usage/mapreduce), and
 GET /buckets/bucket/keys/key/[bucket],[tag],[keep]
 ```
 
-<div class="info"><div class="title">Link filters</div>
-<p>A link filter within the request URL is made of three parts, separated by
-commas:</p>
+{{% note title="Link filters" %}}
+A link filter within the request URL is made of three parts, separated by
+commas:
 
-<ul>
-<li>Bucket - a bucket name to limit the links to</li>
-<li>Tag - a "riaktag" to limit the links to</li>
-<li>Keep - 0 or 1, whether to return results from this phase</li>
-</ul>
+* Bucket - a bucket name to limit the links to
+* Tag - a "riaktag" to limit the links to
+* Keep - 0 or 1, whether to return results from this phase
 
-<p>Any of the three parts may be replaced with <code>_</code> (underscore),
-signifying that any value is valid. Multiple phases of links can be followed by
-adding additional path segments to the URL, separating the link filters by
-slashes. The final phase in the link-walking query implicitly returns its
-results.</p>
-</div>
+Any of the three parts may be replaced with `_` (underscore), signifying that
+any value is valid. Multiple phases of links can be followed by adding
+additional path segments to the URL, separating the link filters by slashes.
+The final phase in the link-walking query implicitly returns its results.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.0.8/developing/api/http/list-buckets.md
+++ b/content/riak/kv/2.0.8/developing/api/http/list-buckets.md
@@ -17,10 +17,10 @@ aliases:
 
 Lists all known buckets (ones that have keys stored in them).
 
-<div class="note"><div class="title">Not for production use</div>
+{{% note title="Not for production use" %}}
 Similar to the list keys operation, this requires traversing all keys stored
 in the cluster and should not be used in production.
-</div>
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.8/developing/api/http/list-keys.md
+++ b/content/riak/kv/2.0.8/developing/api/http/list-keys.md
@@ -17,12 +17,10 @@ aliases:
 
 Lists keys in a bucket.
 
-<div class="note">
-<div class="title">Not for production use</div>
-
-This operation requires traversing all keys stored in the cluster and should not be used in production.
-
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.8/developing/api/http/set-bucket-props.md
+++ b/content/riak/kv/2.0.8/developing/api/http/set-bucket-props.md
@@ -50,14 +50,12 @@ the bucket
 
 Other properties do exist but are not commonly modified.
 
-<div class="note">
-<div class="title">Property types</div>
-<p>Make sure you use the proper types for attributes like <strong>n_val</strong>
-and <strong>allow_mult</strong>. If you use strings instead of integers and
-booleans respectively, you may see some odd errors in your logs, saying
-something like
-<code>"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"</code>.</p>
-</div>
+{{% note title="Property types" %}}
+Make sure you use the proper types for attributes like **n_val** and
+**allow_mult**. If you use strings instead of integers and booleans
+respectively, you may see some odd errors in your logs, saying something like
+`"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"`.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.0.8/developing/api/protocol-buffers.md
+++ b/content/riak/kv/2.0.8/developing/api/protocol-buffers.md
@@ -106,12 +106,11 @@ Code | Message |
 254 | `RpbAuthResp` |
 255 | `RpbStartTls` |
 
-<div class="info">
-<div class="title">Message Definitions</div>
-All Protocol Buffers messages are defined in the <code>riak.proto</code>
-and other <code>.proto</code> files in the <code>/src</code> directory
-of the <a href="https://github.com/basho/riak_pb">RiakPB</a> project.
-</div>
+{{% note title="Message Definitions" %}}
+All Protocol Buffers messages are defined in the `riak.proto` and other
+`.proto` files in the `/src` directory of the
+<a href="https://github.com/basho/riak_pb">RiakPB</a> project.
+{{% /note %}}
 
 ### Error Response
 

--- a/content/riak/kv/2.0.8/developing/api/protocol-buffers/fetch-object.md
+++ b/content/riak/kv/2.0.8/developing/api/protocol-buffers/fetch-object.md
@@ -137,14 +137,12 @@ of the following optional parameters:
 * `deleted` --- Whether the object has been deleted (i.e. whether a
   tombstone for the object has been found under the specified key)
 
-<div class="note">
-<div class="title">Note on missing keys</div>
-Remember: if a key is not stored in Riak, an <code>RpbGetResp</code>
-response without the <code>content</code> and <code>vclock</code> fields
-will be returned. This should be mapped to whatever convention the
-client language uses to return not found. The Erlang client, for
-example, returns the atom <code>{error, notfound}</code>.
-</div>
+{{% note title="Note on missing keys" %}}
+Remember: if a key is not stored in Riak, an `RpbGetResp` response without the
+`content` and `vclock` fields will be returned. This should be mapped to
+whatever convention the client language uses to return not found. The Erlang
+client, for example, returns the atom `{error, notfound}`.
+{{% /note %}}
 
 ## Example
 

--- a/content/riak/kv/2.0.8/developing/api/protocol-buffers/get-client-id.md
+++ b/content/riak/kv/2.0.8/developing/api/protocol-buffers/get-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.0.8/dev/references/protocol-buffers/get-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Get the client id used for this connection. Client ids are used for
 conflict resolution and each unique actor in the system should be

--- a/content/riak/kv/2.0.8/developing/api/protocol-buffers/list-buckets.md
+++ b/content/riak/kv/2.0.8/developing/api/protocol-buffers/list-buckets.md
@@ -17,12 +17,10 @@ aliases:
 
 List all of the bucket names available.
 
-<div class="note">
-<div class="title">Caution</div>
-
-This call can be expensive for the server. Do not use in
-performance-sensitive code.
-</div>
+{{% note title="Caution" %}}
+This call can be expensive for the server. Do not use in performance-sensitive
+code.
+{{% /note %}}
 
 
 ## Request

--- a/content/riak/kv/2.0.8/developing/api/protocol-buffers/list-keys.md
+++ b/content/riak/kv/2.0.8/developing/api/protocol-buffers/list-keys.md
@@ -18,11 +18,10 @@ aliases:
 List all of the keys in a bucket. This is a streaming call, with
 multiple response messages sent for each request.
 
-<div class="note">
-<div class="title">Not for production use</div>
-This operation requires traversing all keys stored in the cluster and
-should not be used in production.
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.0.8/developing/api/protocol-buffers/set-client-id.md
+++ b/content/riak/kv/2.0.8/developing/api/protocol-buffers/set-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.0.8/dev/references/protocol-buffers/set-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Set the client ID for this connection. A library may want to set the
 client ID if it has a good way to uniquely identify actors across

--- a/content/riak/kv/2.0.8/developing/app-guide/replication-properties.md
+++ b/content/riak/kv/2.0.8/developing/app-guide/replication-properties.md
@@ -154,15 +154,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -330,15 +328,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -355,14 +352,12 @@ documentation on [Bitcask](/riak/kv/2.0.8/setup/planning/backend/bitcask), [Leve
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.0.8/developing/client-libraries.md
+++ b/content/riak/kv/2.0.8/developing/client-libraries.md
@@ -49,12 +49,11 @@ developing something that you wish to see added to this list, please
 fork the [Riak Docs repo on GitHub](https://github.com/basho/basho_docs)
 and send us a pull request.
 
-<div class="note">
-<div class="title">Note on community-produced libraries</div>
-All of these projects and libraries are at various stages of
-completeness and may not suit your application's needs based on their
-level of maturity and activity.
-</div>
+{{% note title="Note on community-produced libraries" %}}
+All of these projects and libraries are at various stages of completeness and
+may not suit your application's needs based on their level of maturity and
+activity.
+{{% /note %}}
 
 ### Client Libraries and Frameworks
 

--- a/content/riak/kv/2.0.8/developing/getting-started/csharp.md
+++ b/content/riak/kv/2.0.8/developing/getting-started/csharp.md
@@ -25,10 +25,12 @@ To try this flavor of Riak, a working installation of the .NET Framework or Mono
 
 Install [the Riak .NET Client](https://github.com/basho/riak-dotnet-client/wiki/Installation) through [NuGet](http://nuget.org/packages/RiakClient) or the Visual Studio NuGet package manager.
 
-<div class="note">
-<div class="title">Configuring for a remote cluster</div>
-By default, the Riak .NET Client will add a section to your `app.config` file for a four node local cluster. If you are using a remote cluster, open up `app.config` and change the `hostAddress` values to point to nodes in your remote cluster.
-</div>
+{{% note title="Configuring for a remote cluster" %}}
+By default, the Riak .NET Client will add a section to your `app.config` file
+for a four node local cluster. If you are using a remote cluster, open up
+`app.config` and change the `hostAddress` values to point to nodes in your
+remote cluster.
+{{% /note %}}
 
 ### Connecting to Riak
 

--- a/content/riak/kv/2.0.8/developing/getting-started/csharp/object-modeling.md
+++ b/content/riak/kv/2.0.8/developing/getting-started/csharp/object-modeling.md
@@ -64,12 +64,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially when many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially when many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.8/developing/getting-started/erlang/object-modeling.md
+++ b/content/riak/kv/2.0.8/developing/getting-started/erlang/object-modeling.md
@@ -18,14 +18,13 @@ aliases:
 
 To get started, let's create the records that we'll be using.
 
-<div class="note">
-<div class="title">Code Download</div>
+{{% note title="Code Download" %}}
 You can also download the code for this chapter at
 [Github](https://github.com/basho/taste-of-riak/tree/am-dem-erlang-modules/erlang/Ch03-Msgy-Schema).
 
-The Github version includes Erlang type specifications which have been
-omitted here for brevity.
-</div>
+The Github version includes Erlang type specifications which have been omitted
+here for brevity.
+{{% /note %}}
 
 
 ```erlang
@@ -91,13 +90,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.8/developing/getting-started/golang/object-modeling.md
+++ b/content/riak/kv/2.0.8/developing/getting-started/golang/object-modeling.md
@@ -182,13 +182,11 @@ users and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.8/developing/getting-started/java.md
+++ b/content/riak/kv/2.0.8/developing/getting-started/java.md
@@ -40,13 +40,11 @@ Next, download
 [`TasteOfRiak.java`](https://github.com/basho/basho_docs/raw/master/extras/code-examples/TasteOfRiak.java)
 source code for this tutorial, and save it to your working directory.
 
-<div class="note">
-<div class="title">Configuring for a local cluster</div>
-The `TasteOfRiak.java` file that you downloaded is set up to communicate
-with a 1-node Riak cluster listening on `localhost` port 10017. We
-recommend modifying the connection info directly within the
-`setUpCluster()` method.
-</div>
+{{% note title="Configuring for a local cluster" %}}
+The `TasteOfRiak.java` file that you downloaded is set up to communicate with
+a 1-node Riak cluster listening on `localhost` port 10017. We recommend
+modifying the connection info directly within the `setUpCluster()` method.
+{{% /note %}}
 
 If you execute the `TasteOfRiak.java` file within your IDE, you should
 see the following:

--- a/content/riak/kv/2.0.8/developing/getting-started/java/object-modeling.md
+++ b/content/riak/kv/2.0.8/developing/getting-started/java/object-modeling.md
@@ -157,12 +157,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.8/developing/getting-started/nodejs/object-modeling.md
+++ b/content/riak/kv/2.0.8/developing/getting-started/nodejs/object-modeling.md
@@ -73,12 +73,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_SENT_2014-03-06` or `marketing_group_INBOX_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.8/developing/getting-started/python/object-modeling.md
+++ b/content/riak/kv/2.0.8/developing/getting-started/python/object-modeling.md
@@ -83,13 +83,11 @@ users, and `<groupname>_<type>_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-06`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.8/developing/getting-started/ruby/object-modeling.md
+++ b/content/riak/kv/2.0.8/developing/getting-started/ruby/object-modeling.md
@@ -94,13 +94,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.0.8/developing/usage/conflict-resolution.md
+++ b/content/riak/kv/2.0.8/developing/usage/conflict-resolution.md
@@ -25,16 +25,15 @@ If you are using Riak in an [eventually consistent](/riak/kv/2.0.8/learn/concept
 unavoidable. Often, Riak can resolve these conflicts on its own
 internally if you use causal context, i.e. [vector clocks](/riak/kv/2.0.8/learn/concepts/causal-context#vector-clocks) or [dotted version vectors](/riak/kv/2.0.8/learn/concepts/causal-context#dotted-version-vectors), when updating objects. Instructions on this can be found in the section [below](#siblings).
 
-<div class="note">
-<div class="title">Important note on terminology</div>
-In versions of Riak prior to 2.0, vector clocks were the only causal
-context mechanism available in Riak, which changed with the introduction
-of dotted version vectors in 2.0. Please note that you may frequent find
-terminology in client library APIs, internal Basho documentation, and
-more that uses the term "vector clock" interchangeably with causal
-context in general. Riak's HTTP API still uses a `X-Riak-Vclock` header,
-for example, even if you are using dotted version vectors.
-</div>
+{{% note title="Important note on terminology" %}}
+In versions of Riak prior to 2.0, vector clocks were the only causal context
+mechanism available in Riak, which changed with the introduction of dotted
+version vectors in 2.0. Please note that you may frequent find terminology in
+client library APIs, internal Basho documentation, and more that uses the term
+"vector clock" interchangeably with causal context in general. Riak's HTTP API
+still uses a `X-Riak-Vclock` header, for example, even if you are using dotted
+version vectors.
+{{% /note %}}
 
 But even when you use causal context, Riak cannot always decide which
 value is most causally recent, especially in cases involving concurrent
@@ -118,12 +117,10 @@ will be no concurrent updates. If you are storing immutable data in
 which each object is guaranteed to have its own key or engaging in
 operations related to bulk loading, you should consider LWW.
 
-<div class="note">
-<div class="title">Undefined behavior warning</div>
-Setting both <code>allow_mult</code> and <code>last_write_wins</code> to
-<code>true</code> necessarily leads to unpredictable behavior and should
-always be avoided.
-</div>
+{{% note title="Undefined behavior warning" %}}
+Setting both `allow_mult` and `last_write_wins` to `true` necessarily leads to
+unpredictable behavior and should always be avoided.
+{{% /note %}}
 
 ### Resolve Conflicts on the Application Side
 
@@ -601,13 +598,12 @@ X-Riak-Vclock: a85hYGBgzGDKBVIcR4M2cgczH7HPYEpkzGNlsP/VfYYvCwA=
 # accompany the write for Riak to be able to use the vector clock
 ```
 
-<div class="note">
-<div class="title">Concurrent conflict resolution</div>
+{{% note title="Concurrent conflict resolution" %}}
 It should be noted that it is possible to have two clients that are
 simultaneously engaging in conflict resolution. To avoid a pathological
-divergence, you should be sure to limit the number of reconciliations
-and fail once that limit has been exceeded.
-</div>
+divergence, you should be sure to limit the number of reconciliations and fail
+once that limit has been exceeded.
+{{% /note %}}
 
 ### Sibling Explosion
 
@@ -649,13 +645,10 @@ better performance. Some use cases where you might want to use
 `last_write_wins` include caching, session storage, and insert-only
 (no updates).
 
-<div class="note">
-<div class="title">Note on combining <code>allow_mult</code> and
-<code>last_write_wins</code></div>
-The combination of setting both the <code>allow_mult</code> and
-<code>last_write_wins</code> properties to <code>true</code> leads to
-undefined behavior and should not be used.
-</div>
+{{% note title="Note on combining `allow_mult` and `last_write_wins`" %}}
+The combination of setting both the `allow_mult` and `last_write_wins`
+properties to `true` leads to undefined behavior and should not be used.
+{{% /note %}}
 
 ## Vector Clock Pruning
 

--- a/content/riak/kv/2.0.8/developing/usage/reading-objects.md
+++ b/content/riak/kv/2.0.8/developing/usage/reading-objects.md
@@ -197,12 +197,10 @@ The most common error code:
 
 * `404 Not Found`
 
-<div class="note">
-<div class="title">Note</div>
-If you're using a Riak client instead of HTTP, these responses will vary
-a great deal, so make sure to check the documentation for your specific
-client.
-</div>
+{{% note title="Note" %}}
+If you're using a Riak client instead of HTTP, these responses will vary a
+great deal, so make sure to check the documentation for your specific client.
+{{% /note %}}
 
 ## Not Found
 

--- a/content/riak/kv/2.0.8/developing/usage/replication.md
+++ b/content/riak/kv/2.0.8/developing/usage/replication.md
@@ -45,18 +45,17 @@ is one of the features that differentiates Riak from other databases.
 At the bottom of the page, you'll find a [screencast](/riak/kv/2.0.8/developing/app-guide/replication-properties#screencast) that briefly explains how to adjust your
 replication levels to match your application and business needs.
 
-<div class="note">
-<div class="title">Note on strong consistency</div>
+{{% note title="Note on strong consistency" %}}
 An option introduced in Riak version 2.0 is to use Riak as a
-<a href="http://docs.basho.com/riak/kv/2.0.8/using/reference/strong-consistency/">strongly consistent</a>
-system for data in specified buckets. Using Riak in this way is
-fundamentally different from adjusting replication properties and
-fine-tuning the availability/consistency trade-off, as it sacrifices
-<em>all</em> availability guarantees when necessary. Therefore, you
-should consult the <a href="http://docs.basho.com/riak/kv/2.0.8/developing/app-guide/strong-consistency/">Using
-Strong Consistency</a> documentation, as this option will not be covered
-in this tutorial.
-</div>
+<a href="http://docs.basho.com/riak/kv/2.0.8/using/reference/strong-consistency/">strongly
+consistent</a> system for data in specified buckets. Using Riak in this way is
+fundamentally different from adjusting replication properties and fine-tuning
+the availability/consistency trade-off, as it sacrifices _all_ availability
+guarantees when necessary. Therefore, you should consult the
+<a href="http://docs.basho.com/riak/kv/2.0.8/developing/app-guide/strong-consistency/">Using
+Strong Consistency</a> documentation, as this option will not be covered in
+this tutorial.
+{{% /note %}}
 
 ## How Replication Properties Work
 
@@ -163,15 +162,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -339,15 +336,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -364,14 +360,12 @@ documentation on [Bitcask][plan backend bitcask], [LevelDB][plan backend leveldb
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.0.8/developing/usage/security/erlang.md
+++ b/content/riak/kv/2.0.8/developing/usage/security/erlang.md
@@ -24,13 +24,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.0.8/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Erlang Client Basics
 

--- a/content/riak/kv/2.0.8/developing/usage/security/java.md
+++ b/content/riak/kv/2.0.8/developing/usage/security/java.md
@@ -23,13 +23,11 @@ If you are using [trust-](/riak/kv/2.0.8/using/security/managing-sources/#trust-
 security setup described [below](#java-client-basics). [Certificate](/riak/kv/2.0.8/using/security/managing-sources/#certificate-based-authentication)-based authentication is not
 yet supported in the Java client.
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Java Client Basics
 

--- a/content/riak/kv/2.0.8/developing/usage/security/python.md
+++ b/content/riak/kv/2.0.8/developing/usage/security/python.md
@@ -25,13 +25,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.0.8/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## OpenSSL Versions
 

--- a/content/riak/kv/2.0.8/developing/usage/security/ruby.md
+++ b/content/riak/kv/2.0.8/developing/usage/security/ruby.md
@@ -25,13 +25,11 @@ can use the security setup described in the [Ruby Client Basics](#ruby-client-ba
 in a [later section](#password-based-authentication), while [certificate](/riak/kv/2.0.8/using/security/managing-sources/#certificate-based-authentication)-based authentication
 is covered [further down](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Ruby Client Basics
 

--- a/content/riak/kv/2.0.8/learn/concepts/strong-consistency.md
+++ b/content/riak/kv/2.0.8/learn/concepts/strong-consistency.md
@@ -18,10 +18,14 @@ aliases:
 [usage bucket types]: /riak/kv/2.0.8/developing/usage/bucket-types
 [concept eventual consistency]: /riak/kv/2.0.8/learn/concepts/eventual-consistency
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 Riak was originally designed as an [eventually consistent](/riak/kv/2.0.8/learn/concepts/eventual-consistency) system, fundamentally geared toward providing partition
 (i.e. fault) tolerance and high read and write availability.

--- a/content/riak/kv/2.0.8/setup/installing/amazon-web-services.md
+++ b/content/riak/kv/2.0.8/setup/installing/amazon-web-services.md
@@ -62,10 +62,10 @@ You will need need to launch at least 3 instances to form a Riak cluster.  When 
 
 You can find more information on connecting to an instance on the official [Amazon EC2 instance guide](http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/AccessingInstances.html).
 
-<div class="note">
-<div class="title">Note</div>
-The following clustering setup will <em>not</em> be resilient to instance restarts unless deployed in Amazon VPC.
-</div>
+{{% note title="Note" %}}
+The following clustering setup will _not_ be resilient to instance restarts
+unless deployed in Amazon VPC.
+{{% /note %}}
 
 1. On the first node, obtain the internal IP address:
 

--- a/content/riak/kv/2.0.8/setup/installing/mac-osx.md
+++ b/content/riak/kv/2.0.8/setup/installing/mac-osx.md
@@ -52,13 +52,12 @@ directory and execute `bin/riak start` to start the Riak node.
 
 ## Homebrew
 
-<div class="note">
-<div class="title">Warning: Homebrew not always up to date</div>
-Homebrew's Riak recipe is community supported, and thus is not always up
-to date with the latest Riak package. Please ensure that the current
-recipe is using the latest supported code (and don't be afraid to update
-it if it's not).
-</div>
+{{% note title="Warning: Homebrew not always up to date" %}}
+Homebrew's Riak recipe is community supported, and thus is not always up to
+date with the latest Riak package. Please ensure that the current recipe is
+using the latest supported code (and don't be afraid to update it if it's
+not).
+{{% /note %}}
 
 Installing Riak 2.0 with [Homebrew](http://brew.sh/) is easy:
 
@@ -92,11 +91,10 @@ the Riak installation directory via environment variables.
 You must have Xcode tools installed from [Apple's Developer
 website](http://developer.apple.com/).
 
-<div class="note">
-<div class="title">Note on Clang</div>
-Riak will not compile with Clang. Please make sure that your default
-C/C++ compiler is [GCC](https://gcc.gnu.org/).
-</div>
+{{% note title="Note on Clang" %}}
+Riak will not compile with Clang. Please make sure that your default C/C++
+compiler is [GCC](https://gcc.gnu.org/).
+{{% /note %}}
 
 Riak requires [Erlang](http://www.erlang.org/) R16B02+.
 

--- a/content/riak/kv/2.0.8/using/admin/riak-admin.md
+++ b/content/riak/kv/2.0.8/using/admin/riak-admin.md
@@ -184,11 +184,10 @@ rename the nodes of a cluster. For more information, visit the
 riak-admin reip <old nodename> <new nodename>
 ```
 
-<div class="note">
-<div class="title">Note about reip prior to Riak 2.0</title></div>
-Several bugs have been fixed related to reip in Riak 2.0. We recommend
-against using reip prior to 2.0, if possible.
-</div>
+{{% note title="Note about reip prior to Riak 2.0" %}}
+Several bugs have been fixed related to reip in Riak 2.0. We recommend against
+using reip prior to 2.0, if possible.
+{{% /note %}}
 
 
 ## js-reload
@@ -384,12 +383,10 @@ entropy tree building, and key repairs which were triggered by AAE.
  * The *Max* column shows the maximum number of keys repaired during all
    key exchanges since the last node restart.
 
-<div class="note">
-<div class="title">Note in AAE status information</div>
-All AAE status information is in-memory and is reset across a node
-restart. Only tree build times are persistent (since trees themselves
-are persistent)
-</div>
+{{% note title="Note in AAE status information" %}}
+All AAE status information is in-memory and is reset across a node restart.
+Only tree build times are persistent (since trees themselves are persistent)
+{{% /note %}}
 
 More details on the `aae-status` command are available in the [Riak
 version 1.3 release notes](https://github.com/basho/riak/blob/1.3/RELEASE-NOTES.md#active-anti-entropy).
@@ -623,11 +620,10 @@ repaired for a given exchange round since the node has started.
 
 ### switch-to-new-search
 
-<div class="info">
-<div class="title">Only For Legacy Migration</div>
-This is only needed when migrating from legacy riak search to the new
-Search (Yokozuna).
-</div>
+{{% note title="Only For Legacy Migration" %}}
+This is only needed when migrating from legacy riak search to the new Search
+(Yokozuna).
+{{% /note %}}
 
 ```bash
 riak-admin search switch-to-new-search

--- a/content/riak/kv/2.0.8/using/admin/riak-control.md
+++ b/content/riak/kv/2.0.8/using/admin/riak-control.md
@@ -57,12 +57,11 @@ listener.https.<name> = 127.0.0.1:8096
 %%     the `riak_api` tuple's value list.
 ```
 
-<div class="note">
-<div class="title">Note on SSL</div>
-We strongly recommend that you enable SSL for Riak Control. It is
-disabled by default, and if you wish to enable it you must do so
-explicitly. More information can be found in the document below.
-</div>
+{{% note title="Note on SSL" %}}
+We strongly recommend that you enable SSL for Riak Control. It is disabled by
+default, and if you wish to enable it you must do so explicitly. More
+information can be found in the document below.
+{{% /note %}}
 
 ## Enabling and Disabling Riak Control
 
@@ -168,16 +167,15 @@ be because you are using self-signed certificates. If you have
 authentication enabled in your configuration, you will next be asked to
 authenticate. Enter an appropriate username and password now.
 
-<div class="note">
-<div class="title">Note on browser TLS</div>
-Your browser needs to be support TLS v1.2 to use Riak Control over
-HTTPS. A list of browsers that support TLS v1.2 can be found
+{{% note title="Note on browser TLS" %}}
+Your browser needs to be support TLS v1.2 to use Riak Control over HTTPS. A
+list of browsers that support TLS v1.2 can be found
 [here](https://en.wikipedia.org/wiki/Transport_Layer_Security#Web_browsers).
-TLS v1.2 may be disabled by default on your browser, for example if you
-are using Firefox versions earlier than 27, Safari versions earlier than
-7, Chrome versions earlier than 30, or Internet Explorer versions
-earlier than 11.  To enable it, follow browser-specific instructions.
-</div>
+TLS v1.2 may be disabled by default on your browser, for example if you are
+using Firefox versions earlier than 27, Safari versions earlier than 7, Chrome
+versions earlier than 30, or Internet Explorer versions earlier than 11.  To
+enable it, follow browser-specific instructions.
+{{% /note %}}
 
 ### Snapshot View
 

--- a/content/riak/kv/2.0.8/using/cluster-operations/adding-removing-nodes.md
+++ b/content/riak/kv/2.0.8/using/cluster-operations/adding-removing-nodes.md
@@ -136,15 +136,14 @@ Transfers resulting from cluster changes: 51
 If the plan is to your liking, submit the changes by running `riak-admin
 cluster commit`.
 
-<div class="note">
-<div class="title">Note on ring changes</div>
-The algorithm that distributes partitions across the cluster
-during membership changes is non-deterministic. As a result, there is no
-optimal ring. In the event that a plan results in a slightly uneven
-distribution of partitions, the plan can be cleared. Clearing a cluster
-plan with `riak-admin cluster clear` and running `riak-admin cluster
-plan` again will produce a slightly different ring.
-</div>
+{{% note title="Note on ring changes" %}}
+The algorithm that distributes partitions across the cluster during membership
+changes is non-deterministic. As a result, there is no optimal ring. In the
+event that a plan results in a slightly uneven distribution of partitions, the
+plan can be cleared. Clearing a cluster plan with `riak-admin cluster clear`
+and running `riak-admin cluster plan` again will produce a slightly different
+ring.
+{{% /note %}}
 
 ## Removing a Node From a Cluster
 

--- a/content/riak/kv/2.0.8/using/cluster-operations/bucket-types.md
+++ b/content/riak/kv/2.0.8/using/cluster-operations/bucket-types.md
@@ -16,14 +16,13 @@ Buckets are essentially a flat namespace in Riak. They allow the same
 key name to exist in multiple buckets and enable you to apply
 configurations across keys.
 
-<div class="info">
-<div class="title">How Many Buckets Can I Have?</div>
-Buckets come with virtually no cost <em>except for when you modify the
-default bucket properties</em>. Modified bucket properties are gossiped
-around the cluster and therefore add to the amount of data sent around
-the network. In other words, buckets using the <tt>default</tt> bucket
-type are free. More on that in the next section.
-</div>
+{{% note title="How Many Buckets Can I Have?" %}}
+Buckets come with virtually no cost _except for when you modify the default
+bucket properties_. Modified bucket properties are gossiped around the cluster
+and therefore add to the amount of data sent around the network. In other
+words, buckets using the `default` bucket type are free. More on that in the
+next section.
+{{% /note %}}
 
 In Riak versions 2.0 and later, Basho suggests that you [use bucket types](/riak/kv/2.0.8/developing/usage/bucket-types) to namespace and configure all buckets you use. Bucket types have a lower overhead within the cluster than the
 default bucket namespace but require an additional setup step on the

--- a/content/riak/kv/2.0.8/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.0.8/using/cluster-operations/changing-cluster-info.md
@@ -302,9 +302,12 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
-<div class="note"><div class="title">Note</div>
-When using the `riak-admin force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
-</div>
+{{% note title="Note" %}}
+When using the `riak-admin force-replace` command, you will always get a
+warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be
+lost`. Since we didn't delete any data files and we are replacing the node
+with itself under a new name, we will not lose any replicas.
+{{% /note %}}
 
 <a id="repeat"></a>
 #### Repeat previous steps on each node

--- a/content/riak/kv/2.0.8/using/cluster-operations/replacing-node.md
+++ b/content/riak/kv/2.0.8/using/cluster-operations/replacing-node.md
@@ -86,12 +86,10 @@ with the [`riak-admin ringready`](/riak/kv/2.0.8/using/admin/riak-admin/#ringrea
 and [`riak-admin member-status`](/riak/kv/2.0.8/using/admin/riak-admin/#member-status)
 commands.
 
-<div class="info">
-<div class="title">Ring Settling</div>
-You'll need to make sure that no other ring changes occur between the
-time when you start the new node and the ring settles with the new IP
-info.
+{{% note title="Ring Settling" %}}
+You'll need to make sure that no other ring changes occur between the time
+when you start the new node and the ring settles with the new IP info.
 
-The ring is considered settled when the new node reports `true` when you
-run the `riak-admin ringready` command.
-</div>
+The ring is considered settled when the new node reports `true` when you run
+the `riak-admin ringready` command.
+{{% /note %}}

--- a/content/riak/kv/2.0.8/using/cluster-operations/strong-consistency.md
+++ b/content/riak/kv/2.0.8/using/cluster-operations/strong-consistency.md
@@ -12,10 +12,14 @@ menu:
 toc: true
 ---
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 ## Monitoring Strong Consistency
 

--- a/content/riak/kv/2.0.8/using/performance.md
+++ b/content/riak/kv/2.0.8/using/performance.md
@@ -26,13 +26,12 @@ changes.
 For performance and tuning recommendations specific to running Riak
 clusters on the Amazon Web Services EC2 environment, see [AWS Performance Tuning](/riak/kv/2.0.8/using/performance/amazon-web-services).
 
-<div class="note">
-<div class="title">Note on other operating systems</div>
+{{% note title="Note on other operating systems" %}}
 Unless otherwise specified, the tunings recommended below are for Linux
-distributions. Users implementing Riak on BSD and Solaris distributions
-can use these tuning recommendations to make analogous changes in those
-operating systems.
-</div>
+distributions. Users implementing Riak on BSD and Solaris distributions can
+use these tuning recommendations to make analogous changes in those operating
+systems.
+{{% /note %}}
 
 ## Storage and File System Tuning
 
@@ -187,12 +186,11 @@ net.ipv4.tcp_tw_reuse = 1
 net.ipv4.tcp_moderate_rcvbuf = 1
 ```
 
-<div class="note">
-<div class="title">Note on system default</div>
+{{% note title="Note on system default" %}}
 In general, these recommended values should be compared with the system
-defaults and only changed if benchmarks or other performance metrics
-indicate that networking is the bottleneck.
-</div>
+defaults and only changed if benchmarks or other performance metrics indicate
+that networking is the bottleneck.
+{{% /note %}}
 
 The following settings are optional, but may improve performance on a
 10Gb network:
@@ -227,11 +225,10 @@ ethtool -K eth0 tso off
 `ethtool` settings can be persisted across reboots by adding the above
 command to the `/etc/rc.local` script.
 
-<div class="info">
-<div class="title">Pro tip</div>
-Tuning these values will be required if they are changed, as they affect
-all network operations.
-</div>
+{{% note title="Pro tip" %}}
+Tuning these values will be required if they are changed, as they affect all
+network operations.
+{{% /note %}}
 
 ## Optional I/O Settings
 

--- a/content/riak/kv/2.0.8/using/performance/amazon-web-services.md
+++ b/content/riak/kv/2.0.8/using/performance/amazon-web-services.md
@@ -54,14 +54,13 @@ indexes are not needed for the application.
 In any case, proper benchmarking and tuning are needed to achieve the
 desired performance.
 
-<div class="info">
-<div class="title">Tip</div>
-Most successful AWS cluster deployments use more EC2 instances than they
-would the same number of physical nodes to compensate for the
-performance variability caused by shared, virtualized resources. Plan to
-have more EC2 instance based nodes than physical server nodes when
-estimating cluster size with respect to node count.
-</div>
+{{% note title="Tip" %}}
+Most successful AWS cluster deployments use more EC2 instances than they would
+the same number of physical nodes to compensate for the performance
+variability caused by shared, virtualized resources. Plan to have more EC2
+instance based nodes than physical server nodes when estimating cluster size
+with respect to node count.
+{{% /note %}}
 
 ## Operating System
 

--- a/content/riak/kv/2.0.8/using/performance/erlang.md
+++ b/content/riak/kv/2.0.8/using/performance/erlang.md
@@ -44,16 +44,15 @@ Erlang parameter | Riak parameter
 [`-env ERL_MAX_ETS_TABLES`](http://learnyousomeerlang.com/ets) | `erlang.max_ets_tables`
 `-name` | `nodename`
 
-<div class="note">
-<div class="title">Note on upgrading to 2.0</div>
-In versions of Riak prior to 2.0, Erlang VM-related parameters were
-specified in a `vm.args` configuration file; in versions 2.0 and later,
-all Erlang-VM-specific parameters are set in the `riak.conf` file. If
-you're upgrading to 2.0 from an earlier version, you can still use your
-old `vm.args` if you wish.  Please note, however, that if you set one or
-more parameters in both `vm.args` and in `riak.conf`, the settings in
-`vm.args` will override those in `riak.conf`.
-</div>
+{{% note title="Note on upgrading to 2.0" %}}
+In versions of Riak prior to 2.0, Erlang VM-related parameters were specified
+in a `vm.args` configuration file; in versions 2.0 and later, all
+Erlang-VM-specific parameters are set in the `riak.conf` file. If you're
+upgrading to 2.0 from an earlier version, you can still use your old `vm.args`
+if you wish.  Please note, however, that if you set one or more parameters in
+both `vm.args` and in `riak.conf`, the settings in `vm.args` will override
+those in `riak.conf`.
+{{% /note %}}
 
 ## SMP
 

--- a/content/riak/kv/2.0.8/using/reference/bucket-types.md
+++ b/content/riak/kv/2.0.8/using/reference/bucket-types.md
@@ -16,14 +16,12 @@ Bucket types allow groups of buckets to share configuration details and
 for Riak users to manage bucket properties more efficiently than in the
 older configuration system based on [bucket properties](/riak/kv/2.0.8/developing/usage/bucket-types/#bucket-properties-and-operations).
 
-<div class="note">
-<div class="title">Important note on cluster downgrades</div>
-If you upgrade a Riak to version 2.0 or later, you can still downgrade
-the cluster to a pre-2.0 version <em>as long as you have not created and
-activated a bucket type in the cluster</em>. Once any bucket type has
-been created and activated, you can no longer downgrade the cluster to a
-pre-2.0 version.
-</div>
+{{% note title="Important note on cluster downgrades" %}}
+If you upgrade a Riak to version 2.0 or later, you can still downgrade the
+cluster to a pre-2.0 version _as long as you have not created and activated a
+bucket type in the cluster_. Once any bucket type has been created and
+activated, you can no longer downgrade the cluster to a pre-2.0 version.
+{{% /note %}}
 
 ## How Bucket Types Work
 
@@ -129,11 +127,11 @@ If creation is successful, you should see the following output:
 type_using_defaults created
 ```
 
-<div class="note">
+{{% note %}}
 The `create` command can be run multiple times prior to a bucket type being
 activated. Riak will persist only those properties contained in the final call
 of the command.
-</div>
+{{% /note %}}
 
 Creating bucket types that assign properties _always_ involves passing
 stringified JSON to the `create` command. One way to do that is to pass
@@ -243,11 +241,22 @@ of the type:
 riak-admin bucket-type update type_to_update '{"props":{ ... }}'
 ```
 
-> **Note**
->
-> Any bucket properties associated with a type can be modified after a bucket is created, with two important exceptions: `consistent` and `datatype`. If a bucket type entails strong consistency (requiring that `consistent` be set to `true`) or is set up as a `map`, `set`, or `counter`, then this will be true of the bucket type once and for all.
->
-> If you need to change one of these properties, it is recommended that you simply create and activate a new bucket type.
+{{% note title="Immutable Configurations" %}}
+Any bucket properties associated with a type can be modified after a bucket is
+created, with three important exceptions:
+
+* `consistent`
+* `datatype`
+* `write_once`
+
+If a bucket type entails strong consistency (requiring that `consistent` be
+set to `true`), is set up as a `map`, `set`, or `counter`, or is defined as a
+write-once  bucket (requiring `write_once` be set to `true`), then this will
+be true of the bucket types.
+
+If you need to change one of these properties, we recommend that you simply
+create and activate a new bucket type.
+{{% /note %}}
 
 ## Buckets as Namespaces
 
@@ -375,12 +384,11 @@ curl http://localhost:8098/types/type1/buckets/my_bucket/keys/my_key
 curl http://localhost:8098/types/type2/buckets/my_bucket/keys/my_key
 ```
 
-<div class="note">
-<div class="title">Note on object location</div>
-In Riak 2.x, <em>all requests</em> must be made to a location specified
-by a bucket type, bucket, and key rather than to a bucket/key pair, as
-in previous versions.
-</div>
+{{% note title="Note on object location" %}}
+In Riak 2.x, _all requests_ must be made to a location specified by a bucket
+type, bucket, and key rather than to a bucket/key pair, as in previous
+versions.
+{{% /note %}}
 
 If requests are made to a bucket/key pair without a specified bucket
 type, `default` will be used in place of a bucket type. The following

--- a/content/riak/kv/2.0.8/using/reference/custom-code.md
+++ b/content/riak/kv/2.0.8/using/reference/custom-code.md
@@ -31,13 +31,13 @@ name must have the same name the module. So if you are given a file named
 If you have been given Erlang code and are expected to compile it for
 your developers, keep the following notes in mind.
 
-<div class="info"><div class="title">Note on the Erlang Compiler</div> You
-must use the Erlang compiler (<tt>erlc</tt>) associated with the Riak
+{{% note title="Note on the Erlang Compiler" %}}
+You must use the Erlang compiler (`erlc`) associated with the Riak
 installation or the version of Erlang used when compiling Riak from source.
-For packaged Riak installations, you can consult Table 1 below for the
-default location of Riak's <tt>erlc</tt> for each supported platform.
-If you compiled from source, use the <tt>erlc</tt> from the Erlang version
-you used to compile Riak.</div>
+For packaged Riak installations, you can consult Table 1 below for the default
+location of Riak's `erlc` for each supported platform. If you compiled from
+source, use the `erlc` from the Erlang version you used to compile Riak.
+{{% /note %}}
 
 <table style="width: 100%; border-spacing: 0px;">
 <tbody>
@@ -88,8 +88,9 @@ and loaded. For our example, we'll use a temporary directory `/tmp/beams`,
 but you should choose a directory for production functions based on your
 own requirements such that they will be available where and when needed.
 
-<div class="info">Ensure that the directory chosen above can be read by
-the <tt>riak</tt> user.</div>
+{{% note %}}
+Ensure that the directory chosen above can be read by the `riak` user.
+{{% /note %}}
 
 Successful compilation will result in a new `.beam` file,
 `validate_json.beam`.
@@ -124,5 +125,7 @@ value store has fully initialized and become available for use.
 This is done with the `riak-admin wait-for-service` command as detailed
 in the [Commands documentation](/riak/kv/2.0.8/using/admin/riak-admin/#wait-for-service).
 
-<div class="note">It is important that you ensure riak_kv is
-active before restarting the next node.</div>
+{{% note %}}
+It is important that you ensure riak_kv is active before restarting the next
+node.
+{{% /note %}}

--- a/content/riak/kv/2.0.8/using/reference/multi-datacenter/comparison.md
+++ b/content/riak/kv/2.0.8/using/reference/multi-datacenter/comparison.md
@@ -18,13 +18,12 @@ aliases:
 This document is a systematic comparison of [Version 2](/riak/kv/2.0.8/using/reference/v2-multi-datacenter) and [Version 3](/riak/kv/2.0.8/using/reference/v3-multi-datacenter) of Riak Enterprise's Multi-Datacenter
 Replication capabilities.
 
-<div class="note">
-<div class="title">Important note on mixing versions</div>
+{{% note title="Important note on mixing versions" %}}
 If you are installing Riak Enterprise anew, you should use version 3
-replication. Under no circumstances should you mix version 2 and version
-3 replication. This comparison is meant only to list improvements
-introduced in version 3.
-</div>
+replication. Under no circumstances should you mix version 2 and version 3
+replication. This comparison is meant only to list improvements introduced in
+version 3.
+{{% /note %}}
 
 ## Version 2
 

--- a/content/riak/kv/2.0.8/using/reference/multi-datacenter/monitoring.md
+++ b/content/riak/kv/2.0.8/using/reference/multi-datacenter/monitoring.md
@@ -34,14 +34,12 @@ replication:
 * Use canary (test) objects to test replication and establish trip times
   from source to sink clusters
 
-<div class="note">
-<div class="title">Note on querying and time windows</div>
-Riak's statistics are calculated over a sliding 60-second window. Each
-time you query the stats interface, each sliding statistic shown is a
-sum or histogram value calculated from the previous 60 seconds of data.
-Because of this, the stats interface should not be queried more than
-once per minute.
-</div>
+{{% note title="Note on querying and time windows" %}}
+Riak's statistics are calculated over a sliding 60-second window. Each time
+you query the stats interface, each sliding statistic shown is a sum or
+histogram value calculated from the previous 60 seconds of data. Because of
+this, the stats interface should not be queried more than once per minute.
+{{% /note %}}
 
 ## Statistics
 

--- a/content/riak/kv/2.0.8/using/reference/statistics-monitoring.md
+++ b/content/riak/kv/2.0.8/using/reference/statistics-monitoring.md
@@ -92,15 +92,13 @@ As with the throughput metrics, keeping an eye on average (and max)
 latency times will help detect usage patterns, and provide advanced
 warnings for potential problems.
 
-<div class="note">
-<div class="title">Note on FSM Time Stats</div>
-FSM Time Stats represent the amount of time in microseconds required
-to traverse the GET or PUT Finite State Machine code, offering a
-picture of general node health. From your application's perspective,
-FSM Time effectively represents experienced latency. Mean, Median, and
-95th-, 99th-, and 100th-percentile (Max) counters are displayed. These
-are one-minute stats.
-</div>
+{{% note title="Note on FSM Time Stats" %}}
+FSM Time Stats represent the amount of time in microseconds required to
+traverse the GET or PUT Finite State Machine code, offering a picture of
+general node health. From your application's perspective, FSM Time effectively
+represents experienced latency. Mean, Median, and 95th-, 99th-, and
+100th-percentile (Max) counters are displayed. These are one-minute stats.
+{{% /note %}}
 
 Metric | Also | Relevance | Latency (in microseconds)
 :------|:-----|:----------|:-------------------------
@@ -204,19 +202,21 @@ reported success with when used for monitoring the operational status of
 their Riak clusters. Community and open source projects are presented
 along with commercial and hosted services.
 
-<div class="note">
-<div class="title">Note on Riak 2.x Statistics Support</div>
-Many of the below tools were either created by third-parties or Basho engineers
-for general usage, and have been passed to the community for further updates. As
-such, many of the below only aggregate the statistics and messages that were
-output by Riak 1.4.x.</br>
+{{% note title="Note on Riak 2.x Statistics Support" %}}
+Many of the below tools were either created by third-parties or Basho
+engineers for general usage, and have been passed to the community for further
+updates. As such, many of the below only aggregate the statistics and messages
+that were output by Riak 1.4.x.
+
 Like all code under [Basho Labs](https://github.com/basho-labs/), the below
-tools are "best effort" and have no dedicated Basho support. We both appreciate
-and need your contribution to keep these tools stable and up to date. Please
-open up a GitHub issue on the repository if you'd like to be a maintainer.</br>
-Look for banners calling out the tools we've verified that support the latest Riak 2.x
-statistics!
-</div>
+tools are "best effort" and have no dedicated Basho support. We both
+appreciate and need your contribution to keep these tools stable and up to
+date. Please open up a GitHub issue on the repository if you'd like to be a
+maintainer.
+
+Look for banners calling out the tools we've verified that support the latest
+Riak 2.x statistics!
+{{% /note %}}
 
 ### Self-Hosted Monitoring Tools
 
@@ -263,9 +263,9 @@ the Riak HTTP [`/stats`](/riak/kv/2.0.8/developing/api/http/status) endpoint is 
 
 #### Nagios
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x.**
+{{% /note %}}
 
 [Nagios](http://www.nagios.org) is a monitoring and alerting solution
 that can provide information on the status of Riak cluster nodes, in
@@ -299,9 +299,9 @@ module specifically designed to read Riak statistics.
 
 #### Zabbix
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [Zabbix](http://www.zabbix.com) is an open-source performance monitoring,
 alerting, and graphing solution that can provide information on the state of
@@ -325,9 +325,9 @@ capacity planning in a Riak cluster environment.
 
 #### New Relic
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [New Relic](http://newrelic.com) is a data analytics and visualization platform
 that can provide information on the current and past states of Riak nodes and

--- a/content/riak/kv/2.0.8/using/reference/v3-multi-datacenter/cascading-writes.md
+++ b/content/riak/kv/2.0.8/using/reference/v3-multi-datacenter/cascading-writes.md
@@ -28,13 +28,11 @@ Riak Enterprise. It will need to be manually enabled on new clusters.
 Cascading realtime requires the `{riak_repl, rtq_meta}` capability to
 function.
 
-<div class="note">
-<div class="title">Note on cascading tracking</div>
-Cascading tracking is a simple list of where an object has been written.
-This works well for most common configurations. Larger installations,
-however, may have writes cascade to clusters to which other clusters
-have already written.
-</div>
+{{% note title="Note on cascading tracking" %}}
+Cascading tracking is a simple list of where an object has been written. This
+works well for most common configurations. Larger installations, however, may
+have writes cascade to clusters to which other clusters have already written.
+{{% /note %}}
 
 
 ```

--- a/content/riak/kv/2.0.8/using/repair-recovery/errors.md
+++ b/content/riak/kv/2.0.8/using/repair-recovery/errors.md
@@ -135,11 +135,10 @@ Riak to explain the correct course of action. For example, the
 `map/reduce` `parse_input` phase will respond like this when it
 encounters an invalid input:
 
-<div class="note">
-<div class="title">Note on inputs</div>
-Inputs must be a binary bucket, a tuple of bucket and key-filters, a
-list of target tuples, a search index, or modfun tuple: `INPUT`.
-</div>
+{{% note title="Note on inputs" %}}
+Inputs must be a binary bucket, a tuple of bucket and key-filters, a list of
+target tuples, a search index, or modfun tuple: `INPUT`.
+{{% /note %}}
 
 For the remaining common error codes, they are often marked by Erlang
 atoms (and quite often wrapped within an `{error,{badmatch,{...` tuple,

--- a/content/riak/kv/2.0.8/using/repair-recovery/failure-recovery.md
+++ b/content/riak/kv/2.0.8/using/repair-recovery/failure-recovery.md
@@ -118,6 +118,8 @@ spreading load and increasing available CPU and IOPS.
 
 See [Changing Cluster Information](/riak/kv/2.1.4/using/cluster-operations/changing-cluster-info/#clusters-from-backups) for instructions on cluster recovery.
 
-<div class="info">
-<div class="title">Tip</div> If you are a licensed Riak Enterprise or CS customer and require assistance or further advice with a cluster recovery, please file a ticket with the <a href="https://help.basho.com">Basho Helpdesk</a>.
-</div>
+{{% note title="Tip" %}}
+If you are a licensed Riak Enterprise or CS customer and require assistance or
+further advice with a cluster recovery, please file a ticket with the
+<a href="https://help.basho.com">Basho Helpdesk</a>.
+{{% /note %}}

--- a/content/riak/kv/2.0.8/using/repair-recovery/repairs.md
+++ b/content/riak/kv/2.0.8/using/repair-recovery/repairs.md
@@ -91,10 +91,11 @@ If there are compaction errors in any of your vnodes, those will be listed in th
 ./442446784738847563128068650529343492278651453440/LOG 
 ```
 
-<div class="note">
-<div class="title">Note</div>
-While corruption on one vnode is not uncommon, corruption in several vnodes very likely means that there is a deeper problem that needs to be address, perhaps on the OS or hardware level.
-</div>
+{{% note title="Note" %}}
+While corruption on one vnode is not uncommon, corruption in several vnodes
+very likely means that there is a deeper problem that needs to be address,
+perhaps on the OS or hardware level.
+{{% /note %}}
 
 ## Healing Corrupted LevelDBs
 

--- a/content/riak/kv/2.0.8/using/running-a-cluster.md
+++ b/content/riak/kv/2.0.8/using/running-a-cluster.md
@@ -171,14 +171,13 @@ the node's ring file.
 riak-admin cluster replace riak@127.0.0.1 riak@192.168.1.10
 ```
 
-<div class="note">
-<div class="title">Note on single nodes</div>
-If a node is started singly using default settings, as you might do when
-you are building your first test environment, you will need to remove
-the ring files from the data directory after you edit your configuration
-files. `riak-admin cluster replace` will not work since the node has not
-been joined to a cluster.
-</div>
+{{% note title="Note on single nodes" %}}
+If a node is started singly using default settings, as you might do when you
+are building your first test environment, you will need to remove the ring
+files from the data directory after you edit your configuration files.
+`riak-admin cluster replace` will not work since the node has not been joined
+to a cluster.
+{{% /note %}}
 
 As with all cluster changes, you need to view the planned changes by
 running `riak-admin cluster plan` and then running `riak-admin cluster

--- a/content/riak/kv/2.0.8/using/security/basics.md
+++ b/content/riak/kv/2.0.8/using/security/basics.md
@@ -444,13 +444,11 @@ Permission | Operation |
 `riak_kv.list_keys` | List all of the keys in a bucket
 `riak_kv.list_buckets` | List all buckets
 
-<div class="note">
-<div class="title">Note on Listing Keys and Buckets</div>
-<code>riak_kv.list_keys</code> and <code>riak_kv.list_buckets</code> are
-both very expensive operations that should be performed very rarely and
-never in production. Access to this functionality should be granted very
-carefully.
-</div>
+{{% note title="Note on Listing Keys and Buckets" %}}
+`riak_kv.list_keys` and `riak_kv.list_buckets` are both very expensive
+operations that should be performed very rarely and never in production.
+Access to this functionality should be granted very carefully.
+{{% /note %}}
 
 If you'd like to create, for example, a `client` account that is
 allowed only to run `GET` and `PUT` requests on all buckets:
@@ -631,23 +629,20 @@ The following command would remove the source for `riakuser` on
 riak-admin security del-source riakuser 127.0.0.1/32
 ```
 
-<div class="note">
-<div class="title">Note on Removing Sources</div>
-If you apply a security source both to <code>all</code> and to specific
-users and then wish to remove that source, you will need to do so in
-separate steps. The <code>riak-admin security del-source all ...</code>
-command by itself is not sufficient.
+{{% note title="Note on Removing Sources" %}}
+If you apply a security source both to `all` and to specific users and then
+wish to remove that source, you will need to do so in separate steps. The
+`riak-admin security del-source all ...` command by itself is not sufficient.
 
-For example, if you have assigned the source <code>password</code> to
-both <code>all</code> and to the user <code>riakuser</code> on the
-network <code>127.0.0.1/32</code>, the following two-step process would
-be required to fully remove the source:
+For example, if you have assigned the source `password` to both `all` and to
+the user `riakuser` on the network `127.0.0.1/32`, the following two-step
+process would be required to fully remove the source:
 
 ```bash
 riak-admin security del-source all 127.0.0.1/32 password
 riak-admin security del-source riakuser 127.0.0.1/32 password
 ```
-</div>
+{{% /note %}}
 
 ### More Usage Examples
 

--- a/content/riak/kv/2.0.8/using/security/managing-sources.md
+++ b/content/riak/kv/2.0.8/using/security/managing-sources.md
@@ -29,11 +29,10 @@ The examples below will assume that the network in question is
 [created](/riak/kv/2.0.8/using/security/basics/#user-management) and that
 security has been [enabled](/riak/kv/2.0.8/using/security/basics/#the-basics).
 
-<div class="note">
-<div class="title">Note on SSL connections</div>
-If you use <em>any</em> of the aforementioned security sources, even
-<code>trust</code>, you will need to do so via a secure SSL connection.
-</div>
+{{% note title="Note on SSL connections" %}}
+If you use _any_ of the aforementioned security sources, even `trust`, you
+will need to do so via a secure SSL connection.
+{{% /note %}}
 
 ## Trust-based Authentication
 

--- a/content/riak/kv/2.1.1/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.1.1/configuring/load-balancing-proxy.md
@@ -184,15 +184,13 @@ act as a front-end proxy to a 5-node Riak cluster.
 This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
-<div class="note">
-<div class="title">Nginx version notes</div>
-This example configuration was verified on <strong>Nginx version
-1.2.3</strong>. Please be aware that earlier versions of Nginx did not
-support any HTTP 1.1 semantics for upstream communication to backends.
-You should carefully examine this configuration and make changes
-appropriate to your specific environment before attempting to use
-it
-</div>
+{{% note title="Nginx version notes" %}}
+This example configuration was verified on **Nginx version 1.2.3**. Please be
+aware that earlier versions of Nginx did not support any HTTP 1.1 semantics
+for upstream communication to backends. You should carefully examine this
+configuration and make changes appropriate to your specific environment before
+attempting to use it
+{{% /note %}}
 
 Here is an example `nginx.conf` file:
 
@@ -250,13 +248,12 @@ server {
 }
 ```
 
-<div class="note">
-<div class="title">Note on access controls</div>
-Even when filtering and limiting requests to GETs only as done in the
-example, you should strongly consider additional access controls beyond
-what Nginx can provide directly, such as specific firewall rules to
-limit inbound connections to trusted sources.
-</div>
+{{% note title="Note on access controls" %}}
+Even when filtering and limiting requests to GETs only as done in the example,
+you should strongly consider additional access controls beyond what Nginx can
+provide directly, such as specific firewall rules to limit inbound connections
+to trusted sources.
+{{% /note %}}
 
 ### Querying Secondary Indexes Over HTTP
 

--- a/content/riak/kv/2.1.1/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.1.1/configuring/load-balancing-proxy.md
@@ -185,7 +185,7 @@ This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
 <div class="note">
-<div class="title">Nginx version notes</div
+<div class="title">Nginx version notes</div>
 This example configuration was verified on <strong>Nginx version
 1.2.3</strong>. Please be aware that earlier versions of Nginx did not
 support any HTTP 1.1 semantics for upstream communication to backends.

--- a/content/riak/kv/2.1.1/configuring/v2-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.1.1/configuring/v2-multi-datacenter/ssl.md
@@ -64,8 +64,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -73,7 +72,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.1.1/configuring/v3-multi-datacenter/quick-start.md
+++ b/content/riak/kv/2.1.1/configuring/v3-multi-datacenter/quick-start.md
@@ -137,13 +137,11 @@ Sink             Cluster Name         <Ctrl-Pid>      [Members]
 Cluster1          Cluster1            <0.4456.0>      ["10.60.67.149:9080"] (via 10.60.67.149:9080)
 ```
 
-<div class="note">
-<div class="title">Note on connections</div>
-At this point, if you do not have connections, replication will not
-work. Check your IP bindings by running <code>netstat -a</code> on all
-nodes. You should see <code>*:9080 LISTENING</code>. If not, you have
-configuration problems.
-</div>
+{{% note title="Note on connections" %}}
+At this point, if you do not have connections, replication will not work.
+Check your IP bindings by running `netstat -a` on all nodes. You should see
+`*:9080 LISTENING`. If not, you have configuration problems.
+{{% /note %}}
 
 ### Enable Realtime Replication
 

--- a/content/riak/kv/2.1.1/configuring/v3-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.1.1/configuring/v3-multi-datacenter/ssl.md
@@ -54,12 +54,11 @@ the `riak-core` section of [`advanced.confg`][config reference#advanced.config]:
 The `cacertsdir` is a directory containing all the CA certificates
 needed to verify the CA chain back to the root.
 
-<div class="note">
-<div class="title">Note on configuration</div>
+{{% note title="Note on configuration" %}}
 In Version 3 replication, the SSL settings need to be placed in the
-<code>riak-core</code> section of <code>advanced.config</code> as opposed to
-the <code>riak-repl</code> section used by Version 2 replication.
-</div>
+`riak-core` section of `advanced.config` as opposed to the `riak-repl` section
+used by Version 2 replication.
+{{% /note %}}
 
 ## Verifying Peer Certificates
 
@@ -80,21 +79,20 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
 to connect.
 
-An exception is made when the CN begins with `*`, on the assumption
-that a pool of nodes might all legitimately use a certificate with a CN
-like `*.dc5.example.com`. In this specific case, peers with matching CNs are
+An exception is made when the CN begins with `*`, on the assumption that a
+pool of nodes might all legitimately use a certificate with a CN like
+`*.dc5.example.com`. In this specific case, peers with matching CNs are
 allowed to connect, so long as an explicit or implicit ACL allows it.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.1.1/developing/api/http/fetch-object.md
+++ b/content/riak/kv/2.1.1/developing/api/http/fetch-object.md
@@ -79,22 +79,23 @@ datetime format
 The body of the response will be the contents of the object except when siblings
 are present.
 
-<div class="note"><div class="title">Siblings</div>
-<p>When `allow_mult` is set to true in the bucket properties, concurrent updates
-are allowed to create "sibling" objects, meaning that the object has any number
-of different values that are related to one another by the vector clock.  This
-allows your application to use its own conflict resolution technique.</p>
+{{% note title="Siblings" %}}
+When `allow_mult` is set to true in the bucket properties, concurrent updates
+are allowed to create "sibling" objects, meaning that the object has any
+number of different values that are related to one another by the vector
+clock.  This allows your application to use its own conflict resolution
+technique.
 
-<p>An object with multiple sibling values will result in a `300 Multiple
-Choices` response.  If the `Accept` header prefers `multipart/mixed`, all
-siblings will be returned in a single request as sections of the
-`multipart/mixed` response body.  Otherwise, a list of "vtags" will be given in
-a simple text format. You can request individual siblings by adding the `vtag`
-query parameter. Scroll down to the 'manually requesting siblings' example below for more information.</p>
+An object with multiple sibling values will result in a `300 Multiple Choices`
+response.  If the `Accept` header prefers `multipart/mixed`, all siblings will
+be returned in a single request as sections of the `multipart/mixed` response
+body.  Otherwise, a list of "vtags" will be given in a simple text format. You
+can request individual siblings by adding the `vtag` query parameter. Scroll
+down to the 'manually requesting siblings' example below for more information.
 
-<p>To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
-given in the response.</p>
-</div>
+To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
+given in the response.
+{{% /note %}}
 
 ## Simple Example
 

--- a/content/riak/kv/2.1.1/developing/api/http/link-walking.md
+++ b/content/riak/kv/2.1.1/developing/api/http/link-walking.md
@@ -26,22 +26,19 @@ is a special case of [MapReduce](/riak/kv/2.1.1/developing/usage/mapreduce), and
 GET /buckets/bucket/keys/key/[bucket],[tag],[keep]
 ```
 
-<div class="info"><div class="title">Link filters</div>
-<p>A link filter within the request URL is made of three parts, separated by
-commas:</p>
+{{% note title="Link filters" %}}
+A link filter within the request URL is made of three parts, separated by
+commas:
 
-<ul>
-<li>Bucket - a bucket name to limit the links to</li>
-<li>Tag - a "riaktag" to limit the links to</li>
-<li>Keep - 0 or 1, whether to return results from this phase</li>
-</ul>
+* Bucket - a bucket name to limit the links to
+* Tag - a "riaktag" to limit the links to
+* Keep - 0 or 1, whether to return results from this phase
 
-<p>Any of the three parts may be replaced with <code>_</code> (underscore),
-signifying that any value is valid. Multiple phases of links can be followed by
-adding additional path segments to the URL, separating the link filters by
-slashes. The final phase in the link-walking query implicitly returns its
-results.</p>
-</div>
+Any of the three parts may be replaced with `_` (underscore), signifying that
+any value is valid. Multiple phases of links can be followed by adding
+additional path segments to the URL, separating the link filters by slashes.
+The final phase in the link-walking query implicitly returns its results.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.1.1/developing/api/http/list-buckets.md
+++ b/content/riak/kv/2.1.1/developing/api/http/list-buckets.md
@@ -17,10 +17,10 @@ aliases:
 
 Lists all known buckets (ones that have keys stored in them).
 
-<div class="note"><div class="title">Not for production use</div>
+{{% note title="Not for production use" %}}
 Similar to the list keys operation, this requires traversing all keys stored
 in the cluster and should not be used in production.
-</div>
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.1.1/developing/api/http/list-keys.md
+++ b/content/riak/kv/2.1.1/developing/api/http/list-keys.md
@@ -17,12 +17,10 @@ aliases:
 
 Lists keys in a bucket.
 
-<div class="note">
-<div class="title">Not for production use</div>
-
-This operation requires traversing all keys stored in the cluster and should not be used in production.
-
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.1.1/developing/api/http/set-bucket-props.md
+++ b/content/riak/kv/2.1.1/developing/api/http/set-bucket-props.md
@@ -50,14 +50,12 @@ the bucket
 
 Other properties do exist but are not commonly modified.
 
-<div class="note">
-<div class="title">Property types</div>
-<p>Make sure you use the proper types for attributes like <strong>n_val</strong>
-and <strong>allow_mult</strong>. If you use strings instead of integers and
-booleans respectively, you may see some odd errors in your logs, saying
-something like
-<code>"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"</code>.</p>
-</div>
+{{% note title="Property types" %}}
+Make sure you use the proper types for attributes like **n_val** and
+**allow_mult**. If you use strings instead of integers and booleans
+respectively, you may see some odd errors in your logs, saying something like
+`"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"`.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.1.1/developing/api/protocol-buffers.md
+++ b/content/riak/kv/2.1.1/developing/api/protocol-buffers.md
@@ -106,12 +106,11 @@ Code | Message |
 254 | `RpbAuthResp` |
 255 | `RpbStartTls` |
 
-<div class="info">
-<div class="title">Message Definitions</div>
-All Protocol Buffers messages are defined in the <code>riak.proto</code>
-and other <code>.proto</code> files in the <code>/src</code> directory
-of the <a href="https://github.com/basho/riak_pb">RiakPB</a> project.
-</div>
+{{% note title="Message Definitions" %}}
+All Protocol Buffers messages are defined in the `riak.proto` and other
+`.proto` files in the `/src` directory of the
+<a href="https://github.com/basho/riak_pb">RiakPB</a> project.
+{{% /note %}}
 
 ### Error Response
 

--- a/content/riak/kv/2.1.1/developing/api/protocol-buffers/fetch-object.md
+++ b/content/riak/kv/2.1.1/developing/api/protocol-buffers/fetch-object.md
@@ -137,14 +137,12 @@ of the following optional parameters:
 * `deleted` --- Whether the object has been deleted (i.e. whether a
   tombstone for the object has been found under the specified key)
 
-<div class="note">
-<div class="title">Note on missing keys</div>
-Remember: if a key is not stored in Riak, an <code>RpbGetResp</code>
-response without the <code>content</code> and <code>vclock</code> fields
-will be returned. This should be mapped to whatever convention the
-client language uses to return not found. The Erlang client, for
-example, returns the atom <code>{error, notfound}</code>.
-</div>
+{{% note title="Note on missing keys" %}}
+Remember: if a key is not stored in Riak, an `RpbGetResp` response without the
+`content` and `vclock` fields will be returned. This should be mapped to
+whatever convention the client language uses to return not found. The Erlang
+client, for example, returns the atom `{error, notfound}`.
+{{% /note %}}
 
 ## Example
 

--- a/content/riak/kv/2.1.1/developing/api/protocol-buffers/get-client-id.md
+++ b/content/riak/kv/2.1.1/developing/api/protocol-buffers/get-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.1.1/dev/references/protocol-buffers/get-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Get the client id used for this connection. Client ids are used for
 conflict resolution and each unique actor in the system should be

--- a/content/riak/kv/2.1.1/developing/api/protocol-buffers/list-buckets.md
+++ b/content/riak/kv/2.1.1/developing/api/protocol-buffers/list-buckets.md
@@ -17,12 +17,10 @@ aliases:
 
 List all of the bucket names available.
 
-<div class="note">
-<div class="title">Caution</div>
-
-This call can be expensive for the server. Do not use in
-performance-sensitive code.
-</div>
+{{% note title="Caution" %}}
+This call can be expensive for the server. Do not use in performance-sensitive
+code.
+{{% /note %}}
 
 
 ## Request

--- a/content/riak/kv/2.1.1/developing/api/protocol-buffers/list-keys.md
+++ b/content/riak/kv/2.1.1/developing/api/protocol-buffers/list-keys.md
@@ -18,11 +18,10 @@ aliases:
 List all of the keys in a bucket. This is a streaming call, with
 multiple response messages sent for each request.
 
-<div class="note">
-<div class="title">Not for production use</div>
-This operation requires traversing all keys stored in the cluster and
-should not be used in production.
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.1.1/developing/api/protocol-buffers/set-client-id.md
+++ b/content/riak/kv/2.1.1/developing/api/protocol-buffers/set-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.1.1/dev/references/protocol-buffers/set-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Set the client ID for this connection. A library may want to set the
 client ID if it has a good way to uniquely identify actors across

--- a/content/riak/kv/2.1.1/developing/app-guide/advanced-mapreduce.md
+++ b/content/riak/kv/2.1.1/developing/app-guide/advanced-mapreduce.md
@@ -253,10 +253,10 @@ curl -XPOST localhost:8098/mapred \
 
 The result should be a JSON map of bucket and key names expressed as key/value pairs.
 
-<div class="info">
-Be sure to install the MapReduce function as described above on all of
-the nodes in your cluster to ensure proper operation.
-</div>
+{{% note %}}
+Be sure to install the MapReduce function as described above on all of the
+nodes in your cluster to ensure proper operation.
+{{% /note %}}
 
 
 ## Phase functions
@@ -481,27 +481,25 @@ takes any of the following forms:
 * `{jsanon, {Bucket, Key}}` where the object at `{Bucket, Key}` contains
   the source for an anonymous Javascript function
 
-<div class="info">
-<div class="title">qfun Note</div>
-Using `qfun` in compiled applications can be a fragile
-operation. Please keep the following points in mind.
+{{% note title="qfun Note" %}}
+Using `qfun` in compiled applications can be a fragile operation. Please keep
+the following points in mind.
 
-1. The module in which the function is defined must be present and
-**exactly the same version** on both the client and Riak nodes.
+1. The module in which the function is defined must be present and **exactly
+   the same version** on both the client and Riak nodes.
 
-2. Any modules and functions used by this function (or any function in
-the resulting call stack) must also be present on the Riak nodes.
+2. Any modules and functions used by this function (or any function in the
+   resulting call stack) must also be present on the Riak nodes.
 
-Errors about failures to ensure both 1 and 2 are often surprising,
-usually seen as opaque **missing-function** or **function-clause**
-errors. Especially in the case of differing module versions, this can be
-difficult to diagnose without expecting the issue and knowing of
-`Module:info/0`.
+Errors about failures to ensure both 1 and 2 are often surprising, usually
+seen as opaque **missing-function** or **function-clause** errors. Especially
+in the case of differing module versions, this can be difficult to diagnose
+without expecting the issue and knowing of `Module:info/0`.
 
-When using the Erlang shell, anonymous MapReduce functions can be
-defined and sent to Riak instead of deploying them to all servers in
-advance, but condition #2 above still holds.
-</div>
+When using the Erlang shell, anonymous MapReduce functions can be defined and
+sent to Riak instead of deploying them to all servers in advance, but
+condition #2 above still holds.
+{{% /note %}}
 
 Link phases are expressed in the following form:
 

--- a/content/riak/kv/2.1.1/developing/app-guide/replication-properties.md
+++ b/content/riak/kv/2.1.1/developing/app-guide/replication-properties.md
@@ -154,15 +154,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -330,15 +328,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -355,14 +352,12 @@ documentation on [Bitcask](/riak/kv/2.1.1/setup/planning/backend/bitcask), [Leve
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.1.1/developing/client-libraries.md
+++ b/content/riak/kv/2.1.1/developing/client-libraries.md
@@ -49,12 +49,11 @@ developing something that you wish to see added to this list, please
 fork the [Riak Docs repo on GitHub](https://github.com/basho/basho_docs)
 and send us a pull request.
 
-<div class="note">
-<div class="title">Note on community-produced libraries</div>
-All of these projects and libraries are at various stages of
-completeness and may not suit your application's needs based on their
-level of maturity and activity.
-</div>
+{{% note title="Note on community-produced libraries" %}}
+All of these projects and libraries are at various stages of completeness and
+may not suit your application's needs based on their level of maturity and
+activity.
+{{% /note %}}
 
 ### Client Libraries and Frameworks
 

--- a/content/riak/kv/2.1.1/developing/getting-started/csharp.md
+++ b/content/riak/kv/2.1.1/developing/getting-started/csharp.md
@@ -25,10 +25,12 @@ To try this flavor of Riak, a working installation of the .NET Framework or Mono
 
 Install [the Riak .NET Client](https://github.com/basho/riak-dotnet-client/wiki/Installation) through [NuGet](http://nuget.org/packages/RiakClient) or the Visual Studio NuGet package manager.
 
-<div class="note">
-<div class="title">Configuring for a remote cluster</div>
-By default, the Riak .NET Client will add a section to your `app.config` file for a four node local cluster. If you are using a remote cluster, open up `app.config` and change the `hostAddress` values to point to nodes in your remote cluster.
-</div>
+{{% note title="Configuring for a remote cluster" %}}
+By default, the Riak .NET Client will add a section to your `app.config` file
+for a four node local cluster. If you are using a remote cluster, open up
+`app.config` and change the `hostAddress` values to point to nodes in your
+remote cluster.
+{{% /note %}}
 
 ### Connecting to Riak
 

--- a/content/riak/kv/2.1.1/developing/getting-started/csharp/object-modeling.md
+++ b/content/riak/kv/2.1.1/developing/getting-started/csharp/object-modeling.md
@@ -64,12 +64,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially when many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially when many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.1/developing/getting-started/erlang/object-modeling.md
+++ b/content/riak/kv/2.1.1/developing/getting-started/erlang/object-modeling.md
@@ -18,14 +18,13 @@ aliases:
 
 To get started, let's create the records that we'll be using.
 
-<div class="note">
-<div class="title">Code Download</div>
+{{% note title="Code Download" %}}
 You can also download the code for this chapter at
 [Github](https://github.com/basho/taste-of-riak/tree/am-dem-erlang-modules/erlang/Ch03-Msgy-Schema).
 
-The Github version includes Erlang type specifications which have been
-omitted here for brevity.
-</div>
+The Github version includes Erlang type specifications which have been omitted
+here for brevity.
+{{% /note %}}
 
 
 ```erlang
@@ -91,13 +90,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.1/developing/getting-started/golang/object-modeling.md
+++ b/content/riak/kv/2.1.1/developing/getting-started/golang/object-modeling.md
@@ -182,13 +182,11 @@ users and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.1/developing/getting-started/java.md
+++ b/content/riak/kv/2.1.1/developing/getting-started/java.md
@@ -40,13 +40,11 @@ Next, download
 [`TasteOfRiak.java`](https://github.com/basho/basho_docs/raw/master/extras/code-examples/TasteOfRiak.java)
 source code for this tutorial, and save it to your working directory.
 
-<div class="note">
-<div class="title">Configuring for a local cluster</div>
-The `TasteOfRiak.java` file that you downloaded is set up to communicate
-with a 1-node Riak cluster listening on `localhost` port 10017. We
-recommend modifying the connection info directly within the
-`setUpCluster()` method.
-</div>
+{{% note title="Configuring for a local cluster" %}}
+The `TasteOfRiak.java` file that you downloaded is set up to communicate with
+a 1-node Riak cluster listening on `localhost` port 10017. We recommend
+modifying the connection info directly within the `setUpCluster()` method.
+{{% /note %}}
 
 If you execute the `TasteOfRiak.java` file within your IDE, you should
 see the following:

--- a/content/riak/kv/2.1.1/developing/getting-started/java/object-modeling.md
+++ b/content/riak/kv/2.1.1/developing/getting-started/java/object-modeling.md
@@ -157,12 +157,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.1/developing/getting-started/nodejs/object-modeling.md
+++ b/content/riak/kv/2.1.1/developing/getting-started/nodejs/object-modeling.md
@@ -73,12 +73,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_SENT_2014-03-06` or `marketing_group_INBOX_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.1/developing/getting-started/python/object-modeling.md
+++ b/content/riak/kv/2.1.1/developing/getting-started/python/object-modeling.md
@@ -83,13 +83,11 @@ users, and `<groupname>_<type>_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-06`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.1/developing/getting-started/ruby/object-modeling.md
+++ b/content/riak/kv/2.1.1/developing/getting-started/ruby/object-modeling.md
@@ -94,13 +94,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.1/developing/usage/conflict-resolution.md
+++ b/content/riak/kv/2.1.1/developing/usage/conflict-resolution.md
@@ -25,16 +25,15 @@ If you are using Riak in an [eventually consistent](/riak/kv/2.1.1/learn/concept
 unavoidable. Often, Riak can resolve these conflicts on its own
 internally if you use causal context, i.e. [vector clocks](/riak/kv/2.1.1/learn/concepts/causal-context#vector-clocks) or [dotted version vectors](/riak/kv/2.1.1/learn/concepts/causal-context#dotted-version-vectors), when updating objects. Instructions on this can be found in the section [below](#siblings).
 
-<div class="note">
-<div class="title">Important note on terminology</div>
-In versions of Riak prior to 2.0, vector clocks were the only causal
-context mechanism available in Riak, which changed with the introduction
-of dotted version vectors in 2.0. Please note that you may frequent find
-terminology in client library APIs, internal Basho documentation, and
-more that uses the term "vector clock" interchangeably with causal
-context in general. Riak's HTTP API still uses a `X-Riak-Vclock` header,
-for example, even if you are using dotted version vectors.
-</div>
+{{% note title="Important note on terminology" %}}
+In versions of Riak prior to 2.0, vector clocks were the only causal context
+mechanism available in Riak, which changed with the introduction of dotted
+version vectors in 2.0. Please note that you may frequent find terminology in
+client library APIs, internal Basho documentation, and more that uses the term
+"vector clock" interchangeably with causal context in general. Riak's HTTP API
+still uses a `X-Riak-Vclock` header, for example, even if you are using dotted
+version vectors.
+{{% /note %}}
 
 But even when you use causal context, Riak cannot always decide which
 value is most causally recent, especially in cases involving concurrent
@@ -118,12 +117,10 @@ will be no concurrent updates. If you are storing immutable data in
 which each object is guaranteed to have its own key or engaging in
 operations related to bulk loading, you should consider LWW.
 
-<div class="note">
-<div class="title">Undefined behavior warning</div>
-Setting both <code>allow_mult</code> and <code>last_write_wins</code> to
-<code>true</code> necessarily leads to unpredictable behavior and should
-always be avoided.
-</div>
+{{% note title="Undefined behavior warning" %}}
+Setting both `allow_mult` and `last_write_wins` to `true` necessarily leads to
+unpredictable behavior and should always be avoided.
+{{% /note %}}
 
 ### Resolve Conflicts on the Application Side
 
@@ -602,13 +599,12 @@ X-Riak-Vclock: a85hYGBgzGDKBVIcR4M2cgczH7HPYEpkzGNlsP/VfYYvCwA=
 # accompany the write for Riak to be able to use the vector clock
 ```
 
-<div class="note">
-<div class="title">Concurrent conflict resolution</div>
+{{% note title="Concurrent conflict resolution" %}}
 It should be noted that it is possible to have two clients that are
 simultaneously engaging in conflict resolution. To avoid a pathological
-divergence, you should be sure to limit the number of reconciliations
-and fail once that limit has been exceeded.
-</div>
+divergence, you should be sure to limit the number of reconciliations and fail
+once that limit has been exceeded.
+{{% /note %}}
 
 ### Sibling Explosion
 
@@ -650,13 +646,10 @@ better performance. Some use cases where you might want to use
 `last_write_wins` include caching, session storage, and insert-only
 (no updates).
 
-<div class="note">
-<div class="title">Note on combining <code>allow_mult</code> and
-<code>last_write_wins</code></div>
-The combination of setting both the <code>allow_mult</code> and
-<code>last_write_wins</code> properties to <code>true</code> leads to
-undefined behavior and should not be used.
-</div>
+{{% note title="Note on combining `allow_mult` and `last_write_wins`" %}}
+The combination of setting both the `allow_mult` and `last_write_wins`
+properties to `true` leads to undefined behavior and should not be used.
+{{% /note %}}
 
 ## Vector Clock Pruning
 

--- a/content/riak/kv/2.1.1/developing/usage/mapreduce.md
+++ b/content/riak/kv/2.1.1/developing/usage/mapreduce.md
@@ -15,16 +15,14 @@ aliases:
   - /riak/kv/2.1.1/dev/using/mapreduce
 ---
 
-<div class="note">
-<div class="title">Use MapReduce sparingly</div>
-In Riak, MapReduce is the primary method for non-primary-key-based
-querying. Although useful for a limited range of purposes, such as batch
-processing jobs, MapReduce operations can be very computationally
-expensive, sometimes to the extent that they can degrade performance in
-production clusters operating under load. Thus, we recommend running
-MapReduce operations in a controlled, rate-limited fashion and never for
-realtime querying purposes.
-</div>
+{{% note title="Use MapReduce sparingly" %}}
+In Riak, MapReduce is the primary method for non-primary-key-based querying.
+Although useful for a limited range of purposes, such as batch processing
+jobs, MapReduce operations can be very computationally expensive, sometimes to
+the extent that they can degrade performance in production clusters operating
+under load. Thus, we recommend running MapReduce operations in a controlled,
+rate-limited fashion and never for realtime querying purposes.
+{{% /note %}}
 
 MapReduce (M/R) is a technique for dividing data processing work across
 a distributed system. It takes advantage of the parallel processing

--- a/content/riak/kv/2.1.1/developing/usage/reading-objects.md
+++ b/content/riak/kv/2.1.1/developing/usage/reading-objects.md
@@ -197,12 +197,10 @@ The most common error code:
 
 * `404 Not Found`
 
-<div class="note">
-<div class="title">Note</div>
-If you're using a Riak client instead of HTTP, these responses will vary
-a great deal, so make sure to check the documentation for your specific
-client.
-</div>
+{{% note title="Note" %}}
+If you're using a Riak client instead of HTTP, these responses will vary a
+great deal, so make sure to check the documentation for your specific client.
+{{% /note %}}
 
 ## No Object Stored
 

--- a/content/riak/kv/2.1.1/developing/usage/replication.md
+++ b/content/riak/kv/2.1.1/developing/usage/replication.md
@@ -45,18 +45,17 @@ is one of the features that differentiates Riak from other databases.
 At the bottom of the page, you'll find a [screencast](/riak/kv/2.1.1/developing/app-guide/replication-properties#screencast) that briefly explains how to adjust your
 replication levels to match your application and business needs.
 
-<div class="note">
-<div class="title">Note on strong consistency</div>
+{{% note title="Note on strong consistency" %}}
 An option introduced in Riak version 2.0 is to use Riak as a
-<a href="/riak/kv/2.1.1/using/reference/strong-consistency/">strongly consistent</a>
-system for data in specified buckets. Using Riak in this way is
-fundamentally different from adjusting replication properties and
-fine-tuning the availability/consistency trade-off, as it sacrifices
-<em>all</em> availability guarantees when necessary. Therefore, you
-should consult the <a href="/riak/kv/2.1.1/developing/app-guide/strong-consistency">Using
-Strong Consistency</a> documentation, as this option will not be covered
-in this tutorial.
-</div>
+<a href="/riak/kv/2.1.1/using/reference/strong-consistency/">strongly
+consistent</a> system for data in specified buckets. Using Riak in this way is
+fundamentally different from adjusting replication properties and fine-tuning
+the availability/consistency trade-off, as it sacrifices _all_ availability
+guarantees when necessary. Therefore, you should consult the
+<a href="/riak/kv/2.1.1/developing/app-guide/strong-consistency">Using Strong
+Consistency</a> documentation, as this option will not be covered in this
+tutorial.
+{{% /note %}}
 
 ## How Replication Properties Work
 
@@ -162,15 +161,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -338,15 +335,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -363,14 +359,12 @@ documentation on [Bitcask][plan backend bitcask], [LevelDB][plan backend leveldb
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.1.1/developing/usage/security/erlang.md
+++ b/content/riak/kv/2.1.1/developing/usage/security/erlang.md
@@ -24,13 +24,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.1.1/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Erlang Client Basics
 

--- a/content/riak/kv/2.1.1/developing/usage/security/java.md
+++ b/content/riak/kv/2.1.1/developing/usage/security/java.md
@@ -23,13 +23,11 @@ If you are using [trust-](/riak/kv/2.1.1/using/security/managing-sources/#trust-
 security setup described [below](#java-client-basics). [Certificate](/riak/kv/2.1.1/using/security/managing-sources/#certificate-based-authentication)-based authentication is not
 yet supported in the Java client.
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Java Client Basics
 

--- a/content/riak/kv/2.1.1/developing/usage/security/python.md
+++ b/content/riak/kv/2.1.1/developing/usage/security/python.md
@@ -25,13 +25,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.1.1/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## OpenSSL Versions
 

--- a/content/riak/kv/2.1.1/developing/usage/security/ruby.md
+++ b/content/riak/kv/2.1.1/developing/usage/security/ruby.md
@@ -25,13 +25,11 @@ can use the security setup described in the [Ruby Client Basics](#ruby-client-ba
 in a [later section](#password-based-authentication), while [certificate](/riak/kv/2.1.1/using/security/managing-sources/#certificate-based-authentication)-based authentication
 is covered [further down](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Ruby Client Basics
 

--- a/content/riak/kv/2.1.1/introduction.md
+++ b/content/riak/kv/2.1.1/introduction.md
@@ -185,14 +185,12 @@ Based on Basho's [Cuttlefish](https://github.com/basho/cuttlefish)
 project, the new system is much simpler, leaving behind the Erlang
 syntax required in `app.config`.
 
-<div class="note">
-<div class="title">Note on upgrading</div>
-Version 2.0 will support both the old and the new configuration system,
-in case you're upgrading. Please note, however, that if you use both
-systems side by side, all settings from the older,
-`app.config`/`vm.args`-based system will override any settings from the
-new system.
-</div>
+{{% note title="Note on upgrading" %}}
+Version 2.0 will support both the old and the new configuration system, in
+case you're upgrading. Please note, however, that if you use both systems side
+by side, all settings from the older, `app.config`/`vm.args`-based system will
+override any settings from the new system.
+{{% /note %}}
 
 #### Relevant Docs
 

--- a/content/riak/kv/2.1.1/learn/concepts/strong-consistency.md
+++ b/content/riak/kv/2.1.1/learn/concepts/strong-consistency.md
@@ -18,10 +18,14 @@ aliases:
 [usage bucket types]: /riak/kv/2.1.1/developing/usage/bucket-types
 [concept eventual consistency]: /riak/kv/2.1.1/learn/concepts/eventual-consistency
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 Riak was originally designed as an [eventually consistent](/riak/kv/2.1.1/learn/concepts/eventual-consistency) system, fundamentally geared toward providing partition
 (i.e. fault) tolerance and high read and write availability.

--- a/content/riak/kv/2.1.1/setup/installing/amazon-web-services.md
+++ b/content/riak/kv/2.1.1/setup/installing/amazon-web-services.md
@@ -62,10 +62,10 @@ You will need need to launch at least 3 instances to form a Riak cluster.  When 
 
 You can find more information on connecting to an instance on the official [Amazon EC2 instance guide](http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/AccessingInstances.html).
 
-<div class="note">
-<div class="title">Note</div>
-The following clustering setup will <em>not</em> be resilient to instance restarts unless deployed in Amazon VPC.
-</div>
+{{% note title="Note" %}}
+The following clustering setup will _not_ be resilient to instance restarts
+unless deployed in Amazon VPC.
+{{% /note %}}
 
 1. On the first node, obtain the internal IP address:
 

--- a/content/riak/kv/2.1.1/setup/installing/mac-osx.md
+++ b/content/riak/kv/2.1.1/setup/installing/mac-osx.md
@@ -52,13 +52,12 @@ directory and execute `bin/riak start` to start the Riak node.
 
 ## Homebrew
 
-<div class="note">
-<div class="title">Warning: Homebrew not always up to date</div>
-Homebrew's Riak recipe is community supported, and thus is not always up
-to date with the latest Riak package. Please ensure that the current
-recipe is using the latest supported code (and don't be afraid to update
-it if it's not).
-</div>
+{{% note title="Warning: Homebrew not always up to date" %}}
+Homebrew's Riak recipe is community supported, and thus is not always up to
+date with the latest Riak package. Please ensure that the current recipe is
+using the latest supported code (and don't be afraid to update it if it's
+not).
+{{% /note %}}
 
 Installing Riak 2.0 with [Homebrew](http://brew.sh/) is easy:
 
@@ -92,11 +91,10 @@ the Riak installation directory via environment variables.
 You must have Xcode tools installed from [Apple's Developer
 website](http://developer.apple.com/).
 
-<div class="note">
-<div class="title">Note on Clang</div>
-Riak will not compile with Clang. Please make sure that your default
-C/C++ compiler is [GCC](https://gcc.gnu.org/).
-</div>
+{{% note title="Note on Clang" %}}
+Riak will not compile with Clang. Please make sure that your default C/C++
+compiler is [GCC](https://gcc.gnu.org/).
+{{% /note %}}
 
 Riak requires [Erlang](http://www.erlang.org/) R16B02+.
 

--- a/content/riak/kv/2.1.1/using/admin/riak-admin.md
+++ b/content/riak/kv/2.1.1/using/admin/riak-admin.md
@@ -185,11 +185,10 @@ rename the nodes of a cluster. For more information, visit the
 riak-admin reip <old nodename> <new nodename>
 ```
 
-<div class="note">
-<div class="title">Note about reip prior to Riak 2.0</title></div>
-Several bugs have been fixed related to reip in Riak 2.0. We recommend
-against using reip prior to 2.0, if possible.
-</div>
+{{% note title="Note about reip prior to Riak 2.0" %}}
+Several bugs have been fixed related to reip in Riak 2.0. We recommend against
+using reip prior to 2.0, if possible.
+{{% /note %}}
 
 
 ## js-reload
@@ -389,12 +388,10 @@ entropy tree building, and key repairs which were triggered by AAE.
  * The *Max* column shows the maximum number of keys repaired during all
    key exchanges since the last node restart.
 
-<div class="note">
-<div class="title">Note in AAE status information</div>
-All AAE status information is in-memory and is reset across a node
-restart. Only tree build times are persistent (since trees themselves
-are persistent)
-</div>
+{{% note title="Note in AAE status information" %}}
+All AAE status information is in-memory and is reset across a node restart.
+Only tree build times are persistent (since trees themselves are persistent)
+{{% /note %}}
 
 More details on the `aae-status` command are available in the [Riak
 version 1.3 release notes](https://github.com/basho/riak/blob/1.3/RELEASE-NOTES.md#active-anti-entropy).
@@ -628,11 +625,10 @@ repaired for a given exchange round since the node has started.
 
 ### switch-to-new-search
 
-<div class="info">
-<div class="title">Only For Legacy Migration</div>
-This is only needed when migrating from legacy riak search to the new
-Search (Yokozuna).
-</div>
+{{% note title="Only For Legacy Migration" %}}
+This is only needed when migrating from legacy riak search to the new Search
+(Yokozuna).
+{{% /note %}}
 
 ```bash
 riak-admin search switch-to-new-search

--- a/content/riak/kv/2.1.1/using/admin/riak-control.md
+++ b/content/riak/kv/2.1.1/using/admin/riak-control.md
@@ -57,12 +57,11 @@ listener.https.<name> = 127.0.0.1:8096
 %%     the `riak_api` tuple's value list.
 ```
 
-<div class="note">
-<div class="title">Note on SSL</div>
-We strongly recommend that you enable SSL for Riak Control. It is
-disabled by default, and if you wish to enable it you must do so
-explicitly. More information can be found in the document below.
-</div>
+{{% note title="Note on SSL" %}}
+We strongly recommend that you enable SSL for Riak Control. It is disabled by
+default, and if you wish to enable it you must do so explicitly. More
+information can be found in the document below.
+{{% /note %}}
 
 ## Enabling and Disabling Riak Control
 
@@ -168,16 +167,15 @@ be because you are using self-signed certificates. If you have
 authentication enabled in your configuration, you will next be asked to
 authenticate. Enter an appropriate username and password now.
 
-<div class="note">
-<div class="title">Note on browser TLS</div>
-Your browser needs to be support TLS v1.2 to use Riak Control over
-HTTPS. A list of browsers that support TLS v1.2 can be found
+{{% note title="Note on browser TLS" %}}
+Your browser needs to be support TLS v1.2 to use Riak Control over HTTPS. A
+list of browsers that support TLS v1.2 can be found
 [here](https://en.wikipedia.org/wiki/Transport_Layer_Security#Web_browsers).
-TLS v1.2 may be disabled by default on your browser, for example if you
-are using Firefox versions earlier than 27, Safari versions earlier than
-7, Chrome versions earlier than 30, or Internet Explorer versions
-earlier than 11.  To enable it, follow browser-specific instructions.
-</div>
+TLS v1.2 may be disabled by default on your browser, for example if you are
+using Firefox versions earlier than 27, Safari versions earlier than 7, Chrome
+versions earlier than 30, or Internet Explorer versions earlier than 11.  To
+enable it, follow browser-specific instructions.
+{{% /note %}}
 
 ### Snapshot View
 

--- a/content/riak/kv/2.1.1/using/cluster-operations/adding-removing-nodes.md
+++ b/content/riak/kv/2.1.1/using/cluster-operations/adding-removing-nodes.md
@@ -136,15 +136,14 @@ Transfers resulting from cluster changes: 51
 If the plan is to your liking, submit the changes by running `riak-admin
 cluster commit`.
 
-<div class="note">
-<div class="title">Note on ring changes</div>
-The algorithm that distributes partitions across the cluster
-during membership changes is non-deterministic. As a result, there is no
-optimal ring. In the event that a plan results in a slightly uneven
-distribution of partitions, the plan can be cleared. Clearing a cluster
-plan with `riak-admin cluster clear` and running `riak-admin cluster
-plan` again will produce a slightly different ring.
-</div>
+{{% note title="Note on ring changes" %}}
+The algorithm that distributes partitions across the cluster during membership
+changes is non-deterministic. As a result, there is no optimal ring. In the
+event that a plan results in a slightly uneven distribution of partitions, the
+plan can be cleared. Clearing a cluster plan with `riak-admin cluster clear`
+and running `riak-admin cluster plan` again will produce a slightly different
+ring.
+{{% /note %}}
 
 ## Removing a Node From a Cluster
 

--- a/content/riak/kv/2.1.1/using/cluster-operations/bucket-types.md
+++ b/content/riak/kv/2.1.1/using/cluster-operations/bucket-types.md
@@ -16,14 +16,13 @@ Buckets are essentially a flat namespace in Riak. They allow the same
 key name to exist in multiple buckets and enable you to apply
 configurations across keys.
 
-<div class="info">
-<div class="title">How Many Buckets Can I Have?</div>
-Buckets come with virtually no cost <em>except for when you modify the
-default bucket properties</em>. Modified bucket properties are gossiped
-around the cluster and therefore add to the amount of data sent around
-the network. In other words, buckets using the <tt>default</tt> bucket
-type are free. More on that in the next section.
-</div>
+{{% note title="How Many Buckets Can I Have?" %}}
+Buckets come with virtually no cost _except for when you modify the default
+bucket properties_. Modified bucket properties are gossiped around the cluster
+and therefore add to the amount of data sent around the network. In other
+words, buckets using the `default` bucket type are free. More on that in the
+next section.
+{{% /note %}}
 
 In Riak versions 2.0 and later, Basho suggests that you [use bucket types](/riak/kv/2.1.1/developing/usage/bucket-types) to namespace and configure all buckets you use. Bucket types have a lower overhead within the cluster than the
 default bucket namespace but require an additional setup step on the

--- a/content/riak/kv/2.1.1/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.1.1/using/cluster-operations/changing-cluster-info.md
@@ -302,9 +302,12 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
-<div class="note"><div class="title">Note</div>
-When using the `riak-admin cluster force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
-</div>
+{{% note title="Note" %}}
+When using the `riak-admin cluster force-replace` command, you will always get
+a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be
+lost`. Since we didn't delete any data files and we are replacing the node
+with itself under a new name, we will not lose any replicas.
+{{% /note %}}
 
 <a id="repeat"></a>
 #### Repeat previous steps on each node

--- a/content/riak/kv/2.1.1/using/cluster-operations/replacing-node.md
+++ b/content/riak/kv/2.1.1/using/cluster-operations/replacing-node.md
@@ -86,12 +86,10 @@ with the [`riak-admin ringready`](/riak/kv/2.1.1/using/admin/riak-admin/#ringrea
 and [`riak-admin member-status`](/riak/kv/2.1.1/using/admin/riak-admin/#member-status)
 commands.
 
-<div class="info">
-<div class="title">Ring Settling</div>
-You'll need to make sure that no other ring changes occur between the
-time when you start the new node and the ring settles with the new IP
-info.
+{{% note title="Ring Settling" %}}
+You'll need to make sure that no other ring changes occur between the time
+when you start the new node and the ring settles with the new IP info.
 
-The ring is considered settled when the new node reports `true` when you
-run the `riak-admin ringready` command.
-</div>
+The ring is considered settled when the new node reports `true` when you run
+the `riak-admin ringready` command.
+{{% /note %}}

--- a/content/riak/kv/2.1.1/using/cluster-operations/strong-consistency.md
+++ b/content/riak/kv/2.1.1/using/cluster-operations/strong-consistency.md
@@ -12,10 +12,14 @@ menu:
 toc: true
 ---
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 ## Monitoring Strong Consistency
 

--- a/content/riak/kv/2.1.1/using/performance.md
+++ b/content/riak/kv/2.1.1/using/performance.md
@@ -26,13 +26,12 @@ changes.
 For performance and tuning recommendations specific to running Riak
 clusters on the Amazon Web Services EC2 environment, see [AWS Performance Tuning](/riak/kv/2.1.1/using/performance/amazon-web-services).
 
-<div class="note">
-<div class="title">Note on other operating systems</div>
+{{% note title="Note on other operating systems" %}}
 Unless otherwise specified, the tunings recommended below are for Linux
-distributions. Users implementing Riak on BSD and Solaris distributions
-can use these tuning recommendations to make analogous changes in those
-operating systems.
-</div>
+distributions. Users implementing Riak on BSD and Solaris distributions can
+use these tuning recommendations to make analogous changes in those operating
+systems.
+{{% /note %}}
 
 ## Storage and File System Tuning
 
@@ -171,12 +170,11 @@ net.ipv4.tcp_tw_reuse = 1
 net.ipv4.tcp_moderate_rcvbuf = 1
 ```
 
-<div class="note">
-<div class="title">Note on system default</div>
+{{% note title="Note on system default" %}}
 In general, these recommended values should be compared with the system
-defaults and only changed if benchmarks or other performance metrics
-indicate that networking is the bottleneck.
-</div>
+defaults and only changed if benchmarks or other performance metrics indicate
+that networking is the bottleneck.
+{{% /note %}}
 
 The following settings are optional, but may improve performance on a
 10Gb network:
@@ -211,11 +209,10 @@ ethtool -K eth0 tso off
 `ethtool` settings can be persisted across reboots by adding the above
 command to the `/etc/rc.local` script.
 
-<div class="info">
-<div class="title">Pro tip</div>
-Tuning these values will be required if they are changed, as they affect
-all network operations.
-</div>
+{{% note title="Pro tip" %}}
+Tuning these values will be required if they are changed, as they affect all
+network operations.
+{{% /note %}}
 
 ## Optional I/O Settings
 

--- a/content/riak/kv/2.1.1/using/performance/amazon-web-services.md
+++ b/content/riak/kv/2.1.1/using/performance/amazon-web-services.md
@@ -54,14 +54,13 @@ indexes are not needed for the application.
 In any case, proper benchmarking and tuning are needed to achieve the
 desired performance.
 
-<div class="info">
-<div class="title">Tip</div>
-Most successful AWS cluster deployments use more EC2 instances than they
-would the same number of physical nodes to compensate for the
-performance variability caused by shared, virtualized resources. Plan to
-have more EC2 instance based nodes than physical server nodes when
-estimating cluster size with respect to node count.
-</div>
+{{% note title="Tip" %}}
+Most successful AWS cluster deployments use more EC2 instances than they would
+the same number of physical nodes to compensate for the performance
+variability caused by shared, virtualized resources. Plan to have more EC2
+instance based nodes than physical server nodes when estimating cluster size
+with respect to node count.
+{{% /note %}}
 
 ## Operating System
 

--- a/content/riak/kv/2.1.1/using/performance/erlang.md
+++ b/content/riak/kv/2.1.1/using/performance/erlang.md
@@ -44,16 +44,15 @@ Erlang parameter | Riak parameter
 [`-env ERL_MAX_ETS_TABLES`](http://learnyousomeerlang.com/ets) | `erlang.max_ets_tables`
 `-name` | `nodename`
 
-<div class="note">
-<div class="title">Note on upgrading to 2.0</div>
-In versions of Riak prior to 2.0, Erlang VM-related parameters were
-specified in a `vm.args` configuration file; in versions 2.0 and later,
-all Erlang-VM-specific parameters are set in the `riak.conf` file. If
-you're upgrading to 2.0 from an earlier version, you can still use your
-old `vm.args` if you wish.  Please note, however, that if you set one or
-more parameters in both `vm.args` and in `riak.conf`, the settings in
-`vm.args` will override those in `riak.conf`.
-</div>
+{{% note title="Note on upgrading to 2.0" %}}
+In versions of Riak prior to 2.0, Erlang VM-related parameters were specified
+in a `vm.args` configuration file; in versions 2.0 and later, all
+Erlang-VM-specific parameters are set in the `riak.conf` file. If you're
+upgrading to 2.0 from an earlier version, you can still use your old `vm.args`
+if you wish.  Please note, however, that if you set one or more parameters in
+both `vm.args` and in `riak.conf`, the settings in `vm.args` will override
+those in `riak.conf`.
+{{% /note %}}
 
 ## SMP
 

--- a/content/riak/kv/2.1.1/using/reference/bucket-types.md
+++ b/content/riak/kv/2.1.1/using/reference/bucket-types.md
@@ -16,14 +16,12 @@ Bucket types allow groups of buckets to share configuration details and
 for Riak users to manage bucket properties more efficiently than in the
 older configuration system based on [bucket properties](/riak/kv/2.1.1/developing/usage/bucket-types/#bucket-properties-and-operations).
 
-<div class="note">
-<div class="title">Important note on cluster downgrades</div>
-If you upgrade a Riak to version 2.0 or later, you can still downgrade
-the cluster to a pre-2.0 version <em>as long as you have not created and
-activated a bucket type in the cluster</em>. Once any bucket type has
-been created and activated, you can no longer downgrade the cluster to a
-pre-2.0 version.
-</div>
+{{% note title="Important note on cluster downgrades" %}}
+If you upgrade a Riak to version 2.0 or later, you can still downgrade the
+cluster to a pre-2.0 version _as long as you have not created and activated a
+bucket type in the cluster_. Once any bucket type has been created and
+activated, you can no longer downgrade the cluster to a pre-2.0 version.
+{{% /note %}}
 
 ## How Bucket Types Work
 
@@ -133,11 +131,11 @@ If creation is successful, you should see the following output:
 type_using_defaults created
 ```
 
-<div class="note">
+{{% note %}}
 The `create` command can be run multiple times prior to a bucket type being
 activated. Riak will persist only those properties contained in the final call
 of the command.
-</div>
+{{% /note %}}
 
 Creating bucket types that assign properties _always_ involves passing
 stringified JSON to the `create` command. One way to do that is to pass
@@ -247,7 +245,7 @@ of the type:
 riak-admin bucket-type update type_to_update '{"props":{ ... }}'
 ```
 
-<div class="note"><div class="title">Immutable Configurations</div>
+{{% note title="Immutable Configurations" %}}
 Any bucket properties associated with a type can be modified after a bucket is
 created, with three important exceptions:
 
@@ -255,14 +253,14 @@ created, with three important exceptions:
 * `datatype`
 * `write_once`
 
-If a bucket type entails strong consistency (requiring that `consistent` be set
-to `true`), is set up as a `map`, `set`, or `counter`, or is defined as a write-once 
-bucket (requiring `write_once` be set to `true`), then this will be true of
-the bucket types.
+If a bucket type entails strong consistency (requiring that `consistent` be
+set to `true`), is set up as a `map`, `set`, or `counter`, or is defined as a
+write-once  bucket (requiring `write_once` be set to `true`), then this will
+be true of the bucket types.
 
-If you need to change one of these properties, we recommend that
-you simply create and activate a new bucket type.
-</div>
+If you need to change one of these properties, we recommend that you simply
+create and activate a new bucket type.
+{{% /note %}}
 
 ## Buckets as Namespaces
 
@@ -390,12 +388,11 @@ curl http://localhost:8098/types/type1/buckets/my_bucket/keys/my_key
 curl http://localhost:8098/types/type2/buckets/my_bucket/keys/my_key
 ```
 
-<div class="note">
-<div class="title">Note on object location</div>
-In Riak 2.x, <em>all requests</em> must be made to a location specified
-by a bucket type, bucket, and key rather than to a bucket/key pair, as
-in previous versions.
-</div>
+{{% note title="Note on object location" %}}
+In Riak 2.x, _all requests_ must be made to a location specified by a bucket
+type, bucket, and key rather than to a bucket/key pair, as in previous
+versions.
+{{% /note %}}
 
 If requests are made to a bucket/key pair without a specified bucket
 type, `default` will be used in place of a bucket type. The following

--- a/content/riak/kv/2.1.1/using/reference/custom-code.md
+++ b/content/riak/kv/2.1.1/using/reference/custom-code.md
@@ -31,13 +31,13 @@ name must have the same name the module. So if you are given a file named
 If you have been given Erlang code and are expected to compile it for
 your developers, keep the following notes in mind.
 
-<div class="info"><div class="title">Note on the Erlang Compiler</div> You
-must use the Erlang compiler (<tt>erlc</tt>) associated with the Riak
+{{% note title="Note on the Erlang Compiler" %}}
+You must use the Erlang compiler (`erlc`) associated with the Riak
 installation or the version of Erlang used when compiling Riak from source.
-For packaged Riak installations, you can consult Table 1 below for the
-default location of Riak's <tt>erlc</tt> for each supported platform.
-If you compiled from source, use the <tt>erlc</tt> from the Erlang version
-you used to compile Riak.</div>
+For packaged Riak installations, you can consult Table 1 below for the default
+location of Riak's `erlc` for each supported platform. If you compiled from
+source, use the `erlc` from the Erlang version you used to compile Riak.
+{{% /note %}}
 
 <table style="width: 100%; border-spacing: 0px;">
 <tbody>
@@ -88,8 +88,9 @@ and loaded. For our example, we'll use a temporary directory `/tmp/beams`,
 but you should choose a directory for production functions based on your
 own requirements such that they will be available where and when needed.
 
-<div class="info">Ensure that the directory chosen above can be read by
-the <tt>riak</tt> user.</div>
+{{% note %}}
+Ensure that the directory chosen above can be read by the `riak` user.
+{{% /note %}}
 
 Successful compilation will result in a new `.beam` file,
 `validate_json.beam`.
@@ -124,5 +125,7 @@ value store has fully initialized and become available for use.
 This is done with the `riak-admin wait-for-service` command as detailed
 in the [Commands documentation](/riak/kv/2.1.1/using/admin/riak-admin/#wait-for-service).
 
-<div class="note">It is important that you ensure riak_kv is
-active before restarting the next node.</div>
+{{% note %}}
+It is important that you ensure riak_kv is active before restarting the next
+node.
+{{% /note %}}

--- a/content/riak/kv/2.1.1/using/reference/multi-datacenter/comparison.md
+++ b/content/riak/kv/2.1.1/using/reference/multi-datacenter/comparison.md
@@ -18,13 +18,12 @@ aliases:
 This document is a systematic comparison of [Version 2](/riak/kv/2.1.1/using/reference/v2-multi-datacenter) and [Version 3](/riak/kv/2.1.1/using/reference/v3-multi-datacenter) of Riak Enterprise's Multi-Datacenter
 Replication capabilities.
 
-<div class="note">
-<div class="title">Important note on mixing versions</div>
+{{% note title="Important note on mixing versions" %}}
 If you are installing Riak Enterprise anew, you should use version 3
-replication. Under no circumstances should you mix version 2 and version
-3 replication. This comparison is meant only to list improvements
-introduced in version 3.
-</div>
+replication. Under no circumstances should you mix version 2 and version 3
+replication. This comparison is meant only to list improvements introduced in
+version 3.
+{{% /note %}}
 
 ## Version 2
 

--- a/content/riak/kv/2.1.1/using/reference/multi-datacenter/monitoring.md
+++ b/content/riak/kv/2.1.1/using/reference/multi-datacenter/monitoring.md
@@ -34,14 +34,12 @@ replication:
 * Use canary (test) objects to test replication and establish trip times
   from source to sink clusters
 
-<div class="note">
-<div class="title">Note on querying and time windows</div>
-Riak's statistics are calculated over a sliding 60-second window. Each
-time you query the stats interface, each sliding statistic shown is a
-sum or histogram value calculated from the previous 60 seconds of data.
-Because of this, the stats interface should not be queried more than
-once per minute.
-</div>
+{{% note title="Note on querying and time windows" %}}
+Riak's statistics are calculated over a sliding 60-second window. Each time
+you query the stats interface, each sliding statistic shown is a sum or
+histogram value calculated from the previous 60 seconds of data. Because of
+this, the stats interface should not be queried more than once per minute.
+{{% /note %}}
 
 ## Statistics
 

--- a/content/riak/kv/2.1.1/using/reference/statistics-monitoring.md
+++ b/content/riak/kv/2.1.1/using/reference/statistics-monitoring.md
@@ -92,15 +92,13 @@ As with the throughput metrics, keeping an eye on average (and max)
 latency times will help detect usage patterns, and provide advanced
 warnings for potential problems.
 
-<div class="note">
-<div class="title">Note on FSM Time Stats</div>
-FSM Time Stats represent the amount of time in microseconds required
-to traverse the GET or PUT Finite State Machine code, offering a
-picture of general node health. From your application's perspective,
-FSM Time effectively represents experienced latency. Mean, Median, and
-95th-, 99th-, and 100th-percentile (Max) counters are displayed. These
-are one-minute stats.
-</div>
+{{% note title="Note on FSM Time Stats" %}}
+FSM Time Stats represent the amount of time in microseconds required to
+traverse the GET or PUT Finite State Machine code, offering a picture of
+general node health. From your application's perspective, FSM Time effectively
+represents experienced latency. Mean, Median, and 95th-, 99th-, and
+100th-percentile (Max) counters are displayed. These are one-minute stats.
+{{% /note %}}
 
 Metric | Also | Relevance | Latency (in microseconds)
 :------|:-----|:----------|:-------------------------
@@ -191,19 +189,21 @@ reported success with when used for monitoring the operational status of
 their Riak clusters. Community and open source projects are presented
 along with commercial and hosted services.
 
-<div class="note">
-<div class="title">Note on Riak 2.x Statistics Support</div>
-Many of the below tools were either created by third-parties or Basho engineers
-for general usage, and have been passed to the community for further updates. As
-such, many of the below only aggregate the statistics and messages that were
-output by Riak 1.4.x.</br>
+{{% note title="Note on Riak 2.x Statistics Support" %}}
+Many of the below tools were either created by third-parties or Basho
+engineers for general usage, and have been passed to the community for further
+updates. As such, many of the below only aggregate the statistics and messages
+that were output by Riak 1.4.x.
+
 Like all code under [Basho Labs](https://github.com/basho-labs/), the below
-tools are "best effort" and have no dedicated Basho support. We both appreciate
-and need your contribution to keep these tools stable and up to date. Please
-open up a GitHub issue on the repository if you'd like to be a maintainer.</br>
-Look for banners calling out the tools we've verified that support the latest Riak 2.x
-statistics!
-</div>
+tools are "best effort" and have no dedicated Basho support. We both
+appreciate and need your contribution to keep these tools stable and up to
+date. Please open up a GitHub issue on the repository if you'd like to be a
+maintainer.
+
+Look for banners calling out the tools we've verified that support the latest
+Riak 2.x statistics!
+{{% /note %}}
 
 ### Self-Hosted Monitoring Tools
 
@@ -250,9 +250,9 @@ the Riak HTTP [`/stats`](/riak/kv/2.1.1/developing/api/http/status) endpoint is 
 
 #### Nagios
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x.**
+{{% /note %}}
 
 [Nagios](http://www.nagios.org) is a monitoring and alerting solution
 that can provide information on the status of Riak cluster nodes, in
@@ -286,9 +286,9 @@ module specifically designed to read Riak statistics.
 
 #### Zabbix
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [Zabbix](http://www.zabbix.com) is an open-source performance monitoring,
 alerting, and graphing solution that can provide information on the state of
@@ -312,9 +312,9 @@ capacity planning in a Riak cluster environment.
 
 #### New Relic
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [New Relic](http://newrelic.com) is a data analytics and visualization platform
 that can provide information on the current and past states of Riak nodes and

--- a/content/riak/kv/2.1.1/using/reference/v3-multi-datacenter/cascading-writes.md
+++ b/content/riak/kv/2.1.1/using/reference/v3-multi-datacenter/cascading-writes.md
@@ -28,13 +28,11 @@ Riak Enterprise. It will need to be manually enabled on new clusters.
 Cascading realtime requires the `{riak_repl, rtq_meta}` capability to
 function.
 
-<div class="note">
-<div class="title">Note on cascading tracking</div>
-Cascading tracking is a simple list of where an object has been written.
-This works well for most common configurations. Larger installations,
-however, may have writes cascade to clusters to which other clusters
-have already written.
-</div>
+{{% note title="Note on cascading tracking" %}}
+Cascading tracking is a simple list of where an object has been written. This
+works well for most common configurations. Larger installations, however, may
+have writes cascade to clusters to which other clusters have already written.
+{{% /note %}}
 
 
 ```

--- a/content/riak/kv/2.1.1/using/repair-recovery/errors.md
+++ b/content/riak/kv/2.1.1/using/repair-recovery/errors.md
@@ -135,11 +135,10 @@ Riak to explain the correct course of action. For example, the
 `map/reduce` `parse_input` phase will respond like this when it
 encounters an invalid input:
 
-<div class="note">
-<div class="title">Note on inputs</div>
-Inputs must be a binary bucket, a tuple of bucket and key-filters, a
-list of target tuples, a search index, or modfun tuple: `INPUT`.
-</div>
+{{% note title="Note on inputs" %}}
+Inputs must be a binary bucket, a tuple of bucket and key-filters, a list of
+target tuples, a search index, or modfun tuple: `INPUT`.
+{{% /note %}}
 
 For the remaining common error codes, they are often marked by Erlang
 atoms (and quite often wrapped within an `{error,{badmatch,{...` tuple,

--- a/content/riak/kv/2.1.1/using/repair-recovery/failure-recovery.md
+++ b/content/riak/kv/2.1.1/using/repair-recovery/failure-recovery.md
@@ -117,6 +117,8 @@ spreading load and increasing available CPU and IOPS.
 
 See [Changing Cluster Information](/riak/kv/2.1.4/using/cluster-operations/changing-cluster-info/#clusters-from-backups) for instructions on cluster recovery.
 
-<div class="info">
-<div class="title">Tip</div> If you are a licensed Riak Enterprise or CS customer and require assistance or further advice with a cluster recovery, please file a ticket with the <a href="https://help.basho.com">Basho Helpdesk</a>.
-</div>
+{{% note title="Tip" %}}
+If you are a licensed Riak Enterprise or CS customer and require assistance or
+further advice with a cluster recovery, please file a ticket with the
+<a href="https://help.basho.com">Basho Helpdesk</a>.
+{{% /note %}}

--- a/content/riak/kv/2.1.1/using/repair-recovery/repairs.md
+++ b/content/riak/kv/2.1.1/using/repair-recovery/repairs.md
@@ -169,10 +169,11 @@ If there are compaction errors in any of your vnodes, those will be listed in th
 ./442446784738847563128068650529343492278651453440/LOG 
 ```
 
-<div class="note">
-<div class="title">Note</div>
-While corruption on one vnode is not uncommon, corruption in several vnodes very likely means that there is a deeper problem that needs to be address, perhaps on the OS or hardware level.
-</div>
+{{% note title="Note" %}}
+While corruption on one vnode is not uncommon, corruption in several vnodes
+very likely means that there is a deeper problem that needs to be address,
+perhaps on the OS or hardware level.
+{{% /note %}}
 
 ## Healing Corrupted LevelDBs
 

--- a/content/riak/kv/2.1.1/using/running-a-cluster.md
+++ b/content/riak/kv/2.1.1/using/running-a-cluster.md
@@ -171,14 +171,13 @@ the node's ring file.
 riak-admin cluster replace riak@127.0.0.1 riak@192.168.1.10
 ```
 
-<div class="note">
-<div class="title">Note on single nodes</div>
-If a node is started singly using default settings, as you might do when
-you are building your first test environment, you will need to remove
-the ring files from the data directory after you edit your configuration
-files. `riak-admin cluster replace` will not work since the node has not
-been joined to a cluster.
-</div>
+{{% note title="Note on single nodes" %}}
+If a node is started singly using default settings, as you might do when you
+are building your first test environment, you will need to remove the ring
+files from the data directory after you edit your configuration files.
+`riak-admin cluster replace` will not work since the node has not been joined
+to a cluster.
+{{% /note %}}
 
 As with all cluster changes, you need to view the planned changes by
 running `riak-admin cluster plan` and then running `riak-admin cluster

--- a/content/riak/kv/2.1.1/using/security/basics.md
+++ b/content/riak/kv/2.1.1/using/security/basics.md
@@ -444,13 +444,11 @@ Permission | Operation |
 `riak_kv.list_keys` | List all of the keys in a bucket
 `riak_kv.list_buckets` | List all buckets
 
-<div class="note">
-<div class="title">Note on Listing Keys and Buckets</div>
-<code>riak_kv.list_keys</code> and <code>riak_kv.list_buckets</code> are
-both very expensive operations that should be performed very rarely and
-never in production. Access to this functionality should be granted very
-carefully.
-</div>
+{{% note title="Note on Listing Keys and Buckets" %}}
+`riak_kv.list_keys` and `riak_kv.list_buckets` are both very expensive
+operations that should be performed very rarely and never in production.
+Access to this functionality should be granted very carefully.
+{{% /note %}}
 
 If you'd like to create, for example, a `client` account that is
 allowed only to run `GET` and `PUT` requests on all buckets:
@@ -631,23 +629,20 @@ The following command would remove the source for `riakuser` on
 riak-admin security del-source riakuser 127.0.0.1/32
 ```
 
-<div class="note">
-<div class="title">Note on Removing Sources</div>
-If you apply a security source both to <code>all</code> and to specific
-users and then wish to remove that source, you will need to do so in
-separate steps. The <code>riak-admin security del-source all ...</code>
-command by itself is not sufficient.
+{{% note title="Note on Removing Sources" %}}
+If you apply a security source both to `all` and to specific users and then
+wish to remove that source, you will need to do so in separate steps. The
+`riak-admin security del-source all ...` command by itself is not sufficient.
 
-For example, if you have assigned the source <code>password</code> to
-both <code>all</code> and to the user <code>riakuser</code> on the
-network <code>127.0.0.1/32</code>, the following two-step process would
-be required to fully remove the source:
+For example, if you have assigned the source `password` to both `all` and to
+the user `riakuser` on the network `127.0.0.1/32`, the following two-step
+process would be required to fully remove the source:
 
 ```bash
 riak-admin security del-source all 127.0.0.1/32 password
 riak-admin security del-source riakuser 127.0.0.1/32 password
 ```
-</div>
+{{% /note %}}
 
 ### More Usage Examples
 

--- a/content/riak/kv/2.1.1/using/security/managing-sources.md
+++ b/content/riak/kv/2.1.1/using/security/managing-sources.md
@@ -29,11 +29,10 @@ The examples below will assume that the network in question is
 [created](/riak/kv/2.1.1/using/security/basics/#user-management) and that
 security has been [enabled](/riak/kv/2.1.1/using/security/basics/#the-basics).
 
-<div class="note">
-<div class="title">Note on SSL connections</div>
-If you use <em>any</em> of the aforementioned security sources, even
-<code>trust</code>, you will need to do so via a secure SSL connection.
-</div>
+{{% note title="Note on SSL connections" %}}
+If you use _any_ of the aforementioned security sources, even `trust`, you
+will need to do so via a secure SSL connection.
+{{% /note %}}
 
 ## Trust-based Authentication
 

--- a/content/riak/kv/2.1.3/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.1.3/configuring/load-balancing-proxy.md
@@ -184,15 +184,13 @@ act as a front-end proxy to a 5-node Riak cluster.
 This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
-<div class="note">
-<div class="title">Nginx version notes</div>
-This example configuration was verified on <strong>Nginx version
-1.2.3</strong>. Please be aware that earlier versions of Nginx did not
-support any HTTP 1.1 semantics for upstream communication to backends.
-You should carefully examine this configuration and make changes
-appropriate to your specific environment before attempting to use
-it
-</div>
+{{% note title="Nginx version notes" %}}
+This example configuration was verified on **Nginx version 1.2.3**. Please be
+aware that earlier versions of Nginx did not support any HTTP 1.1 semantics
+for upstream communication to backends. You should carefully examine this
+configuration and make changes appropriate to your specific environment before
+attempting to use it
+{{% /note %}}
 
 Here is an example `nginx.conf` file:
 
@@ -250,13 +248,12 @@ server {
 }
 ```
 
-<div class="note">
-<div class="title">Note on access controls</div>
-Even when filtering and limiting requests to GETs only as done in the
-example, you should strongly consider additional access controls beyond
-what Nginx can provide directly, such as specific firewall rules to
-limit inbound connections to trusted sources.
-</div>
+{{% note title="Note on access controls" %}}
+Even when filtering and limiting requests to GETs only as done in the example,
+you should strongly consider additional access controls beyond what Nginx can
+provide directly, such as specific firewall rules to limit inbound connections
+to trusted sources.
+{{% /note %}}
 
 ### Querying Secondary Indexes Over HTTP
 

--- a/content/riak/kv/2.1.3/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.1.3/configuring/load-balancing-proxy.md
@@ -185,7 +185,7 @@ This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
 <div class="note">
-<div class="title">Nginx version notes</div
+<div class="title">Nginx version notes</div>
 This example configuration was verified on <strong>Nginx version
 1.2.3</strong>. Please be aware that earlier versions of Nginx did not
 support any HTTP 1.1 semantics for upstream communication to backends.

--- a/content/riak/kv/2.1.3/configuring/v2-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.1.3/configuring/v2-multi-datacenter/ssl.md
@@ -64,8 +64,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -73,7 +72,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.1.3/configuring/v3-multi-datacenter/quick-start.md
+++ b/content/riak/kv/2.1.3/configuring/v3-multi-datacenter/quick-start.md
@@ -137,13 +137,11 @@ Sink             Cluster Name         <Ctrl-Pid>      [Members]
 Cluster1          Cluster1            <0.4456.0>      ["10.60.67.149:9080"] (via 10.60.67.149:9080)
 ```
 
-<div class="note">
-<div class="title">Note on connections</div>
-At this point, if you do not have connections, replication will not
-work. Check your IP bindings by running <code>netstat -a</code> on all
-nodes. You should see <code>*:9080 LISTENING</code>. If not, you have
-configuration problems.
-</div>
+{{% note title="Note on connections" %}}
+At this point, if you do not have connections, replication will not work.
+Check your IP bindings by running `netstat -a` on all nodes. You should see
+`*:9080 LISTENING`. If not, you have configuration problems.
+{{% /note %}}
 
 ### Enable Realtime Replication
 

--- a/content/riak/kv/2.1.3/configuring/v3-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.1.3/configuring/v3-multi-datacenter/ssl.md
@@ -54,12 +54,11 @@ the `riak-core` section of [`advanced.confg`][config reference#advanced.config]:
 The `cacertsdir` is a directory containing all the CA certificates
 needed to verify the CA chain back to the root.
 
-<div class="note">
-<div class="title">Note on configuration</div>
+{{% note title="Note on configuration" %}}
 In Version 3 replication, the SSL settings need to be placed in the
-<code>riak-core</code> section of <code>advanced.config</code> as opposed to
-the <code>riak-repl</code> section used by Version 2 replication.
-</div>
+`riak-core` section of `advanced.config` as opposed to the `riak-repl` section
+used by Version 2 replication.
+{{% /note %}}
 
 ## Verifying Peer Certificates
 
@@ -80,21 +79,20 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
 to connect.
 
-An exception is made when the CN begins with `*`, on the assumption
-that a pool of nodes might all legitimately use a certificate with a CN
-like `*.dc5.example.com`. In this specific case, peers with matching CNs are
+An exception is made when the CN begins with `*`, on the assumption that a
+pool of nodes might all legitimately use a certificate with a CN like
+`*.dc5.example.com`. In this specific case, peers with matching CNs are
 allowed to connect, so long as an explicit or implicit ACL allows it.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.1.3/developing/api/http/fetch-object.md
+++ b/content/riak/kv/2.1.3/developing/api/http/fetch-object.md
@@ -79,22 +79,23 @@ datetime format
 The body of the response will be the contents of the object except when siblings
 are present.
 
-<div class="note"><div class="title">Siblings</div>
-<p>When `allow_mult` is set to true in the bucket properties, concurrent updates
-are allowed to create "sibling" objects, meaning that the object has any number
-of different values that are related to one another by the vector clock.  This
-allows your application to use its own conflict resolution technique.</p>
+{{% note title="Siblings" %}}
+When `allow_mult` is set to true in the bucket properties, concurrent updates
+are allowed to create "sibling" objects, meaning that the object has any
+number of different values that are related to one another by the vector
+clock.  This allows your application to use its own conflict resolution
+technique.
 
-<p>An object with multiple sibling values will result in a `300 Multiple
-Choices` response.  If the `Accept` header prefers `multipart/mixed`, all
-siblings will be returned in a single request as sections of the
-`multipart/mixed` response body.  Otherwise, a list of "vtags" will be given in
-a simple text format. You can request individual siblings by adding the `vtag`
-query parameter. Scroll down to the 'manually requesting siblings' example below for more information.</p>
+An object with multiple sibling values will result in a `300 Multiple Choices`
+response.  If the `Accept` header prefers `multipart/mixed`, all siblings will
+be returned in a single request as sections of the `multipart/mixed` response
+body.  Otherwise, a list of "vtags" will be given in a simple text format. You
+can request individual siblings by adding the `vtag` query parameter. Scroll
+down to the 'manually requesting siblings' example below for more information.
 
-<p>To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
-given in the response.</p>
-</div>
+To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
+given in the response.
+{{% /note %}}
 
 ## Simple Example
 

--- a/content/riak/kv/2.1.3/developing/api/http/link-walking.md
+++ b/content/riak/kv/2.1.3/developing/api/http/link-walking.md
@@ -26,22 +26,19 @@ is a special case of [MapReduce](/riak/kv/2.1.3/developing/usage/mapreduce), and
 GET /buckets/bucket/keys/key/[bucket],[tag],[keep]
 ```
 
-<div class="info"><div class="title">Link filters</div>
-<p>A link filter within the request URL is made of three parts, separated by
-commas:</p>
+{{% note title="Link filters" %}}
+A link filter within the request URL is made of three parts, separated by
+commas:
 
-<ul>
-<li>Bucket - a bucket name to limit the links to</li>
-<li>Tag - a "riaktag" to limit the links to</li>
-<li>Keep - 0 or 1, whether to return results from this phase</li>
-</ul>
+* Bucket - a bucket name to limit the links to
+* Tag - a "riaktag" to limit the links to
+* Keep - 0 or 1, whether to return results from this phase
 
-<p>Any of the three parts may be replaced with <code>_</code> (underscore),
-signifying that any value is valid. Multiple phases of links can be followed by
-adding additional path segments to the URL, separating the link filters by
-slashes. The final phase in the link-walking query implicitly returns its
-results.</p>
-</div>
+Any of the three parts may be replaced with `_` (underscore), signifying that
+any value is valid. Multiple phases of links can be followed by adding
+additional path segments to the URL, separating the link filters by slashes.
+The final phase in the link-walking query implicitly returns its results.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.1.3/developing/api/http/list-buckets.md
+++ b/content/riak/kv/2.1.3/developing/api/http/list-buckets.md
@@ -17,10 +17,10 @@ aliases:
 
 Lists all known buckets (ones that have keys stored in them).
 
-<div class="note"><div class="title">Not for production use</div>
+{{% note title="Not for production use" %}}
 Similar to the list keys operation, this requires traversing all keys stored
 in the cluster and should not be used in production.
-</div>
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.1.3/developing/api/http/list-keys.md
+++ b/content/riak/kv/2.1.3/developing/api/http/list-keys.md
@@ -17,12 +17,10 @@ aliases:
 
 Lists keys in a bucket.
 
-<div class="note">
-<div class="title">Not for production use</div>
-
-This operation requires traversing all keys stored in the cluster and should not be used in production.
-
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.1.3/developing/api/http/set-bucket-props.md
+++ b/content/riak/kv/2.1.3/developing/api/http/set-bucket-props.md
@@ -50,14 +50,12 @@ the bucket
 
 Other properties do exist but are not commonly modified.
 
-<div class="note">
-<div class="title">Property types</div>
-<p>Make sure you use the proper types for attributes like <strong>n_val</strong>
-and <strong>allow_mult</strong>. If you use strings instead of integers and
-booleans respectively, you may see some odd errors in your logs, saying
-something like
-<code>"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"</code>.</p>
-</div>
+{{% note title="Property types" %}}
+Make sure you use the proper types for attributes like **n_val** and
+**allow_mult**. If you use strings instead of integers and booleans
+respectively, you may see some odd errors in your logs, saying something like
+`"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"`.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.1.3/developing/api/protocol-buffers.md
+++ b/content/riak/kv/2.1.3/developing/api/protocol-buffers.md
@@ -106,12 +106,11 @@ Code | Message |
 254 | `RpbAuthResp` |
 255 | `RpbStartTls` |
 
-<div class="info">
-<div class="title">Message Definitions</div>
-All Protocol Buffers messages are defined in the <code>riak.proto</code>
-and other <code>.proto</code> files in the <code>/src</code> directory
-of the <a href="https://github.com/basho/riak_pb">RiakPB</a> project.
-</div>
+{{% note title="Message Definitions" %}}
+All Protocol Buffers messages are defined in the `riak.proto` and other
+`.proto` files in the `/src` directory of the
+<a href="https://github.com/basho/riak_pb">RiakPB</a> project.
+{{% /note %}}
 
 ### Error Response
 

--- a/content/riak/kv/2.1.3/developing/api/protocol-buffers/fetch-object.md
+++ b/content/riak/kv/2.1.3/developing/api/protocol-buffers/fetch-object.md
@@ -137,14 +137,12 @@ of the following optional parameters:
 * `deleted` --- Whether the object has been deleted (i.e. whether a
   tombstone for the object has been found under the specified key)
 
-<div class="note">
-<div class="title">Note on missing keys</div>
-Remember: if a key is not stored in Riak, an <code>RpbGetResp</code>
-response without the <code>content</code> and <code>vclock</code> fields
-will be returned. This should be mapped to whatever convention the
-client language uses to return not found. The Erlang client, for
-example, returns the atom <code>{error, notfound}</code>.
-</div>
+{{% note title="Note on missing keys" %}}
+Remember: if a key is not stored in Riak, an `RpbGetResp` response without the
+`content` and `vclock` fields will be returned. This should be mapped to
+whatever convention the client language uses to return not found. The Erlang
+client, for example, returns the atom `{error, notfound}`.
+{{% /note %}}
 
 ## Example
 

--- a/content/riak/kv/2.1.3/developing/api/protocol-buffers/get-client-id.md
+++ b/content/riak/kv/2.1.3/developing/api/protocol-buffers/get-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.1.3/dev/references/protocol-buffers/get-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Get the client id used for this connection. Client ids are used for
 conflict resolution and each unique actor in the system should be

--- a/content/riak/kv/2.1.3/developing/api/protocol-buffers/list-buckets.md
+++ b/content/riak/kv/2.1.3/developing/api/protocol-buffers/list-buckets.md
@@ -17,12 +17,10 @@ aliases:
 
 List all of the bucket names available.
 
-<div class="note">
-<div class="title">Caution</div>
-
-This call can be expensive for the server. Do not use in
-performance-sensitive code.
-</div>
+{{% note title="Caution" %}}
+This call can be expensive for the server. Do not use in performance-sensitive
+code.
+{{% /note %}}
 
 
 ## Request

--- a/content/riak/kv/2.1.3/developing/api/protocol-buffers/list-keys.md
+++ b/content/riak/kv/2.1.3/developing/api/protocol-buffers/list-keys.md
@@ -18,11 +18,10 @@ aliases:
 List all of the keys in a bucket. This is a streaming call, with
 multiple response messages sent for each request.
 
-<div class="note">
-<div class="title">Not for production use</div>
-This operation requires traversing all keys stored in the cluster and
-should not be used in production.
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.1.3/developing/api/protocol-buffers/set-client-id.md
+++ b/content/riak/kv/2.1.3/developing/api/protocol-buffers/set-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.1.3/dev/references/protocol-buffers/set-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Set the client ID for this connection. A library may want to set the
 client ID if it has a good way to uniquely identify actors across

--- a/content/riak/kv/2.1.3/developing/app-guide/advanced-mapreduce.md
+++ b/content/riak/kv/2.1.3/developing/app-guide/advanced-mapreduce.md
@@ -253,10 +253,10 @@ curl -XPOST localhost:8098/mapred \
 
 The result should be a JSON map of bucket and key names expressed as key/value pairs.
 
-<div class="info">
-Be sure to install the MapReduce function as described above on all of
-the nodes in your cluster to ensure proper operation.
-</div>
+{{% note %}}
+Be sure to install the MapReduce function as described above on all of the
+nodes in your cluster to ensure proper operation.
+{{% /note %}}
 
 
 ## Phase functions
@@ -481,27 +481,25 @@ takes any of the following forms:
 * `{jsanon, {Bucket, Key}}` where the object at `{Bucket, Key}` contains
   the source for an anonymous Javascript function
 
-<div class="info">
-<div class="title">qfun Note</div>
-Using `qfun` in compiled applications can be a fragile
-operation. Please keep the following points in mind.
+{{% note title="qfun Note" %}}
+Using `qfun` in compiled applications can be a fragile operation. Please keep
+the following points in mind.
 
-1. The module in which the function is defined must be present and
-**exactly the same version** on both the client and Riak nodes.
+1. The module in which the function is defined must be present and **exactly
+   the same version** on both the client and Riak nodes.
 
-2. Any modules and functions used by this function (or any function in
-the resulting call stack) must also be present on the Riak nodes.
+2. Any modules and functions used by this function (or any function in the
+   resulting call stack) must also be present on the Riak nodes.
 
-Errors about failures to ensure both 1 and 2 are often surprising,
-usually seen as opaque **missing-function** or **function-clause**
-errors. Especially in the case of differing module versions, this can be
-difficult to diagnose without expecting the issue and knowing of
-`Module:info/0`.
+Errors about failures to ensure both 1 and 2 are often surprising, usually
+seen as opaque **missing-function** or **function-clause** errors. Especially
+in the case of differing module versions, this can be difficult to diagnose
+without expecting the issue and knowing of `Module:info/0`.
 
-When using the Erlang shell, anonymous MapReduce functions can be
-defined and sent to Riak instead of deploying them to all servers in
-advance, but condition #2 above still holds.
-</div>
+When using the Erlang shell, anonymous MapReduce functions can be defined and
+sent to Riak instead of deploying them to all servers in advance, but
+condition #2 above still holds.
+{{% /note %}}
 
 Link phases are expressed in the following form:
 

--- a/content/riak/kv/2.1.3/developing/app-guide/replication-properties.md
+++ b/content/riak/kv/2.1.3/developing/app-guide/replication-properties.md
@@ -154,15 +154,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -330,15 +328,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -355,14 +352,12 @@ documentation on [Bitcask](/riak/kv/2.1.3/setup/planning/backend/bitcask), [Leve
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.1.3/developing/client-libraries.md
+++ b/content/riak/kv/2.1.3/developing/client-libraries.md
@@ -50,12 +50,11 @@ developing something that you wish to see added to this list, please
 fork the [Riak Docs repo on GitHub](https://github.com/basho/basho_docs)
 and send us a pull request.
 
-<div class="note">
-<div class="title">Note on community-produced libraries</div>
-All of these projects and libraries are at various stages of
-completeness and may not suit your application's needs based on their
-level of maturity and activity.
-</div>
+{{% note title="Note on community-produced libraries" %}}
+All of these projects and libraries are at various stages of completeness and
+may not suit your application's needs based on their level of maturity and
+activity.
+{{% /note %}}
 
 ### Client Libraries and Frameworks
 

--- a/content/riak/kv/2.1.3/developing/getting-started/csharp.md
+++ b/content/riak/kv/2.1.3/developing/getting-started/csharp.md
@@ -23,10 +23,12 @@ To try this flavor of Riak, a working installation of the .NET Framework or Mono
 
 Install [the Riak .NET Client](https://github.com/basho/riak-dotnet-client/wiki/Installation) through [NuGet](http://nuget.org/packages/RiakClient) or the Visual Studio NuGet package manager.
 
-<div class="note">
-<div class="title">Configuring for a remote cluster</div>
-By default, the Riak .NET Client will add a section to your `app.config` file for a four node local cluster. If you are using a remote cluster, open up `app.config` and change the `hostAddress` values to point to nodes in your remote cluster.
-</div>
+{{% note title="Configuring for a remote cluster" %}}
+By default, the Riak .NET Client will add a section to your `app.config` file
+for a four node local cluster. If you are using a remote cluster, open up
+`app.config` and change the `hostAddress` values to point to nodes in your
+remote cluster.
+{{% /note %}}
 
 ### Connecting to Riak
 

--- a/content/riak/kv/2.1.3/developing/getting-started/csharp/object-modeling.md
+++ b/content/riak/kv/2.1.3/developing/getting-started/csharp/object-modeling.md
@@ -64,12 +64,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially when many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially when many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.3/developing/getting-started/erlang/object-modeling.md
+++ b/content/riak/kv/2.1.3/developing/getting-started/erlang/object-modeling.md
@@ -18,14 +18,13 @@ aliases:
 
 To get started, let's create the records that we'll be using.
 
-<div class="note">
-<div class="title">Code Download</div>
+{{% note title="Code Download" %}}
 You can also download the code for this chapter at
 [Github](https://github.com/basho/taste-of-riak/tree/am-dem-erlang-modules/erlang/Ch03-Msgy-Schema).
 
-The Github version includes Erlang type specifications which have been
-omitted here for brevity.
-</div>
+The Github version includes Erlang type specifications which have been omitted
+here for brevity.
+{{% /note %}}
 
 
 ```erlang
@@ -91,13 +90,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.3/developing/getting-started/golang/object-modeling.md
+++ b/content/riak/kv/2.1.3/developing/getting-started/golang/object-modeling.md
@@ -182,13 +182,11 @@ users and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.3/developing/getting-started/java.md
+++ b/content/riak/kv/2.1.3/developing/getting-started/java.md
@@ -38,13 +38,11 @@ Next, download
 [`TasteOfRiak.java`](https://github.com/basho/basho_docs/raw/master/extras/code-examples/TasteOfRiak.java)
 source code for this tutorial, and save it to your working directory.
 
-<div class="note">
-<div class="title">Configuring for a local cluster</div>
-The `TasteOfRiak.java` file that you downloaded is set up to communicate
-with a 1-node Riak cluster listening on `localhost` port 10017. We
-recommend modifying the connection info directly within the
-`setUpCluster()` method.
-</div>
+{{% note title="Configuring for a local cluster" %}}
+The `TasteOfRiak.java` file that you downloaded is set up to communicate with
+a 1-node Riak cluster listening on `localhost` port 10017. We recommend
+modifying the connection info directly within the `setUpCluster()` method.
+{{% /note %}}
 
 If you execute the `TasteOfRiak.java` file within your IDE, you should
 see the following:

--- a/content/riak/kv/2.1.3/developing/getting-started/java/object-modeling.md
+++ b/content/riak/kv/2.1.3/developing/getting-started/java/object-modeling.md
@@ -157,12 +157,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.3/developing/getting-started/nodejs/object-modeling.md
+++ b/content/riak/kv/2.1.3/developing/getting-started/nodejs/object-modeling.md
@@ -73,12 +73,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_SENT_2014-03-06` or `marketing_group_INBOX_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.3/developing/getting-started/python/object-modeling.md
+++ b/content/riak/kv/2.1.3/developing/getting-started/python/object-modeling.md
@@ -83,13 +83,11 @@ users, and `<groupname>_<type>_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-06`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.3/developing/getting-started/ruby/object-modeling.md
+++ b/content/riak/kv/2.1.3/developing/getting-started/ruby/object-modeling.md
@@ -94,13 +94,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.3/developing/usage/conflict-resolution.md
+++ b/content/riak/kv/2.1.3/developing/usage/conflict-resolution.md
@@ -25,16 +25,15 @@ If you are using Riak in an [eventually consistent](/riak/kv/2.1.3/learn/concept
 unavoidable. Often, Riak can resolve these conflicts on its own
 internally if you use causal context, i.e. [vector clocks](/riak/kv/2.1.3/learn/concepts/causal-context#vector-clocks) or [dotted version vectors](/riak/kv/2.1.3/learn/concepts/causal-context#dotted-version-vectors), when updating objects. Instructions on this can be found in the section [below](#siblings).
 
-<div class="note">
-<div class="title">Important note on terminology</div>
-In versions of Riak prior to 2.0, vector clocks were the only causal
-context mechanism available in Riak, which changed with the introduction
-of dotted version vectors in 2.0. Please note that you may frequent find
-terminology in client library APIs, internal Basho documentation, and
-more that uses the term "vector clock" interchangeably with causal
-context in general. Riak's HTTP API still uses a `X-Riak-Vclock` header,
-for example, even if you are using dotted version vectors.
-</div>
+{{% note title="Important note on terminology" %}}
+In versions of Riak prior to 2.0, vector clocks were the only causal context
+mechanism available in Riak, which changed with the introduction of dotted
+version vectors in 2.0. Please note that you may frequent find terminology in
+client library APIs, internal Basho documentation, and more that uses the term
+"vector clock" interchangeably with causal context in general. Riak's HTTP API
+still uses a `X-Riak-Vclock` header, for example, even if you are using dotted
+version vectors.
+{{% /note %}}
 
 But even when you use causal context, Riak cannot always decide which
 value is most causally recent, especially in cases involving concurrent
@@ -118,12 +117,10 @@ will be no concurrent updates. If you are storing immutable data in
 which each object is guaranteed to have its own key or engaging in
 operations related to bulk loading, you should consider LWW.
 
-<div class="note">
-<div class="title">Undefined behavior warning</div>
-Setting both <code>allow_mult</code> and <code>last_write_wins</code> to
-<code>true</code> necessarily leads to unpredictable behavior and should
-always be avoided.
-</div>
+{{% note title="Undefined behavior warning" %}}
+Setting both `allow_mult` and `last_write_wins` to `true` necessarily leads to
+unpredictable behavior and should always be avoided.
+{{% /note %}}
 
 ### Resolve Conflicts on the Application Side
 
@@ -602,13 +599,12 @@ X-Riak-Vclock: a85hYGBgzGDKBVIcR4M2cgczH7HPYEpkzGNlsP/VfYYvCwA=
 # accompany the write for Riak to be able to use the vector clock
 ```
 
-<div class="note">
-<div class="title">Concurrent conflict resolution</div>
+{{% note title="Concurrent conflict resolution" %}}
 It should be noted that it is possible to have two clients that are
 simultaneously engaging in conflict resolution. To avoid a pathological
-divergence, you should be sure to limit the number of reconciliations
-and fail once that limit has been exceeded.
-</div>
+divergence, you should be sure to limit the number of reconciliations and fail
+once that limit has been exceeded.
+{{% /note %}}
 
 ### Sibling Explosion
 
@@ -650,13 +646,10 @@ better performance. Some use cases where you might want to use
 `last_write_wins` include caching, session storage, and insert-only
 (no updates).
 
-<div class="note">
-<div class="title">Note on combining <code>allow_mult</code> and
-<code>last_write_wins</code></div>
-The combination of setting both the <code>allow_mult</code> and
-<code>last_write_wins</code> properties to <code>true</code> leads to
-undefined behavior and should not be used.
-</div>
+{{% note title="Note on combining `allow_mult` and `last_write_wins`" %}}
+The combination of setting both the `allow_mult` and `last_write_wins`
+properties to `true` leads to undefined behavior and should not be used.
+{{% /note %}}
 
 ## Vector Clock Pruning
 

--- a/content/riak/kv/2.1.3/developing/usage/mapreduce.md
+++ b/content/riak/kv/2.1.3/developing/usage/mapreduce.md
@@ -15,16 +15,14 @@ aliases:
   - /riak/kv/2.1.3/dev/using/mapreduce
 ---
 
-<div class="note">
-<div class="title">Use MapReduce sparingly</div>
-In Riak, MapReduce is the primary method for non-primary-key-based
-querying. Although useful for a limited range of purposes, such as batch
-processing jobs, MapReduce operations can be very computationally
-expensive, sometimes to the extent that they can degrade performance in
-production clusters operating under load. Thus, we recommend running
-MapReduce operations in a controlled, rate-limited fashion and never for
-realtime querying purposes.
-</div>
+{{% note title="Use MapReduce sparingly" %}}
+In Riak, MapReduce is the primary method for non-primary-key-based querying.
+Although useful for a limited range of purposes, such as batch processing
+jobs, MapReduce operations can be very computationally expensive, sometimes to
+the extent that they can degrade performance in production clusters operating
+under load. Thus, we recommend running MapReduce operations in a controlled,
+rate-limited fashion and never for realtime querying purposes.
+{{% /note %}}
 
 MapReduce (M/R) is a technique for dividing data processing work across
 a distributed system. It takes advantage of the parallel processing

--- a/content/riak/kv/2.1.3/developing/usage/reading-objects.md
+++ b/content/riak/kv/2.1.3/developing/usage/reading-objects.md
@@ -197,12 +197,10 @@ The most common error code:
 
 * `404 Not Found`
 
-<div class="note">
-<div class="title">Note</div>
-If you're using a Riak client instead of HTTP, these responses will vary
-a great deal, so make sure to check the documentation for your specific
-client.
-</div>
+{{% note title="Note" %}}
+If you're using a Riak client instead of HTTP, these responses will vary a
+great deal, so make sure to check the documentation for your specific client.
+{{% /note %}}
 
 ## No Object Stored
 

--- a/content/riak/kv/2.1.3/developing/usage/replication.md
+++ b/content/riak/kv/2.1.3/developing/usage/replication.md
@@ -45,18 +45,17 @@ is one of the features that differentiates Riak from other databases.
 At the bottom of the page, you'll find a [screencast](/riak/kv/2.1.3/developing/app-guide/replication-properties#screencast) that briefly explains how to adjust your
 replication levels to match your application and business needs.
 
-<div class="note">
-<div class="title">Note on strong consistency</div>
+{{% note title="Note on strong consistency" %}}
 An option introduced in Riak version 2.0 is to use Riak as a
-<a href="/riak/kv/2.1.3/using/reference/strong-consistency/">strongly consistent</a>
-system for data in specified buckets. Using Riak in this way is
-fundamentally different from adjusting replication properties and
-fine-tuning the availability/consistency trade-off, as it sacrifices
-<em>all</em> availability guarantees when necessary. Therefore, you
-should consult the <a href="/riak/kv/2.1.3/developing/app-guide/strong-consistency">Using
-Strong Consistency</a> documentation, as this option will not be covered
-in this tutorial.
-</div>
+<a href="/riak/kv/2.1.3/using/reference/strong-consistency/">strongly
+consistent</a> system for data in specified buckets. Using Riak in this way is
+fundamentally different from adjusting replication properties and fine-tuning
+the availability/consistency trade-off, as it sacrifices _all_ availability
+guarantees when necessary. Therefore, you should consult the
+<a href="/riak/kv/2.1.3/developing/app-guide/strong-consistency">Using Strong
+Consistency</a> documentation, as this option will not be covered in this
+tutorial.
+{{% /note %}}
 
 ## How Replication Properties Work
 
@@ -162,15 +161,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -338,15 +335,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -363,14 +359,12 @@ documentation on [Bitcask][plan backend bitcask], [LevelDB][plan backend leveldb
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.1.3/developing/usage/security/erlang.md
+++ b/content/riak/kv/2.1.3/developing/usage/security/erlang.md
@@ -24,13 +24,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.1.3/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Erlang Client Basics
 

--- a/content/riak/kv/2.1.3/developing/usage/security/java.md
+++ b/content/riak/kv/2.1.3/developing/usage/security/java.md
@@ -23,13 +23,11 @@ If you are using [trust-](/riak/kv/2.1.3/using/security/managing-sources/#trust-
 security setup described [below](#java-client-basics). [Certificate](/riak/kv/2.1.3/using/security/managing-sources/#certificate-based-authentication)-based authentication is not
 yet supported in the Java client.
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Java Client Basics
 

--- a/content/riak/kv/2.1.3/developing/usage/security/python.md
+++ b/content/riak/kv/2.1.3/developing/usage/security/python.md
@@ -25,13 +25,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.1.3/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## OpenSSL Versions
 

--- a/content/riak/kv/2.1.3/developing/usage/security/ruby.md
+++ b/content/riak/kv/2.1.3/developing/usage/security/ruby.md
@@ -25,13 +25,11 @@ can use the security setup described in the [Ruby Client Basics](#ruby-client-ba
 in a [later section](#password-based-authentication), while [certificate](/riak/kv/2.1.3/using/security/managing-sources/#certificate-based-authentication)-based authentication
 is covered [further down](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Ruby Client Basics
 

--- a/content/riak/kv/2.1.3/introduction.md
+++ b/content/riak/kv/2.1.3/introduction.md
@@ -185,14 +185,12 @@ Based on Basho's [Cuttlefish](https://github.com/basho/cuttlefish)
 project, the new system is much simpler, leaving behind the Erlang
 syntax required in `app.config`.
 
-<div class="note">
-<div class="title">Note on upgrading</div>
-Version 2.0 will support both the old and the new configuration system,
-in case you're upgrading. Please note, however, that if you use both
-systems side by side, all settings from the older,
-`app.config`/`vm.args`-based system will override any settings from the
-new system.
-</div>
+{{% note title="Note on upgrading" %}}
+Version 2.0 will support both the old and the new configuration system, in
+case you're upgrading. Please note, however, that if you use both systems side
+by side, all settings from the older, `app.config`/`vm.args`-based system will
+override any settings from the new system.
+{{% /note %}}
 
 #### Relevant Docs
 

--- a/content/riak/kv/2.1.3/learn/concepts/strong-consistency.md
+++ b/content/riak/kv/2.1.3/learn/concepts/strong-consistency.md
@@ -18,10 +18,14 @@ aliases:
 [usage bucket types]: /riak/kv/2.1.3/developing/usage/bucket-types
 [concept eventual consistency]: /riak/kv/2.1.3/learn/concepts/eventual-consistency
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 Riak was originally designed as an [eventually consistent](/riak/kv/2.1.3/learn/concepts/eventual-consistency) system, fundamentally geared toward providing partition
 (i.e. fault) tolerance and high read and write availability.

--- a/content/riak/kv/2.1.3/setup/installing/amazon-web-services.md
+++ b/content/riak/kv/2.1.3/setup/installing/amazon-web-services.md
@@ -62,10 +62,10 @@ You will need need to launch at least 3 instances to form a Riak cluster.  When 
 
 You can find more information on connecting to an instance on the official [Amazon EC2 instance guide](http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/AccessingInstances.html).
 
-<div class="note">
-<div class="title">Note</div>
-The following clustering setup will <em>not</em> be resilient to instance restarts unless deployed in Amazon VPC.
-</div>
+{{% note title="Note" %}}
+The following clustering setup will _not_ be resilient to instance restarts
+unless deployed in Amazon VPC.
+{{% /note %}}
 
 1. On the first node, obtain the internal IP address:
 

--- a/content/riak/kv/2.1.3/setup/installing/mac-osx.md
+++ b/content/riak/kv/2.1.3/setup/installing/mac-osx.md
@@ -50,13 +50,12 @@ directory and execute `bin/riak start` to start the Riak node.
 
 ## Homebrew
 
-<div class="note">
-<div class="title">Warning: Homebrew not always up to date</div>
-Homebrew's Riak recipe is community supported, and thus is not always up
-to date with the latest Riak package. Please ensure that the current
-recipe is using the latest supported code (and don't be afraid to update
-it if it's not).
-</div>
+{{% note title="Warning: Homebrew not always up to date" %}}
+Homebrew's Riak recipe is community supported, and thus is not always up to
+date with the latest Riak package. Please ensure that the current recipe is
+using the latest supported code (and don't be afraid to update it if it's
+not).
+{{% /note %}}
 
 Installing Riak 2.0 with [Homebrew](http://brew.sh/) is easy:
 
@@ -90,11 +89,10 @@ the Riak installation directory via environment variables.
 You must have Xcode tools installed from [Apple's Developer
 website](http://developer.apple.com/).
 
-<div class="note">
-<div class="title">Note on Clang</div>
-Riak will not compile with Clang. Please make sure that your default
-C/C++ compiler is [GCC](https://gcc.gnu.org/).
-</div>
+{{% note title="Note on Clang" %}}
+Riak will not compile with Clang. Please make sure that your default C/C++
+compiler is [GCC](https://gcc.gnu.org/).
+{{% /note %}}
 
 Riak requires [Erlang](http://www.erlang.org/) R16B02+.
 

--- a/content/riak/kv/2.1.3/using/admin/riak-admin.md
+++ b/content/riak/kv/2.1.3/using/admin/riak-admin.md
@@ -185,11 +185,10 @@ rename the nodes of a cluster. For more information, visit the
 riak-admin reip <old nodename> <new nodename>
 ```
 
-<div class="note">
-<div class="title">Note about reip prior to Riak 2.0</title></div>
-Several bugs have been fixed related to reip in Riak 2.0. We recommend
-against using reip prior to 2.0, if possible.
-</div>
+{{% note title="Note about reip prior to Riak 2.0" %}}
+Several bugs have been fixed related to reip in Riak 2.0. We recommend against
+using reip prior to 2.0, if possible.
+{{% /note %}}
 
 
 ## js-reload
@@ -389,12 +388,10 @@ entropy tree building, and key repairs which were triggered by AAE.
  * The *Max* column shows the maximum number of keys repaired during all
    key exchanges since the last node restart.
 
-<div class="note">
-<div class="title">Note in AAE status information</div>
-All AAE status information is in-memory and is reset across a node
-restart. Only tree build times are persistent (since trees themselves
-are persistent)
-</div>
+{{% note title="Note in AAE status information" %}}
+All AAE status information is in-memory and is reset across a node restart.
+Only tree build times are persistent (since trees themselves are persistent)
+{{% /note %}}
 
 More details on the `aae-status` command are available in the [Riak
 version 1.3 release notes](https://github.com/basho/riak/blob/1.3/RELEASE-NOTES.md#active-anti-entropy).
@@ -628,11 +625,10 @@ repaired for a given exchange round since the node has started.
 
 ### switch-to-new-search
 
-<div class="info">
-<div class="title">Only For Legacy Migration</div>
-This is only needed when migrating from legacy riak search to the new
-Search (Yokozuna).
-</div>
+{{% note title="Only For Legacy Migration" %}}
+This is only needed when migrating from legacy riak search to the new Search
+(Yokozuna).
+{{% /note %}}
 
 ```bash
 riak-admin search switch-to-new-search

--- a/content/riak/kv/2.1.3/using/admin/riak-control.md
+++ b/content/riak/kv/2.1.3/using/admin/riak-control.md
@@ -57,12 +57,11 @@ listener.https.<name> = 127.0.0.1:8096
 %%     the `riak_api` tuple's value list.
 ```
 
-<div class="note">
-<div class="title">Note on SSL</div>
-We strongly recommend that you enable SSL for Riak Control. It is
-disabled by default, and if you wish to enable it you must do so
-explicitly. More information can be found in the document below.
-</div>
+{{% note title="Note on SSL" %}}
+We strongly recommend that you enable SSL for Riak Control. It is disabled by
+default, and if you wish to enable it you must do so explicitly. More
+information can be found in the document below.
+{{% /note %}}
 
 ## Enabling and Disabling Riak Control
 
@@ -168,16 +167,15 @@ be because you are using self-signed certificates. If you have
 authentication enabled in your configuration, you will next be asked to
 authenticate. Enter an appropriate username and password now.
 
-<div class="note">
-<div class="title">Note on browser TLS</div>
-Your browser needs to be support TLS v1.2 to use Riak Control over
-HTTPS. A list of browsers that support TLS v1.2 can be found
+{{% note title="Note on browser TLS" %}}
+Your browser needs to be support TLS v1.2 to use Riak Control over HTTPS. A
+list of browsers that support TLS v1.2 can be found
 [here](https://en.wikipedia.org/wiki/Transport_Layer_Security#Web_browsers).
-TLS v1.2 may be disabled by default on your browser, for example if you
-are using Firefox versions earlier than 27, Safari versions earlier than
-7, Chrome versions earlier than 30, or Internet Explorer versions
-earlier than 11.  To enable it, follow browser-specific instructions.
-</div>
+TLS v1.2 may be disabled by default on your browser, for example if you are
+using Firefox versions earlier than 27, Safari versions earlier than 7, Chrome
+versions earlier than 30, or Internet Explorer versions earlier than 11.  To
+enable it, follow browser-specific instructions.
+{{% /note %}}
 
 ### Snapshot View
 

--- a/content/riak/kv/2.1.3/using/cluster-operations/adding-removing-nodes.md
+++ b/content/riak/kv/2.1.3/using/cluster-operations/adding-removing-nodes.md
@@ -136,15 +136,14 @@ Transfers resulting from cluster changes: 51
 If the plan is to your liking, submit the changes by running `riak-admin
 cluster commit`.
 
-<div class="note">
-<div class="title">Note on ring changes</div>
-The algorithm that distributes partitions across the cluster
-during membership changes is non-deterministic. As a result, there is no
-optimal ring. In the event that a plan results in a slightly uneven
-distribution of partitions, the plan can be cleared. Clearing a cluster
-plan with `riak-admin cluster clear` and running `riak-admin cluster
-plan` again will produce a slightly different ring.
-</div>
+{{% note title="Note on ring changes" %}}
+The algorithm that distributes partitions across the cluster during membership
+changes is non-deterministic. As a result, there is no optimal ring. In the
+event that a plan results in a slightly uneven distribution of partitions, the
+plan can be cleared. Clearing a cluster plan with `riak-admin cluster clear`
+and running `riak-admin cluster plan` again will produce a slightly different
+ring.
+{{% /note %}}
 
 ## Removing a Node From a Cluster
 

--- a/content/riak/kv/2.1.3/using/cluster-operations/bucket-types.md
+++ b/content/riak/kv/2.1.3/using/cluster-operations/bucket-types.md
@@ -16,14 +16,13 @@ Buckets are essentially a flat namespace in Riak. They allow the same
 key name to exist in multiple buckets and enable you to apply
 configurations across keys.
 
-<div class="info">
-<div class="title">How Many Buckets Can I Have?</div>
-Buckets come with virtually no cost <em>except for when you modify the
-default bucket properties</em>. Modified bucket properties are gossiped
-around the cluster and therefore add to the amount of data sent around
-the network. In other words, buckets using the <tt>default</tt> bucket
-type are free. More on that in the next section.
-</div>
+{{% note title="How Many Buckets Can I Have?" %}}
+Buckets come with virtually no cost _except for when you modify the default
+bucket properties_. Modified bucket properties are gossiped around the cluster
+and therefore add to the amount of data sent around the network. In other
+words, buckets using the `default` bucket type are free. More on that in the
+next section.
+{{% /note %}}
 
 In Riak versions 2.0 and later, Basho suggests that you [use bucket types](/riak/kv/2.1.3/developing/usage/bucket-types) to namespace and configure all buckets you use. Bucket types have a lower overhead within the cluster than the
 default bucket namespace but require an additional setup step on the

--- a/content/riak/kv/2.1.3/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.1.3/using/cluster-operations/changing-cluster-info.md
@@ -302,9 +302,12 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
-<div class="note"><div class="title">Note</div>
-When using the `riak-admin cluster force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
-</div>
+{{% note title="Note" %}}
+When using the `riak-admin cluster force-replace` command, you will always get
+a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be
+lost`. Since we didn't delete any data files and we are replacing the node
+with itself under a new name, we will not lose any replicas.
+{{% /note %}}
 
 <a id="repeat"></a>
 #### Repeat previous steps on each node

--- a/content/riak/kv/2.1.3/using/cluster-operations/replacing-node.md
+++ b/content/riak/kv/2.1.3/using/cluster-operations/replacing-node.md
@@ -86,12 +86,10 @@ with the [`riak-admin ringready`](/riak/kv/2.1.3/using/admin/riak-admin/#ringrea
 and [`riak-admin member-status`](/riak/kv/2.1.3/using/admin/riak-admin/#member-status)
 commands.
 
-<div class="info">
-<div class="title">Ring Settling</div>
-You'll need to make sure that no other ring changes occur between the
-time when you start the new node and the ring settles with the new IP
-info.
+{{% note title="Ring Settling" %}}
+You'll need to make sure that no other ring changes occur between the time
+when you start the new node and the ring settles with the new IP info.
 
-The ring is considered settled when the new node reports `true` when you
-run the `riak-admin ringready` command.
-</div>
+The ring is considered settled when the new node reports `true` when you run
+the `riak-admin ringready` command.
+{{% /note %}}

--- a/content/riak/kv/2.1.3/using/cluster-operations/strong-consistency.md
+++ b/content/riak/kv/2.1.3/using/cluster-operations/strong-consistency.md
@@ -12,10 +12,14 @@ menu:
 toc: true
 ---
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 ## Monitoring Strong Consistency
 

--- a/content/riak/kv/2.1.3/using/performance.md
+++ b/content/riak/kv/2.1.3/using/performance.md
@@ -26,13 +26,12 @@ changes.
 For performance and tuning recommendations specific to running Riak
 clusters on the Amazon Web Services EC2 environment, see [AWS Performance Tuning](/riak/kv/2.1.3/using/performance/amazon-web-services).
 
-<div class="note">
-<div class="title">Note on other operating systems</div>
+{{% note title="Note on other operating systems" %}}
 Unless otherwise specified, the tunings recommended below are for Linux
-distributions. Users implementing Riak on BSD and Solaris distributions
-can use these tuning recommendations to make analogous changes in those
-operating systems.
-</div>
+distributions. Users implementing Riak on BSD and Solaris distributions can
+use these tuning recommendations to make analogous changes in those operating
+systems.
+{{% /note %}}
 
 ## Storage and File System Tuning
 
@@ -171,12 +170,11 @@ net.ipv4.tcp_tw_reuse = 1
 net.ipv4.tcp_moderate_rcvbuf = 1
 ```
 
-<div class="note">
-<div class="title">Note on system default</div>
+{{% note title="Note on system default" %}}
 In general, these recommended values should be compared with the system
-defaults and only changed if benchmarks or other performance metrics
-indicate that networking is the bottleneck.
-</div>
+defaults and only changed if benchmarks or other performance metrics indicate
+that networking is the bottleneck.
+{{% /note %}}
 
 The following settings are optional, but may improve performance on a
 10Gb network:
@@ -211,11 +209,10 @@ ethtool -K eth0 tso off
 `ethtool` settings can be persisted across reboots by adding the above
 command to the `/etc/rc.local` script.
 
-<div class="info">
-<div class="title">Pro tip</div>
-Tuning these values will be required if they are changed, as they affect
-all network operations.
-</div>
+{{% note title="Pro tip" %}}
+Tuning these values will be required if they are changed, as they affect all
+network operations.
+{{% /note %}}
 
 ## Optional I/O Settings
 

--- a/content/riak/kv/2.1.3/using/performance/amazon-web-services.md
+++ b/content/riak/kv/2.1.3/using/performance/amazon-web-services.md
@@ -54,14 +54,13 @@ indexes are not needed for the application.
 In any case, proper benchmarking and tuning are needed to achieve the
 desired performance.
 
-<div class="info">
-<div class="title">Tip</div>
-Most successful AWS cluster deployments use more EC2 instances than they
-would the same number of physical nodes to compensate for the
-performance variability caused by shared, virtualized resources. Plan to
-have more EC2 instance based nodes than physical server nodes when
-estimating cluster size with respect to node count.
-</div>
+{{% note title="Tip" %}}
+Most successful AWS cluster deployments use more EC2 instances than they would
+the same number of physical nodes to compensate for the performance
+variability caused by shared, virtualized resources. Plan to have more EC2
+instance based nodes than physical server nodes when estimating cluster size
+with respect to node count.
+{{% /note %}}
 
 ## Operating System
 

--- a/content/riak/kv/2.1.3/using/performance/erlang.md
+++ b/content/riak/kv/2.1.3/using/performance/erlang.md
@@ -44,16 +44,15 @@ Erlang parameter | Riak parameter
 [`-env ERL_MAX_ETS_TABLES`](http://learnyousomeerlang.com/ets) | `erlang.max_ets_tables`
 `-name` | `nodename`
 
-<div class="note">
-<div class="title">Note on upgrading to 2.0</div>
-In versions of Riak prior to 2.0, Erlang VM-related parameters were
-specified in a `vm.args` configuration file; in versions 2.0 and later,
-all Erlang-VM-specific parameters are set in the `riak.conf` file. If
-you're upgrading to 2.0 from an earlier version, you can still use your
-old `vm.args` if you wish.  Please note, however, that if you set one or
-more parameters in both `vm.args` and in `riak.conf`, the settings in
-`vm.args` will override those in `riak.conf`.
-</div>
+{{% note title="Note on upgrading to 2.0" %}}
+In versions of Riak prior to 2.0, Erlang VM-related parameters were specified
+in a `vm.args` configuration file; in versions 2.0 and later, all
+Erlang-VM-specific parameters are set in the `riak.conf` file. If you're
+upgrading to 2.0 from an earlier version, you can still use your old `vm.args`
+if you wish.  Please note, however, that if you set one or more parameters in
+both `vm.args` and in `riak.conf`, the settings in `vm.args` will override
+those in `riak.conf`.
+{{% /note %}}
 
 ## SMP
 

--- a/content/riak/kv/2.1.3/using/reference/bucket-types.md
+++ b/content/riak/kv/2.1.3/using/reference/bucket-types.md
@@ -16,14 +16,12 @@ Bucket types allow groups of buckets to share configuration details and
 for Riak users to manage bucket properties more efficiently than in the
 older configuration system based on [bucket properties](/riak/kv/2.1.3/developing/usage/bucket-types/#bucket-properties-and-operations).
 
-<div class="note">
-<div class="title">Important note on cluster downgrades</div>
-If you upgrade a Riak to version 2.0 or later, you can still downgrade
-the cluster to a pre-2.0 version <em>as long as you have not created and
-activated a bucket type in the cluster</em>. Once any bucket type has
-been created and activated, you can no longer downgrade the cluster to a
-pre-2.0 version.
-</div>
+{{% note title="Important note on cluster downgrades" %}}
+If you upgrade a Riak to version 2.0 or later, you can still downgrade the
+cluster to a pre-2.0 version _as long as you have not created and activated a
+bucket type in the cluster_. Once any bucket type has been created and
+activated, you can no longer downgrade the cluster to a pre-2.0 version.
+{{% /note %}}
 
 ## How Bucket Types Work
 
@@ -133,11 +131,11 @@ If creation is successful, you should see the following output:
 type_using_defaults created
 ```
 
-<div class="note">
+{{% note %}}
 The `create` command can be run multiple times prior to a bucket type being
 activated. Riak will persist only those properties contained in the final call
 of the command.
-</div>
+{{% /note %}}
 
 Creating bucket types that assign properties _always_ involves passing
 stringified JSON to the `create` command. One way to do that is to pass
@@ -247,7 +245,7 @@ of the type:
 riak-admin bucket-type update type_to_update '{"props":{ ... }}'
 ```
 
-<div class="note"><div class="title">Immutable Configurations</div>
+{{% note title="Immutable Configurations" %}}
 Any bucket properties associated with a type can be modified after a bucket is
 created, with three important exceptions:
 
@@ -255,14 +253,14 @@ created, with three important exceptions:
 * `datatype`
 * `write_once`
 
-If a bucket type entails strong consistency (requiring that `consistent` be set
-to `true`), is set up as a `map`, `set`, or `counter`, or is defined as a write-once 
-bucket (requiring `write_once` be set to `true`), then this will be true of
-the bucket types.
+If a bucket type entails strong consistency (requiring that `consistent` be
+set to `true`), is set up as a `map`, `set`, or `counter`, or is defined as a
+write-once  bucket (requiring `write_once` be set to `true`), then this will
+be true of the bucket types.
 
-If you need to change one of these properties, we recommend that
-you simply create and activate a new bucket type.
-</div>
+If you need to change one of these properties, we recommend that you simply
+create and activate a new bucket type.
+{{% /note %}}
 
 ## Buckets as Namespaces
 
@@ -390,12 +388,11 @@ curl http://localhost:8098/types/type1/buckets/my_bucket/keys/my_key
 curl http://localhost:8098/types/type2/buckets/my_bucket/keys/my_key
 ```
 
-<div class="note">
-<div class="title">Note on object location</div>
-In Riak 2.x, <em>all requests</em> must be made to a location specified
-by a bucket type, bucket, and key rather than to a bucket/key pair, as
-in previous versions.
-</div>
+{{% note title="Note on object location" %}}
+In Riak 2.x, _all requests_ must be made to a location specified by a bucket
+type, bucket, and key rather than to a bucket/key pair, as in previous
+versions.
+{{% /note %}}
 
 If requests are made to a bucket/key pair without a specified bucket
 type, `default` will be used in place of a bucket type. The following

--- a/content/riak/kv/2.1.3/using/reference/custom-code.md
+++ b/content/riak/kv/2.1.3/using/reference/custom-code.md
@@ -31,13 +31,13 @@ name must have the same name the module. So if you are given a file named
 If you have been given Erlang code and are expected to compile it for
 your developers, keep the following notes in mind.
 
-<div class="info"><div class="title">Note on the Erlang Compiler</div> You
-must use the Erlang compiler (<tt>erlc</tt>) associated with the Riak
+{{% note title="Note on the Erlang Compiler" %}}
+You must use the Erlang compiler (`erlc`) associated with the Riak
 installation or the version of Erlang used when compiling Riak from source.
-For packaged Riak installations, you can consult Table 1 below for the
-default location of Riak's <tt>erlc</tt> for each supported platform.
-If you compiled from source, use the <tt>erlc</tt> from the Erlang version
-you used to compile Riak.</div>
+For packaged Riak installations, you can consult Table 1 below for the default
+location of Riak's `erlc` for each supported platform. If you compiled from
+source, use the `erlc` from the Erlang version you used to compile Riak.
+{{% /note %}}
 
 <table style="width: 100%; border-spacing: 0px;">
 <tbody>
@@ -88,8 +88,9 @@ and loaded. For our example, we'll use a temporary directory `/tmp/beams`,
 but you should choose a directory for production functions based on your
 own requirements such that they will be available where and when needed.
 
-<div class="info">Ensure that the directory chosen above can be read by
-the <tt>riak</tt> user.</div>
+{{% note %}}
+Ensure that the directory chosen above can be read by the `riak` user.
+{{% /note %}}
 
 Successful compilation will result in a new `.beam` file,
 `validate_json.beam`.
@@ -124,5 +125,7 @@ value store has fully initialized and become available for use.
 This is done with the `riak-admin wait-for-service` command as detailed
 in the [Commands documentation](/riak/kv/2.1.3/using/admin/riak-admin/#wait-for-service).
 
-<div class="note">It is important that you ensure riak_kv is
-active before restarting the next node.</div>
+{{% note %}}
+It is important that you ensure riak_kv is active before restarting the next
+node.
+{{% /note %}}

--- a/content/riak/kv/2.1.3/using/reference/multi-datacenter/comparison.md
+++ b/content/riak/kv/2.1.3/using/reference/multi-datacenter/comparison.md
@@ -18,13 +18,12 @@ aliases:
 This document is a systematic comparison of [Version 2](/riak/kv/2.1.3/using/reference/v2-multi-datacenter) and [Version 3](/riak/kv/2.1.3/using/reference/v3-multi-datacenter) of Riak Enterprise's Multi-Datacenter
 Replication capabilities.
 
-<div class="note">
-<div class="title">Important note on mixing versions</div>
+{{% note title="Important note on mixing versions" %}}
 If you are installing Riak Enterprise anew, you should use version 3
-replication. Under no circumstances should you mix version 2 and version
-3 replication. This comparison is meant only to list improvements
-introduced in version 3.
-</div>
+replication. Under no circumstances should you mix version 2 and version 3
+replication. This comparison is meant only to list improvements introduced in
+version 3.
+{{% /note %}}
 
 ## Version 2
 

--- a/content/riak/kv/2.1.3/using/reference/multi-datacenter/monitoring.md
+++ b/content/riak/kv/2.1.3/using/reference/multi-datacenter/monitoring.md
@@ -34,14 +34,12 @@ replication:
 * Use canary (test) objects to test replication and establish trip times
   from source to sink clusters
 
-<div class="note">
-<div class="title">Note on querying and time windows</div>
-Riak's statistics are calculated over a sliding 60-second window. Each
-time you query the stats interface, each sliding statistic shown is a
-sum or histogram value calculated from the previous 60 seconds of data.
-Because of this, the stats interface should not be queried more than
-once per minute.
-</div>
+{{% note title="Note on querying and time windows" %}}
+Riak's statistics are calculated over a sliding 60-second window. Each time
+you query the stats interface, each sliding statistic shown is a sum or
+histogram value calculated from the previous 60 seconds of data. Because of
+this, the stats interface should not be queried more than once per minute.
+{{% /note %}}
 
 ## Statistics
 

--- a/content/riak/kv/2.1.3/using/reference/statistics-monitoring.md
+++ b/content/riak/kv/2.1.3/using/reference/statistics-monitoring.md
@@ -92,15 +92,13 @@ As with the throughput metrics, keeping an eye on average (and max)
 latency times will help detect usage patterns, and provide advanced
 warnings for potential problems.
 
-<div class="note">
-<div class="title">Note on FSM Time Stats</div>
-FSM Time Stats represent the amount of time in microseconds required
-to traverse the GET or PUT Finite State Machine code, offering a
-picture of general node health. From your application's perspective,
-FSM Time effectively represents experienced latency. Mean, Median, and
-95th-, 99th-, and 100th-percentile (Max) counters are displayed. These
-are one-minute stats.
-</div>
+{{% note title="Note on FSM Time Stats" %}}
+FSM Time Stats represent the amount of time in microseconds required to
+traverse the GET or PUT Finite State Machine code, offering a picture of
+general node health. From your application's perspective, FSM Time effectively
+represents experienced latency. Mean, Median, and 95th-, 99th-, and
+100th-percentile (Max) counters are displayed. These are one-minute stats.
+{{% /note %}}
 
 Metric | Also | Relevance | Latency (in microseconds)
 :------|:-----|:----------|:-------------------------
@@ -191,19 +189,21 @@ reported success with when used for monitoring the operational status of
 their Riak clusters. Community and open source projects are presented
 along with commercial and hosted services.
 
-<div class="note">
-<div class="title">Note on Riak 2.x Statistics Support</div>
-Many of the below tools were either created by third-parties or Basho engineers
-for general usage, and have been passed to the community for further updates. As
-such, many of the below only aggregate the statistics and messages that were
-output by Riak 1.4.x.</br>
+{{% note title="Note on Riak 2.x Statistics Support" %}}
+Many of the below tools were either created by third-parties or Basho
+engineers for general usage, and have been passed to the community for further
+updates. As such, many of the below only aggregate the statistics and messages
+that were output by Riak 1.4.x.
+
 Like all code under [Basho Labs](https://github.com/basho-labs/), the below
-tools are "best effort" and have no dedicated Basho support. We both appreciate
-and need your contribution to keep these tools stable and up to date. Please
-open up a GitHub issue on the repository if you'd like to be a maintainer.</br>
-Look for banners calling out the tools we've verified that support the latest Riak 2.x
-statistics!
-</div>
+tools are "best effort" and have no dedicated Basho support. We both
+appreciate and need your contribution to keep these tools stable and up to
+date. Please open up a GitHub issue on the repository if you'd like to be a
+maintainer.
+
+Look for banners calling out the tools we've verified that support the latest
+Riak 2.x statistics!
+{{% /note %}}
 
 ### Self-Hosted Monitoring Tools
 
@@ -250,9 +250,9 @@ the Riak HTTP [`/stats`](/riak/kv/2.1.3/developing/api/http/status) endpoint is 
 
 #### Nagios
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x.**
+{{% /note %}}
 
 [Nagios](http://www.nagios.org) is a monitoring and alerting solution
 that can provide information on the status of Riak cluster nodes, in
@@ -286,9 +286,9 @@ module specifically designed to read Riak statistics.
 
 #### Zabbix
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [Zabbix](http://www.zabbix.com) is an open-source performance monitoring,
 alerting, and graphing solution that can provide information on the state of
@@ -312,9 +312,9 @@ capacity planning in a Riak cluster environment.
 
 #### New Relic
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [New Relic](http://newrelic.com) is a data analytics and visualization platform
 that can provide information on the current and past states of Riak nodes and

--- a/content/riak/kv/2.1.3/using/reference/strong-consistency.md
+++ b/content/riak/kv/2.1.3/using/reference/strong-consistency.md
@@ -15,10 +15,14 @@ toc: true
 [usage bucket types]: /riak/kv/2.1.3/developing/usage/bucket-types
 [concept eventual consistency]: /riak/kv/2.1.3/learn/concepts/eventual-consistency
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 Riak was originally designed as an [eventually consistent](/riak/kv/2.1.3/learn/concepts/eventual-consistency) system, fundamentally geared toward providing partition
 (i.e. fault) tolerance and high read and write availability.

--- a/content/riak/kv/2.1.3/using/reference/v3-multi-datacenter/cascading-writes.md
+++ b/content/riak/kv/2.1.3/using/reference/v3-multi-datacenter/cascading-writes.md
@@ -28,13 +28,11 @@ Riak Enterprise. It will need to be manually enabled on new clusters.
 Cascading realtime requires the `{riak_repl, rtq_meta}` capability to
 function.
 
-<div class="note">
-<div class="title">Note on cascading tracking</div>
-Cascading tracking is a simple list of where an object has been written.
-This works well for most common configurations. Larger installations,
-however, may have writes cascade to clusters to which other clusters
-have already written.
-</div>
+{{% note title="Note on cascading tracking" %}}
+Cascading tracking is a simple list of where an object has been written. This
+works well for most common configurations. Larger installations, however, may
+have writes cascade to clusters to which other clusters have already written.
+{{% /note %}}
 
 
 ```

--- a/content/riak/kv/2.1.3/using/repair-recovery/errors.md
+++ b/content/riak/kv/2.1.3/using/repair-recovery/errors.md
@@ -135,11 +135,10 @@ Riak to explain the correct course of action. For example, the
 `map/reduce` `parse_input` phase will respond like this when it
 encounters an invalid input:
 
-<div class="note">
-<div class="title">Note on inputs</div>
-Inputs must be a binary bucket, a tuple of bucket and key-filters, a
-list of target tuples, a search index, or modfun tuple: `INPUT`.
-</div>
+{{% note title="Note on inputs" %}}
+Inputs must be a binary bucket, a tuple of bucket and key-filters, a list of
+target tuples, a search index, or modfun tuple: `INPUT`.
+{{% /note %}}
 
 For the remaining common error codes, they are often marked by Erlang
 atoms (and quite often wrapped within an `{error,{badmatch,{...` tuple,

--- a/content/riak/kv/2.1.3/using/repair-recovery/failure-recovery.md
+++ b/content/riak/kv/2.1.3/using/repair-recovery/failure-recovery.md
@@ -117,6 +117,8 @@ spreading load and increasing available CPU and IOPS.
 
 See [Changing Cluster Information](/riak/kv/2.1.4/using/cluster-operations/changing-cluster-info/#clusters-from-backups) for instructions on cluster recovery.
 
-<div class="info">
-<div class="title">Tip</div> If you are a licensed Riak Enterprise or CS customer and require assistance or further advice with a cluster recovery, please file a ticket with the <a href="https://help.basho.com">Basho Helpdesk</a>.
-</div>
+{{% note title="Tip" %}}
+If you are a licensed Riak Enterprise or CS customer and require assistance or
+further advice with a cluster recovery, please file a ticket with the
+<a href="https://help.basho.com">Basho Helpdesk</a>.
+{{% /note %}}

--- a/content/riak/kv/2.1.3/using/repair-recovery/repairs.md
+++ b/content/riak/kv/2.1.3/using/repair-recovery/repairs.md
@@ -169,10 +169,11 @@ If there are compaction errors in any of your vnodes, those will be listed in th
 ./442446784738847563128068650529343492278651453440/LOG 
 ```
 
-<div class="note">
-<div class="title">Note</div>
-While corruption on one vnode is not uncommon, corruption in several vnodes very likely means that there is a deeper problem that needs to be address, perhaps on the OS or hardware level.
-</div>
+{{% note title="Note" %}}
+While corruption on one vnode is not uncommon, corruption in several vnodes
+very likely means that there is a deeper problem that needs to be address,
+perhaps on the OS or hardware level.
+{{% /note %}}
 
 ## Healing Corrupted LevelDBs
 

--- a/content/riak/kv/2.1.3/using/running-a-cluster.md
+++ b/content/riak/kv/2.1.3/using/running-a-cluster.md
@@ -171,14 +171,13 @@ the node's ring file.
 riak-admin cluster replace riak@127.0.0.1 riak@192.168.1.10
 ```
 
-<div class="note">
-<div class="title">Note on single nodes</div>
-If a node is started singly using default settings, as you might do when
-you are building your first test environment, you will need to remove
-the ring files from the data directory after you edit your configuration
-files. `riak-admin cluster replace` will not work since the node has not
-been joined to a cluster.
-</div>
+{{% note title="Note on single nodes" %}}
+If a node is started singly using default settings, as you might do when you
+are building your first test environment, you will need to remove the ring
+files from the data directory after you edit your configuration files.
+`riak-admin cluster replace` will not work since the node has not been joined
+to a cluster.
+{{% /note %}}
 
 As with all cluster changes, you need to view the planned changes by
 running `riak-admin cluster plan` and then running `riak-admin cluster

--- a/content/riak/kv/2.1.3/using/security/basics.md
+++ b/content/riak/kv/2.1.3/using/security/basics.md
@@ -444,13 +444,11 @@ Permission | Operation |
 `riak_kv.list_keys` | List all of the keys in a bucket
 `riak_kv.list_buckets` | List all buckets
 
-<div class="note">
-<div class="title">Note on Listing Keys and Buckets</div>
-<code>riak_kv.list_keys</code> and <code>riak_kv.list_buckets</code> are
-both very expensive operations that should be performed very rarely and
-never in production. Access to this functionality should be granted very
-carefully.
-</div>
+{{% note title="Note on Listing Keys and Buckets" %}}
+`riak_kv.list_keys` and `riak_kv.list_buckets` are both very expensive
+operations that should be performed very rarely and never in production.
+Access to this functionality should be granted very carefully.
+{{% /note %}}
 
 If you'd like to create, for example, a `client` account that is
 allowed only to run `GET` and `PUT` requests on all buckets:
@@ -631,23 +629,20 @@ The following command would remove the source for `riakuser` on
 riak-admin security del-source riakuser 127.0.0.1/32
 ```
 
-<div class="note">
-<div class="title">Note on Removing Sources</div>
-If you apply a security source both to <code>all</code> and to specific
-users and then wish to remove that source, you will need to do so in
-separate steps. The <code>riak-admin security del-source all ...</code>
-command by itself is not sufficient.
+{{% note title="Note on Removing Sources" %}}
+If you apply a security source both to `all` and to specific users and then
+wish to remove that source, you will need to do so in separate steps. The
+`riak-admin security del-source all ...` command by itself is not sufficient.
 
-For example, if you have assigned the source <code>password</code> to
-both <code>all</code> and to the user <code>riakuser</code> on the
-network <code>127.0.0.1/32</code>, the following two-step process would
-be required to fully remove the source:
+For example, if you have assigned the source `password` to both `all` and to
+the user `riakuser` on the network `127.0.0.1/32`, the following two-step
+process would be required to fully remove the source:
 
 ```bash
 riak-admin security del-source all 127.0.0.1/32 password
 riak-admin security del-source riakuser 127.0.0.1/32 password
 ```
-</div>
+{{% /note %}}
 
 ### More Usage Examples
 

--- a/content/riak/kv/2.1.3/using/security/managing-sources.md
+++ b/content/riak/kv/2.1.3/using/security/managing-sources.md
@@ -29,11 +29,10 @@ The examples below will assume that the network in question is
 [created](/riak/kv/2.1.3/using/security/basics/#user-management) and that
 security has been [enabled](/riak/kv/2.1.3/using/security/basics/#the-basics).
 
-<div class="note">
-<div class="title">Note on SSL connections</div>
-If you use <em>any</em> of the aforementioned security sources, even
-<code>trust</code>, you will need to do so via a secure SSL connection.
-</div>
+{{% note title="Note on SSL connections" %}}
+If you use _any_ of the aforementioned security sources, even `trust`, you
+will need to do so via a secure SSL connection.
+{{% /note %}}
 
 ## Trust-based Authentication
 

--- a/content/riak/kv/2.1.4/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.1.4/configuring/load-balancing-proxy.md
@@ -184,15 +184,13 @@ act as a front-end proxy to a 5-node Riak cluster.
 This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
-<div class="note">
-<div class="title">Nginx version notes</div>
-This example configuration was verified on <strong>Nginx version
-1.2.3</strong>. Please be aware that earlier versions of Nginx did not
-support any HTTP 1.1 semantics for upstream communication to backends.
-You should carefully examine this configuration and make changes
-appropriate to your specific environment before attempting to use
-it
-</div>
+{{% note title="Nginx version notes" %}}
+This example configuration was verified on **Nginx version 1.2.3**. Please be
+aware that earlier versions of Nginx did not support any HTTP 1.1 semantics
+for upstream communication to backends. You should carefully examine this
+configuration and make changes appropriate to your specific environment before
+attempting to use it
+{{% /note %}}
 
 Here is an example `nginx.conf` file:
 
@@ -250,13 +248,12 @@ server {
 }
 ```
 
-<div class="note">
-<div class="title">Note on access controls</div>
-Even when filtering and limiting requests to GETs only as done in the
-example, you should strongly consider additional access controls beyond
-what Nginx can provide directly, such as specific firewall rules to
-limit inbound connections to trusted sources.
-</div>
+{{% note title="Note on access controls" %}}
+Even when filtering and limiting requests to GETs only as done in the example,
+you should strongly consider additional access controls beyond what Nginx can
+provide directly, such as specific firewall rules to limit inbound connections
+to trusted sources.
+{{% /note %}}
 
 ### Querying Secondary Indexes Over HTTP
 

--- a/content/riak/kv/2.1.4/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.1.4/configuring/load-balancing-proxy.md
@@ -185,7 +185,7 @@ This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
 <div class="note">
-<div class="title">Nginx version notes</div
+<div class="title">Nginx version notes</div>
 This example configuration was verified on <strong>Nginx version
 1.2.3</strong>. Please be aware that earlier versions of Nginx did not
 support any HTTP 1.1 semantics for upstream communication to backends.

--- a/content/riak/kv/2.1.4/configuring/v2-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.1.4/configuring/v2-multi-datacenter/ssl.md
@@ -63,8 +63,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -72,7 +71,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.1.4/configuring/v3-multi-datacenter/quick-start.md
+++ b/content/riak/kv/2.1.4/configuring/v3-multi-datacenter/quick-start.md
@@ -136,13 +136,11 @@ Sink             Cluster Name         <Ctrl-Pid>      [Members]
 Cluster1          Cluster1            <0.4456.0>      ["10.60.67.149:9080"] (via 10.60.67.149:9080)
 ```
 
-<div class="note">
-<div class="title">Note on connections</div>
-At this point, if you do not have connections, replication will not
-work. Check your IP bindings by running <code>netstat -a</code> on all
-nodes. You should see <code>*:9080 LISTENING</code>. If not, you have
-configuration problems.
-</div>
+{{% note title="Note on connections" %}}
+At this point, if you do not have connections, replication will not work.
+Check your IP bindings by running `netstat -a` on all nodes. You should see
+`*:9080 LISTENING`. If not, you have configuration problems.
+{{% /note %}}
 
 ### Enable Realtime Replication
 

--- a/content/riak/kv/2.1.4/configuring/v3-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.1.4/configuring/v3-multi-datacenter/ssl.md
@@ -53,12 +53,11 @@ the `riak-core` section of [`advanced.confg`][config reference#advanced.config]:
 The `cacertsdir` is a directory containing all the CA certificates
 needed to verify the CA chain back to the root.
 
-<div class="note">
-<div class="title">Note on configuration</div>
+{{% note title="Note on configuration" %}}
 In Version 3 replication, the SSL settings need to be placed in the
-<code>riak-core</code> section of <code>advanced.config</code> as opposed to
-the <code>riak-repl</code> section used by Version 2 replication.
-</div>
+`riak-core` section of `advanced.config` as opposed to the `riak-repl` section
+used by Version 2 replication.
+{{% /note %}}
 
 ## Verifying Peer Certificates
 
@@ -79,21 +78,20 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
 to connect.
 
-An exception is made when the CN begins with `*`, on the assumption
-that a pool of nodes might all legitimately use a certificate with a CN
-like `*.dc5.example.com`. In this specific case, peers with matching CNs are
+An exception is made when the CN begins with `*`, on the assumption that a
+pool of nodes might all legitimately use a certificate with a CN like
+`*.dc5.example.com`. In this specific case, peers with matching CNs are
 allowed to connect, so long as an explicit or implicit ACL allows it.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.1.4/developing/api/http/fetch-object.md
+++ b/content/riak/kv/2.1.4/developing/api/http/fetch-object.md
@@ -79,22 +79,23 @@ datetime format
 The body of the response will be the contents of the object except when siblings
 are present.
 
-<div class="note"><div class="title">Siblings</div>
-<p>When `allow_mult` is set to true in the bucket properties, concurrent updates
-are allowed to create "sibling" objects, meaning that the object has any number
-of different values that are related to one another by the vector clock.  This
-allows your application to use its own conflict resolution technique.</p>
+{{% note title="Siblings" %}}
+When `allow_mult` is set to true in the bucket properties, concurrent updates
+are allowed to create "sibling" objects, meaning that the object has any
+number of different values that are related to one another by the vector
+clock.  This allows your application to use its own conflict resolution
+technique.
 
-<p>An object with multiple sibling values will result in a `300 Multiple
-Choices` response.  If the `Accept` header prefers `multipart/mixed`, all
-siblings will be returned in a single request as sections of the
-`multipart/mixed` response body.  Otherwise, a list of "vtags" will be given in
-a simple text format. You can request individual siblings by adding the `vtag`
-query parameter. Scroll down to the 'manually requesting siblings' example below for more information.</p>
+An object with multiple sibling values will result in a `300 Multiple Choices`
+response.  If the `Accept` header prefers `multipart/mixed`, all siblings will
+be returned in a single request as sections of the `multipart/mixed` response
+body.  Otherwise, a list of "vtags" will be given in a simple text format. You
+can request individual siblings by adding the `vtag` query parameter. Scroll
+down to the 'manually requesting siblings' example below for more information.
 
-<p>To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
-given in the response.</p>
-</div>
+To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
+given in the response.
+{{% /note %}}
 
 ## Simple Example
 

--- a/content/riak/kv/2.1.4/developing/api/http/link-walking.md
+++ b/content/riak/kv/2.1.4/developing/api/http/link-walking.md
@@ -26,22 +26,19 @@ is a special case of [MapReduce](/riak/kv/2.1.4/developing/usage/mapreduce), and
 GET /buckets/bucket/keys/key/[bucket],[tag],[keep]
 ```
 
-<div class="info"><div class="title">Link filters</div>
-<p>A link filter within the request URL is made of three parts, separated by
-commas:</p>
+{{% note title="Link filters" %}}
+A link filter within the request URL is made of three parts, separated by
+commas:
 
-<ul>
-<li>Bucket - a bucket name to limit the links to</li>
-<li>Tag - a "riaktag" to limit the links to</li>
-<li>Keep - 0 or 1, whether to return results from this phase</li>
-</ul>
+* Bucket - a bucket name to limit the links to
+* Tag - a "riaktag" to limit the links to
+* Keep - 0 or 1, whether to return results from this phase
 
-<p>Any of the three parts may be replaced with <code>_</code> (underscore),
-signifying that any value is valid. Multiple phases of links can be followed by
-adding additional path segments to the URL, separating the link filters by
-slashes. The final phase in the link-walking query implicitly returns its
-results.</p>
-</div>
+Any of the three parts may be replaced with `_` (underscore), signifying that
+any value is valid. Multiple phases of links can be followed by adding
+additional path segments to the URL, separating the link filters by slashes.
+The final phase in the link-walking query implicitly returns its results.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.1.4/developing/api/http/list-buckets.md
+++ b/content/riak/kv/2.1.4/developing/api/http/list-buckets.md
@@ -17,10 +17,10 @@ aliases:
 
 Lists all known buckets (ones that have keys stored in them).
 
-<div class="note"><div class="title">Not for production use</div>
+{{% note title="Not for production use" %}}
 Similar to the list keys operation, this requires traversing all keys stored
 in the cluster and should not be used in production.
-</div>
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.1.4/developing/api/http/list-keys.md
+++ b/content/riak/kv/2.1.4/developing/api/http/list-keys.md
@@ -17,12 +17,10 @@ aliases:
 
 Lists keys in a bucket.
 
-<div class="note">
-<div class="title">Not for production use</div>
-
-This operation requires traversing all keys stored in the cluster and should not be used in production.
-
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.1.4/developing/api/http/set-bucket-props.md
+++ b/content/riak/kv/2.1.4/developing/api/http/set-bucket-props.md
@@ -50,14 +50,12 @@ the bucket
 
 Other properties do exist but are not commonly modified.
 
-<div class="note">
-<div class="title">Property types</div>
-<p>Make sure you use the proper types for attributes like <strong>n_val</strong>
-and <strong>allow_mult</strong>. If you use strings instead of integers and
-booleans respectively, you may see some odd errors in your logs, saying
-something like
-<code>"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"</code>.</p>
-</div>
+{{% note title="Property types" %}}
+Make sure you use the proper types for attributes like **n_val** and
+**allow_mult**. If you use strings instead of integers and booleans
+respectively, you may see some odd errors in your logs, saying something like
+`"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"`.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.1.4/developing/api/protocol-buffers.md
+++ b/content/riak/kv/2.1.4/developing/api/protocol-buffers.md
@@ -106,12 +106,11 @@ Code | Message |
 254 | `RpbAuthResp` |
 255 | `RpbStartTls` |
 
-<div class="info">
-<div class="title">Message Definitions</div>
-All Protocol Buffers messages are defined in the <code>riak.proto</code>
-and other <code>.proto</code> files in the <code>/src</code> directory
-of the <a href="https://github.com/basho/riak_pb">RiakPB</a> project.
-</div>
+{{% note title="Message Definitions" %}}
+All Protocol Buffers messages are defined in the `riak.proto` and other
+`.proto` files in the `/src` directory of the
+<a href="https://github.com/basho/riak_pb">RiakPB</a> project.
+{{% /note %}}
 
 ### Error Response
 

--- a/content/riak/kv/2.1.4/developing/api/protocol-buffers/delete-object.md
+++ b/content/riak/kv/2.1.4/developing/api/protocol-buffers/delete-object.md
@@ -46,22 +46,17 @@ Parameter | Description |
 
 #### Optional Parameters
 
-<div class="note">
-<div class="title">Note on defaults and special values</div>
+{{% note title="Note on defaults and special values" %}}
 All of the optional parameters below have default values determined on a
 per-bucket basis. Please refer to the documentation on <a
-href="http://docs.basho.com/riak/kv/2.1.4/developing/api/protocol-buffers/set-bucket-props/">setting bucket
-properties</a> for more information.
+href="http://docs.basho.com/riak/kv/2.1.4/developing/api/protocol-buffers/set-bucket-props/">setting
+bucket properties</a> for more information.
 
-Furthermore, you can assign an integer value to the <code>rw</code>,
-<code>r</code>, <code>w</code>, <code>pr</code>, <code>pw</code>, and
-<code>dw</code>, provided that that integer value is less than or equal
-to N, <em>or</em> a special value denoting <code>one</code>
-(<code>4294967295-1</code>), <code>quorum</code>
-(<code>4294967295-2</code>), <code>all</code>
-(<code>4294967295-3</code>), or <code>default</code>
-(<code>4294967295-4</code>).
-</div>
+Furthermore, you can assign an integer value to the `rw`, `r`, `w`, `pr`,
+`pw`, and `dw`, provided that that integer value is less than or equal to N,
+_or_ a special value denoting `one` (`4294967295-1`), `quorum`
+(`4294967295-2`), `all` (`4294967295-3`), or `default` (`4294967295-4`).
+{{% /note %}}
 
 Parameter | Description |
 :---------|:------------|

--- a/content/riak/kv/2.1.4/developing/api/protocol-buffers/dt-store.md
+++ b/content/riak/kv/2.1.4/developing/api/protocol-buffers/dt-store.md
@@ -66,21 +66,17 @@ message DtOp {
 
 #### Optional Parameters
 
-<div class="note">
-<div class="title">Note on defaults and special values</div>
+{{% note title="Note on defaults and special values" %}}
 All of the optional parameters below have default values determined on a
 per-bucket basis. Please refer to the documentation on <a
-href="http://docs.basho.com/riak/kv/2.1.4/developing/api/protocol-buffers/set-bucket-props/">setting bucket
-properties</a> for more information.
+href="http://docs.basho.com/riak/kv/2.1.4/developing/api/protocol-buffers/set-bucket-props/">setting
+bucket properties</a> for more information.
 
-Furthermore, you can assign an integer value to the <code>w</code>,
-<code>dw</code>, and <code>pw</code>, provided that that integer value
-is less than or equal to N, <em>or</em> a special value denoting
-<code>one</code> (<code>4294967295-1</code>), <code>quorum</code>
-(<code>4294967295-2</code>), <code>all</code>
-(<code>4294967295-3</code>), or <code>default</code>
-(<code>4294967295-4</code>).
-</div>
+Furthermore, you can assign an integer value to the `w`, `dw`, and `pw`,
+provided that that integer value is less than or equal to N, _or_ a special
+value denoting `one` (`4294967295-1`), `quorum` (`4294967295-2`), `all`
+(`4294967295-3`), or `default` (`4294967295-4`).
+{{% /note %}}
 
 Parameter | Description
 :---------|:-----------

--- a/content/riak/kv/2.1.4/developing/api/protocol-buffers/fetch-object.md
+++ b/content/riak/kv/2.1.4/developing/api/protocol-buffers/fetch-object.md
@@ -137,14 +137,12 @@ of the following optional parameters:
 * `deleted` --- Whether the object has been deleted (i.e. whether a
   tombstone for the object has been found under the specified key)
 
-<div class="note">
-<div class="title">Note on missing keys</div>
-Remember: if a key is not stored in Riak, an <code>RpbGetResp</code>
-response without the <code>content</code> and <code>vclock</code> fields
-will be returned. This should be mapped to whatever convention the
-client language uses to return not found. The Erlang client, for
-example, returns the atom <code>{error, notfound}</code>.
-</div>
+{{% note title="Note on missing keys" %}}
+Remember: if a key is not stored in Riak, an `RpbGetResp` response without the
+`content` and `vclock` fields will be returned. This should be mapped to
+whatever convention the client language uses to return not found. The Erlang
+client, for example, returns the atom `{error, notfound}`.
+{{% /note %}}
 
 ## Example
 

--- a/content/riak/kv/2.1.4/developing/api/protocol-buffers/get-client-id.md
+++ b/content/riak/kv/2.1.4/developing/api/protocol-buffers/get-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.1.4/dev/references/protocol-buffers/get-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Get the client id used for this connection. Client ids are used for
 conflict resolution and each unique actor in the system should be

--- a/content/riak/kv/2.1.4/developing/api/protocol-buffers/list-buckets.md
+++ b/content/riak/kv/2.1.4/developing/api/protocol-buffers/list-buckets.md
@@ -17,12 +17,10 @@ aliases:
 
 List all of the bucket names available.
 
-<div class="note">
-<div class="title">Caution</div>
-
-This call can be expensive for the server. Do not use in
-performance-sensitive code.
-</div>
+{{% note title="Caution" %}}
+This call can be expensive for the server. Do not use in performance-sensitive
+code.
+{{% /note %}}
 
 
 ## Request

--- a/content/riak/kv/2.1.4/developing/api/protocol-buffers/list-keys.md
+++ b/content/riak/kv/2.1.4/developing/api/protocol-buffers/list-keys.md
@@ -18,11 +18,10 @@ aliases:
 List all of the keys in a bucket. This is a streaming call, with
 multiple response messages sent for each request.
 
-<div class="note">
-<div class="title">Not for production use</div>
-This operation requires traversing all keys stored in the cluster and
-should not be used in production.
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.1.4/developing/api/protocol-buffers/set-client-id.md
+++ b/content/riak/kv/2.1.4/developing/api/protocol-buffers/set-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.1.4/dev/references/protocol-buffers/set-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Set the client ID for this connection. A library may want to set the
 client ID if it has a good way to uniquely identify actors across

--- a/content/riak/kv/2.1.4/developing/api/protocol-buffers/store-object.md
+++ b/content/riak/kv/2.1.4/developing/api/protocol-buffers/store-object.md
@@ -54,18 +54,17 @@ Parameter | Description
 
 #### Optional Parameters
 
-<div class="note">
-<div class="title">Note on defaults and special values</div>
+{{% note title="Note on defaults and special values" %}}
 All of the optional parameters below have default values determined on a
 per-bucket basis. Please refer to the documentation on <a
-href="http://docs.basho.com/riak/kv/2.1.4/developing/api/protocol-buffers/set-bucket-props/">setting bucket
-properties</a> for more information.
+href="http://docs.basho.com/riak/kv/2.1.4/developing/api/protocol-buffers/set-bucket-props/">setting
+bucket properties</a> for more information.
 
-Furthermore, you can assign an integer value to the `w`, `dw`, `pr`, and
-`pw`, provided that that integer value is less than or equal to N, _or_
-a special value denoting `one` (`4294967295-1`), `quorum`
-(`4294967295-2`), `all` (`4294967295-3`), or `default` (`4294967295-4`).
-</div>
+Furthermore, you can assign an integer value to the `w`, `dw`, `pr`, and `pw`,
+provided that that integer value is less than or equal to N, _or_ a special
+value denoting `one` (`4294967295-1`), `quorum` (`4294967295-2`), `all`
+(`4294967295-3`), or `default` (`4294967295-4`).
+{{% /note %}}
 
 Parameter | Description
 :---------|:-----------

--- a/content/riak/kv/2.1.4/developing/app-guide/advanced-mapreduce.md
+++ b/content/riak/kv/2.1.4/developing/app-guide/advanced-mapreduce.md
@@ -253,10 +253,10 @@ curl -XPOST localhost:8098/mapred \
 
 The result should be a JSON map of bucket and key names expressed as key/value pairs.
 
-<div class="info">
-Be sure to install the MapReduce function as described above on all of
-the nodes in your cluster to ensure proper operation.
-</div>
+{{% note %}}
+Be sure to install the MapReduce function as described above on all of the
+nodes in your cluster to ensure proper operation.
+{{% /note %}}
 
 
 ## Phase functions
@@ -481,27 +481,25 @@ takes any of the following forms:
 * `{jsanon, {Bucket, Key}}` where the object at `{Bucket, Key}` contains
   the source for an anonymous Javascript function
 
-<div class="info">
-<div class="title">qfun Note</div>
-Using `qfun` in compiled applications can be a fragile
-operation. Please keep the following points in mind.
+{{% note title="qfun Note" %}}
+Using `qfun` in compiled applications can be a fragile operation. Please keep
+the following points in mind.
 
-1. The module in which the function is defined must be present and
-**exactly the same version** on both the client and Riak nodes.
+1. The module in which the function is defined must be present and **exactly
+   the same version** on both the client and Riak nodes.
 
-2. Any modules and functions used by this function (or any function in
-the resulting call stack) must also be present on the Riak nodes.
+2. Any modules and functions used by this function (or any function in the
+   resulting call stack) must also be present on the Riak nodes.
 
-Errors about failures to ensure both 1 and 2 are often surprising,
-usually seen as opaque **missing-function** or **function-clause**
-errors. Especially in the case of differing module versions, this can be
-difficult to diagnose without expecting the issue and knowing of
-`Module:info/0`.
+Errors about failures to ensure both 1 and 2 are often surprising, usually
+seen as opaque **missing-function** or **function-clause** errors. Especially
+in the case of differing module versions, this can be difficult to diagnose
+without expecting the issue and knowing of `Module:info/0`.
 
-When using the Erlang shell, anonymous MapReduce functions can be
-defined and sent to Riak instead of deploying them to all servers in
-advance, but condition #2 above still holds.
-</div>
+When using the Erlang shell, anonymous MapReduce functions can be defined and
+sent to Riak instead of deploying them to all servers in advance, but
+condition #2 above still holds.
+{{% /note %}}
 
 Link phases are expressed in the following form:
 

--- a/content/riak/kv/2.1.4/developing/app-guide/replication-properties.md
+++ b/content/riak/kv/2.1.4/developing/app-guide/replication-properties.md
@@ -154,15 +154,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -330,15 +328,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -355,14 +352,12 @@ documentation on [Bitcask](/riak/kv/2.1.4/setup/planning/backend/bitcask), [Leve
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.1.4/developing/client-libraries.md
+++ b/content/riak/kv/2.1.4/developing/client-libraries.md
@@ -50,12 +50,11 @@ developing something that you wish to see added to this list, please
 fork the [Riak Docs repo on GitHub](https://github.com/basho/basho_docs)
 and send us a pull request.
 
-<div class="note">
-<div class="title">Note on community-produced libraries</div>
-All of these projects and libraries are at various stages of
-completeness and may not suit your application's needs based on their
-level of maturity and activity.
-</div>
+{{% note title="Note on community-produced libraries" %}}
+All of these projects and libraries are at various stages of completeness and
+may not suit your application's needs based on their level of maturity and
+activity.
+{{% /note %}}
 
 ### Client Libraries and Frameworks
 

--- a/content/riak/kv/2.1.4/developing/getting-started/csharp.md
+++ b/content/riak/kv/2.1.4/developing/getting-started/csharp.md
@@ -23,10 +23,12 @@ To try this flavor of Riak, a working installation of the .NET Framework or Mono
 
 Install [the Riak .NET Client](https://github.com/basho/riak-dotnet-client/wiki/Installation) through [NuGet](http://nuget.org/packages/RiakClient) or the Visual Studio NuGet package manager.
 
-<div class="note">
-<div class="title">Configuring for a remote cluster</div>
-By default, the Riak .NET Client will add a section to your `app.config` file for a four node local cluster. If you are using a remote cluster, open up `app.config` and change the `hostAddress` values to point to nodes in your remote cluster.
-</div>
+{{% note title="Configuring for a remote cluster" %}}
+By default, the Riak .NET Client will add a section to your `app.config` file
+for a four node local cluster. If you are using a remote cluster, open up
+`app.config` and change the `hostAddress` values to point to nodes in your
+remote cluster.
+{{% /note %}}
 
 ### Connecting to Riak
 

--- a/content/riak/kv/2.1.4/developing/getting-started/csharp/object-modeling.md
+++ b/content/riak/kv/2.1.4/developing/getting-started/csharp/object-modeling.md
@@ -64,12 +64,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially when many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially when many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.4/developing/getting-started/erlang/object-modeling.md
+++ b/content/riak/kv/2.1.4/developing/getting-started/erlang/object-modeling.md
@@ -18,14 +18,13 @@ aliases:
 
 To get started, let's create the records that we'll be using.
 
-<div class="note">
-<div class="title">Code Download</div>
+{{% note title="Code Download" %}}
 You can also download the code for this chapter at
 [Github](https://github.com/basho/taste-of-riak/tree/am-dem-erlang-modules/erlang/Ch03-Msgy-Schema).
 
-The Github version includes Erlang type specifications which have been
-omitted here for brevity.
-</div>
+The Github version includes Erlang type specifications which have been omitted
+here for brevity.
+{{% /note %}}
 
 
 ```erlang
@@ -91,13 +90,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.4/developing/getting-started/golang/object-modeling.md
+++ b/content/riak/kv/2.1.4/developing/getting-started/golang/object-modeling.md
@@ -182,13 +182,11 @@ users and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.4/developing/getting-started/java.md
+++ b/content/riak/kv/2.1.4/developing/getting-started/java.md
@@ -38,13 +38,11 @@ Next, download
 [`TasteOfRiak.java`](https://github.com/basho/basho_docs/raw/master/extras/code-examples/TasteOfRiak.java)
 source code for this tutorial, and save it to your working directory.
 
-<div class="note">
-<div class="title">Configuring for a local cluster</div>
-The `TasteOfRiak.java` file that you downloaded is set up to communicate
-with a 1-node Riak cluster listening on `localhost` port 10017. We
-recommend modifying the connection info directly within the
-`setUpCluster()` method.
-</div>
+{{% note title="Configuring for a local cluster" %}}
+The `TasteOfRiak.java` file that you downloaded is set up to communicate with
+a 1-node Riak cluster listening on `localhost` port 10017. We recommend
+modifying the connection info directly within the `setUpCluster()` method.
+{{% /note %}}
 
 If you execute the `TasteOfRiak.java` file within your IDE, you should
 see the following:

--- a/content/riak/kv/2.1.4/developing/getting-started/java/object-modeling.md
+++ b/content/riak/kv/2.1.4/developing/getting-started/java/object-modeling.md
@@ -157,12 +157,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.4/developing/getting-started/nodejs/object-modeling.md
+++ b/content/riak/kv/2.1.4/developing/getting-started/nodejs/object-modeling.md
@@ -73,12 +73,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_SENT_2014-03-06` or `marketing_group_INBOX_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.4/developing/getting-started/python/object-modeling.md
+++ b/content/riak/kv/2.1.4/developing/getting-started/python/object-modeling.md
@@ -83,13 +83,11 @@ users, and `<groupname>_<type>_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-06`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.4/developing/getting-started/ruby/object-modeling.md
+++ b/content/riak/kv/2.1.4/developing/getting-started/ruby/object-modeling.md
@@ -94,13 +94,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.1.4/developing/usage/conflict-resolution.md
+++ b/content/riak/kv/2.1.4/developing/usage/conflict-resolution.md
@@ -25,16 +25,15 @@ If you are using Riak in an [eventually consistent](/riak/kv/2.1.4/learn/concept
 unavoidable. Often, Riak can resolve these conflicts on its own
 internally if you use causal context, i.e. [vector clocks](/riak/kv/2.1.4/learn/concepts/causal-context#vector-clocks) or [dotted version vectors](/riak/kv/2.1.4/learn/concepts/causal-context#dotted-version-vectors), when updating objects. Instructions on this can be found in the section [below](#siblings).
 
-<div class="note">
-<div class="title">Important note on terminology</div>
-In versions of Riak prior to 2.0, vector clocks were the only causal
-context mechanism available in Riak, which changed with the introduction
-of dotted version vectors in 2.0. Please note that you may frequent find
-terminology in client library APIs, internal Basho documentation, and
-more that uses the term "vector clock" interchangeably with causal
-context in general. Riak's HTTP API still uses a `X-Riak-Vclock` header,
-for example, even if you are using dotted version vectors.
-</div>
+{{% note title="Important note on terminology" %}}
+In versions of Riak prior to 2.0, vector clocks were the only causal context
+mechanism available in Riak, which changed with the introduction of dotted
+version vectors in 2.0. Please note that you may frequent find terminology in
+client library APIs, internal Basho documentation, and more that uses the term
+"vector clock" interchangeably with causal context in general. Riak's HTTP API
+still uses a `X-Riak-Vclock` header, for example, even if you are using dotted
+version vectors.
+{{% /note %}}
 
 But even when you use causal context, Riak cannot always decide which
 value is most causally recent, especially in cases involving concurrent
@@ -118,12 +117,10 @@ will be no concurrent updates. If you are storing immutable data in
 which each object is guaranteed to have its own key or engaging in
 operations related to bulk loading, you should consider LWW.
 
-<div class="note">
-<div class="title">Undefined behavior warning</div>
-Setting both <code>allow_mult</code> and <code>last_write_wins</code> to
-<code>true</code> necessarily leads to unpredictable behavior and should
-always be avoided.
-</div>
+{{% note title="Undefined behavior warning" %}}
+Setting both `allow_mult` and `last_write_wins` to `true` necessarily leads to
+unpredictable behavior and should always be avoided.
+{{% /note %}}
 
 ### Resolve Conflicts on the Application Side
 
@@ -602,13 +599,12 @@ X-Riak-Vclock: a85hYGBgzGDKBVIcR4M2cgczH7HPYEpkzGNlsP/VfYYvCwA=
 # accompany the write for Riak to be able to use the vector clock
 ```
 
-<div class="note">
-<div class="title">Concurrent conflict resolution</div>
+{{% note title="Concurrent conflict resolution" %}}
 It should be noted that it is possible to have two clients that are
 simultaneously engaging in conflict resolution. To avoid a pathological
-divergence, you should be sure to limit the number of reconciliations
-and fail once that limit has been exceeded.
-</div>
+divergence, you should be sure to limit the number of reconciliations and fail
+once that limit has been exceeded.
+{{% /note %}}
 
 ### Sibling Explosion
 
@@ -650,13 +646,10 @@ better performance. Some use cases where you might want to use
 `last_write_wins` include caching, session storage, and insert-only
 (no updates).
 
-<div class="note">
-<div class="title">Note on combining <code>allow_mult</code> and
-<code>last_write_wins</code></div>
-The combination of setting both the <code>allow_mult</code> and
-<code>last_write_wins</code> properties to <code>true</code> leads to
-undefined behavior and should not be used.
-</div>
+{{% note title="Note on combining `allow_mult` and `last_write_wins`" %}}
+The combination of setting both the `allow_mult` and `last_write_wins`
+properties to `true` leads to undefined behavior and should not be used.
+{{% /note %}}
 
 ## Vector Clock Pruning
 

--- a/content/riak/kv/2.1.4/developing/usage/mapreduce.md
+++ b/content/riak/kv/2.1.4/developing/usage/mapreduce.md
@@ -15,16 +15,14 @@ aliases:
   - /riak/kv/2.1.4/dev/using/mapreduce
 ---
 
-<div class="note">
-<div class="title">Use MapReduce sparingly</div>
-In Riak, MapReduce is the primary method for non-primary-key-based
-querying. Although useful for a limited range of purposes, such as batch
-processing jobs, MapReduce operations can be very computationally
-expensive, sometimes to the extent that they can degrade performance in
-production clusters operating under load. Thus, we recommend running
-MapReduce operations in a controlled, rate-limited fashion and never for
-realtime querying purposes.
-</div>
+{{% note title="Use MapReduce sparingly" %}}
+In Riak, MapReduce is the primary method for non-primary-key-based querying.
+Although useful for a limited range of purposes, such as batch processing
+jobs, MapReduce operations can be very computationally expensive, sometimes to
+the extent that they can degrade performance in production clusters operating
+under load. Thus, we recommend running MapReduce operations in a controlled,
+rate-limited fashion and never for realtime querying purposes.
+{{% /note %}}
 
 MapReduce (M/R) is a technique for dividing data processing work across
 a distributed system. It takes advantage of the parallel processing

--- a/content/riak/kv/2.1.4/developing/usage/reading-objects.md
+++ b/content/riak/kv/2.1.4/developing/usage/reading-objects.md
@@ -197,12 +197,10 @@ The most common error code:
 
 * `404 Not Found`
 
-<div class="note">
-<div class="title">Note</div>
-If you're using a Riak client instead of HTTP, these responses will vary
-a great deal, so make sure to check the documentation for your specific
-client.
-</div>
+{{% note title="Note" %}}
+If you're using a Riak client instead of HTTP, these responses will vary a
+great deal, so make sure to check the documentation for your specific client.
+{{% /note %}}
 
 ## No Object Stored
 

--- a/content/riak/kv/2.1.4/developing/usage/replication.md
+++ b/content/riak/kv/2.1.4/developing/usage/replication.md
@@ -45,18 +45,17 @@ is one of the features that differentiates Riak from other databases.
 At the bottom of the page, you'll find a [screencast](/riak/kv/2.1.4/developing/app-guide/replication-properties#screencast) that briefly explains how to adjust your
 replication levels to match your application and business needs.
 
-<div class="note">
-<div class="title">Note on strong consistency</div>
+{{% note title="Note on strong consistency" %}}
 An option introduced in Riak version 2.0 is to use Riak as a
-<a href="http://docs.basho.com/riak/kv/2.1.4/using/reference/strong-consistency/">strongly consistent</a>
-system for data in specified buckets. Using Riak in this way is
-fundamentally different from adjusting replication properties and
-fine-tuning the availability/consistency trade-off, as it sacrifices
-<em>all</em> availability guarantees when necessary. Therefore, you
-should consult the <a href="http://docs.basho.com/riak/kv/2.1.4/developing/app-guide/strong-consistency/">Using
-Strong Consistency</a> documentation, as this option will not be covered
-in this tutorial.
-</div>
+<a href="http://docs.basho.com/riak/kv/2.1.4/using/reference/strong-consistency/">strongly
+consistent</a> system for data in specified buckets. Using Riak in this way is
+fundamentally different from adjusting replication properties and fine-tuning
+the availability/consistency trade-off, as it sacrifices _all_ availability
+guarantees when necessary. Therefore, you should consult the
+<a href="http://docs.basho.com/riak/kv/2.1.4/developing/app-guide/strong-consistency/">Using
+Strong Consistency</a> documentation, as this option will not be covered in
+this tutorial.
+{{% /note %}}
 
 ## How Replication Properties Work
 
@@ -162,15 +161,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -338,15 +335,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -363,14 +359,12 @@ documentation on [Bitcask][plan backend bitcask], [LevelDB][plan backend leveldb
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.1.4/developing/usage/security/erlang.md
+++ b/content/riak/kv/2.1.4/developing/usage/security/erlang.md
@@ -24,13 +24,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.1.4/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Erlang Client Basics
 

--- a/content/riak/kv/2.1.4/developing/usage/security/java.md
+++ b/content/riak/kv/2.1.4/developing/usage/security/java.md
@@ -23,13 +23,11 @@ If you are using [trust-](/riak/kv/2.1.4/using/security/managing-sources/#trust-
 security setup described [below](#java-client-basics). [Certificate](/riak/kv/2.1.4/using/security/managing-sources/#certificate-based-authentication)-based authentication is not
 yet supported in the Java client.
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Java Client Basics
 

--- a/content/riak/kv/2.1.4/developing/usage/security/python.md
+++ b/content/riak/kv/2.1.4/developing/usage/security/python.md
@@ -25,13 +25,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.1.4/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## OpenSSL Versions
 

--- a/content/riak/kv/2.1.4/developing/usage/security/ruby.md
+++ b/content/riak/kv/2.1.4/developing/usage/security/ruby.md
@@ -25,13 +25,11 @@ can use the security setup described in the [Ruby Client Basics](#ruby-client-ba
 in a [later section](#password-based-authentication), while [certificate](/riak/kv/2.1.4/using/security/managing-sources/#certificate-based-authentication)-based authentication
 is covered [further down](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Ruby Client Basics
 

--- a/content/riak/kv/2.1.4/introduction.md
+++ b/content/riak/kv/2.1.4/introduction.md
@@ -185,14 +185,12 @@ Based on Basho's [Cuttlefish](https://github.com/basho/cuttlefish)
 project, the new system is much simpler, leaving behind the Erlang
 syntax required in `app.config`.
 
-<div class="note">
-<div class="title">Note on upgrading</div>
-Version 2.0 will support both the old and the new configuration system,
-in case you're upgrading. Please note, however, that if you use both
-systems side by side, all settings from the older,
-`app.config`/`vm.args`-based system will override any settings from the
-new system.
-</div>
+{{% note title="Note on upgrading" %}}
+Version 2.0 will support both the old and the new configuration system, in
+case you're upgrading. Please note, however, that if you use both systems side
+by side, all settings from the older, `app.config`/`vm.args`-based system will
+override any settings from the new system.
+{{% /note %}}
 
 #### Relevant Docs
 

--- a/content/riak/kv/2.1.4/learn/concepts/strong-consistency.md
+++ b/content/riak/kv/2.1.4/learn/concepts/strong-consistency.md
@@ -18,10 +18,14 @@ aliases:
 [usage bucket types]: /riak/kv/2.1.4/developing/usage/bucket-types
 [concept eventual consistency]: /riak/kv/2.1.4/learn/concepts/eventual-consistency
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 Riak was originally designed as an [eventually consistent](/riak/kv/2.1.4/learn/concepts/eventual-consistency) system, fundamentally geared toward providing partition
 (i.e. fault) tolerance and high read and write availability.

--- a/content/riak/kv/2.1.4/setup/installing/amazon-web-services.md
+++ b/content/riak/kv/2.1.4/setup/installing/amazon-web-services.md
@@ -62,10 +62,10 @@ You will need need to launch at least 3 instances to form a Riak cluster.  When 
 
 You can find more information on connecting to an instance on the official [Amazon EC2 instance guide](http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/AccessingInstances.html).
 
-<div class="note">
-<div class="title">Note</div>
-The following clustering setup will <em>not</em> be resilient to instance restarts unless deployed in Amazon VPC.
-</div>
+{{% note title="Note" %}}
+The following clustering setup will _not_ be resilient to instance restarts
+unless deployed in Amazon VPC.
+{{% /note %}}
 
 1. On the first node, obtain the internal IP address:
 

--- a/content/riak/kv/2.1.4/setup/installing/mac-osx.md
+++ b/content/riak/kv/2.1.4/setup/installing/mac-osx.md
@@ -50,13 +50,12 @@ directory and execute `bin/riak start` to start the Riak node.
 
 ## Homebrew
 
-<div class="note">
-<div class="title">Warning: Homebrew not always up to date</div>
-Homebrew's Riak recipe is community supported, and thus is not always up
-to date with the latest Riak package. Please ensure that the current
-recipe is using the latest supported code (and don't be afraid to update
-it if it's not).
-</div>
+{{% note title="Warning: Homebrew not always up to date" %}}
+Homebrew's Riak recipe is community supported, and thus is not always up to
+date with the latest Riak package. Please ensure that the current recipe is
+using the latest supported code (and don't be afraid to update it if it's
+not).
+{{% /note %}}
 
 Installing Riak 2.0 with [Homebrew](http://brew.sh/) is easy:
 
@@ -89,11 +88,10 @@ the Riak installation directory via environment variables.
 
 You must have Xcode tools installed from [Apple's Developer website](https://developer.apple.com/).
 
-<div class="note">
-<div class="title">Note on Clang</div>
-Riak will not compile with Clang. Please make sure that your default
-C/C++ compiler is [GCC](https://gcc.gnu.org/).
-</div>
+{{% note title="Note on Clang" %}}
+Riak will not compile with Clang. Please make sure that your default C/C++
+compiler is [GCC](https://gcc.gnu.org/).
+{{% /note %}}
 
 Riak requires [Erlang](http://www.erlang.org/) R16B02+.
 

--- a/content/riak/kv/2.1.4/using/admin/riak-admin.md
+++ b/content/riak/kv/2.1.4/using/admin/riak-admin.md
@@ -185,11 +185,10 @@ rename the nodes of a cluster. For more information, visit the
 riak-admin reip <old nodename> <new nodename>
 ```
 
-<div class="note">
-<div class="title">Note about reip prior to Riak 2.0</title></div>
-Several bugs have been fixed related to reip in Riak 2.0. We recommend
-against using reip prior to 2.0, if possible.
-</div>
+{{% note title="Note about reip prior to Riak 2.0" %}}
+Several bugs have been fixed related to reip in Riak 2.0. We recommend against
+using reip prior to 2.0, if possible.
+{{% /note %}}
 
 
 ## js-reload
@@ -389,12 +388,10 @@ entropy tree building, and key repairs which were triggered by AAE.
  * The *Max* column shows the maximum number of keys repaired during all
    key exchanges since the last node restart.
 
-<div class="note">
-<div class="title">Note in AAE status information</div>
-All AAE status information is in-memory and is reset across a node
-restart. Only tree build times are persistent (since trees themselves
-are persistent)
-</div>
+{{% note title="Note in AAE status information" %}}
+All AAE status information is in-memory and is reset across a node restart.
+Only tree build times are persistent (since trees themselves are persistent)
+{{% /note %}}
 
 More details on the `aae-status` command are available in the [Riak
 version 1.3 release notes](https://github.com/basho/riak/blob/1.3/RELEASE-NOTES.md#active-anti-entropy).
@@ -628,11 +625,10 @@ repaired for a given exchange round since the node has started.
 
 ### switch-to-new-search
 
-<div class="info">
-<div class="title">Only For Legacy Migration</div>
-This is only needed when migrating from legacy riak search to the new
-Search (Yokozuna).
-</div>
+{{% note title="Only For Legacy Migration" %}}
+This is only needed when migrating from legacy riak search to the new Search
+(Yokozuna).
+{{% /note %}}
 
 ```bash
 riak-admin search switch-to-new-search

--- a/content/riak/kv/2.1.4/using/admin/riak-control.md
+++ b/content/riak/kv/2.1.4/using/admin/riak-control.md
@@ -57,12 +57,11 @@ listener.https.<name> = 127.0.0.1:8096
 %%     the `riak_api` tuple's value list.
 ```
 
-<div class="note">
-<div class="title">Note on SSL</div>
-We strongly recommend that you enable SSL for Riak Control. It is
-disabled by default, and if you wish to enable it you must do so
-explicitly. More information can be found in the document below.
-</div>
+{{% note title="Note on SSL" %}}
+We strongly recommend that you enable SSL for Riak Control. It is disabled by
+default, and if you wish to enable it you must do so explicitly. More
+information can be found in the document below.
+{{% /note %}}
 
 ## Enabling and Disabling Riak Control
 
@@ -168,16 +167,15 @@ be because you are using self-signed certificates. If you have
 authentication enabled in your configuration, you will next be asked to
 authenticate. Enter an appropriate username and password now.
 
-<div class="note">
-<div class="title">Note on browser TLS</div>
-Your browser needs to be support TLS v1.2 to use Riak Control over
-HTTPS. A list of browsers that support TLS v1.2 can be found
+{{% note title="Note on browser TLS" %}}
+Your browser needs to be support TLS v1.2 to use Riak Control over HTTPS. A
+list of browsers that support TLS v1.2 can be found
 [here](https://en.wikipedia.org/wiki/Transport_Layer_Security#Web_browsers).
-TLS v1.2 may be disabled by default on your browser, for example if you
-are using Firefox versions earlier than 27, Safari versions earlier than
-7, Chrome versions earlier than 30, or Internet Explorer versions
-earlier than 11.  To enable it, follow browser-specific instructions.
-</div>
+TLS v1.2 may be disabled by default on your browser, for example if you are
+using Firefox versions earlier than 27, Safari versions earlier than 7, Chrome
+versions earlier than 30, or Internet Explorer versions earlier than 11.  To
+enable it, follow browser-specific instructions.
+{{% /note %}}
 
 ### Snapshot View
 

--- a/content/riak/kv/2.1.4/using/cluster-operations/adding-removing-nodes.md
+++ b/content/riak/kv/2.1.4/using/cluster-operations/adding-removing-nodes.md
@@ -136,15 +136,14 @@ Transfers resulting from cluster changes: 51
 If the plan is to your liking, submit the changes by running `riak-admin
 cluster commit`.
 
-<div class="note">
-<div class="title">Note on ring changes</div>
-The algorithm that distributes partitions across the cluster
-during membership changes is non-deterministic. As a result, there is no
-optimal ring. In the event that a plan results in a slightly uneven
-distribution of partitions, the plan can be cleared. Clearing a cluster
-plan with `riak-admin cluster clear` and running `riak-admin cluster
-plan` again will produce a slightly different ring.
-</div>
+{{% note title="Note on ring changes" %}}
+The algorithm that distributes partitions across the cluster during membership
+changes is non-deterministic. As a result, there is no optimal ring. In the
+event that a plan results in a slightly uneven distribution of partitions, the
+plan can be cleared. Clearing a cluster plan with `riak-admin cluster clear`
+and running `riak-admin cluster plan` again will produce a slightly different
+ring.
+{{% /note %}}
 
 ## Removing a Node From a Cluster
 

--- a/content/riak/kv/2.1.4/using/cluster-operations/bucket-types.md
+++ b/content/riak/kv/2.1.4/using/cluster-operations/bucket-types.md
@@ -16,14 +16,13 @@ Buckets are essentially a flat namespace in Riak. They allow the same
 key name to exist in multiple buckets and enable you to apply
 configurations across keys.
 
-<div class="info">
-<div class="title">How Many Buckets Can I Have?</div>
-Buckets come with virtually no cost <em>except for when you modify the
-default bucket properties</em>. Modified bucket properties are gossiped
-around the cluster and therefore add to the amount of data sent around
-the network. In other words, buckets using the <tt>default</tt> bucket
-type are free. More on that in the next section.
-</div>
+{{% note title="How Many Buckets Can I Have?" %}}
+Buckets come with virtually no cost _except for when you modify the default
+bucket properties_. Modified bucket properties are gossiped around the cluster
+and therefore add to the amount of data sent around the network. In other
+words, buckets using the `default` bucket type are free. More on that in the
+next section.
+{{% /note %}}
 
 In Riak versions 2.0 and later, Basho suggests that you [use bucket types](/riak/kv/2.1.4/developing/usage/bucket-types) to namespace and configure all buckets you use. Bucket types have a lower overhead within the cluster than the
 default bucket namespace but require an additional setup step on the

--- a/content/riak/kv/2.1.4/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.1.4/using/cluster-operations/changing-cluster-info.md
@@ -302,9 +302,12 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
-<div class="note"><div class="title">Note</div>
-When using the `riak-admin cluster force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
-</div>
+{{% note title="Note" %}}
+When using the `riak-admin cluster force-replace` command, you will always get
+a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be
+lost`. Since we didn't delete any data files and we are replacing the node
+with itself under a new name, we will not lose any replicas.
+{{% /note %}}
 
 <a id="repeat"></a>
 #### Repeat previous steps on each node

--- a/content/riak/kv/2.1.4/using/cluster-operations/replacing-node.md
+++ b/content/riak/kv/2.1.4/using/cluster-operations/replacing-node.md
@@ -89,12 +89,10 @@ with the [`riak-admin ringready`](/riak/kv/2.1.4/using/admin/riak-admin/#ringrea
 and [`riak-admin member-status`](/riak/kv/2.1.4/using/admin/riak-admin/#member-status)
 commands.
 
-<div class="info">
-<div class="title">Ring Settling</div>
-You'll need to make sure that no other ring changes occur between the
-time when you start the new node and the ring settles with the new IP
-info.
+{{% note title="Ring Settling" %}}
+You'll need to make sure that no other ring changes occur between the time
+when you start the new node and the ring settles with the new IP info.
 
-The ring is considered settled when the new node reports `true` when you
-run the `riak-admin ringready` command.
-</div>
+The ring is considered settled when the new node reports `true` when you run
+the `riak-admin ringready` command.
+{{% /note %}}

--- a/content/riak/kv/2.1.4/using/cluster-operations/strong-consistency.md
+++ b/content/riak/kv/2.1.4/using/cluster-operations/strong-consistency.md
@@ -12,10 +12,14 @@ menu:
 toc: true
 ---
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 ## Monitoring Strong Consistency
 

--- a/content/riak/kv/2.1.4/using/performance.md
+++ b/content/riak/kv/2.1.4/using/performance.md
@@ -26,13 +26,12 @@ changes.
 For performance and tuning recommendations specific to running Riak
 clusters on the Amazon Web Services EC2 environment, see [AWS Performance Tuning](/riak/kv/2.1.4/using/performance/amazon-web-services).
 
-<div class="note">
-<div class="title">Note on other operating systems</div>
+{{% note title="Note on other operating systems" %}}
 Unless otherwise specified, the tunings recommended below are for Linux
-distributions. Users implementing Riak on BSD and Solaris distributions
-can use these tuning recommendations to make analogous changes in those
-operating systems.
-</div>
+distributions. Users implementing Riak on BSD and Solaris distributions can
+use these tuning recommendations to make analogous changes in those operating
+systems.
+{{% /note %}}
 
 ## Storage and File System Tuning
 
@@ -171,12 +170,11 @@ net.ipv4.tcp_tw_reuse = 1
 net.ipv4.tcp_moderate_rcvbuf = 1
 ```
 
-<div class="note">
-<div class="title">Note on system default</div>
+{{% note title="Note on system default" %}}
 In general, these recommended values should be compared with the system
-defaults and only changed if benchmarks or other performance metrics
-indicate that networking is the bottleneck.
-</div>
+defaults and only changed if benchmarks or other performance metrics indicate
+that networking is the bottleneck.
+{{% /note %}}
 
 The following settings are optional, but may improve performance on a
 10Gb network:
@@ -211,11 +209,10 @@ ethtool -K eth0 tso off
 `ethtool` settings can be persisted across reboots by adding the above
 command to the `/etc/rc.local` script.
 
-<div class="info">
-<div class="title">Pro tip</div>
-Tuning these values will be required if they are changed, as they affect
-all network operations.
-</div>
+{{% note title="Pro tip" %}}
+Tuning these values will be required if they are changed, as they affect all
+network operations.
+{{% /note %}}
 
 ## Optional I/O Settings
 

--- a/content/riak/kv/2.1.4/using/performance/amazon-web-services.md
+++ b/content/riak/kv/2.1.4/using/performance/amazon-web-services.md
@@ -54,14 +54,13 @@ indexes are not needed for the application.
 In any case, proper benchmarking and tuning are needed to achieve the
 desired performance.
 
-<div class="info">
-<div class="title">Tip</div>
-Most successful AWS cluster deployments use more EC2 instances than they
-would the same number of physical nodes to compensate for the
-performance variability caused by shared, virtualized resources. Plan to
-have more EC2 instance based nodes than physical server nodes when
-estimating cluster size with respect to node count.
-</div>
+{{% note title="Tip" %}}
+Most successful AWS cluster deployments use more EC2 instances than they would
+the same number of physical nodes to compensate for the performance
+variability caused by shared, virtualized resources. Plan to have more EC2
+instance based nodes than physical server nodes when estimating cluster size
+with respect to node count.
+{{% /note %}}
 
 ## Operating System
 

--- a/content/riak/kv/2.1.4/using/performance/erlang.md
+++ b/content/riak/kv/2.1.4/using/performance/erlang.md
@@ -44,16 +44,15 @@ Erlang parameter | Riak parameter
 [`-env ERL_MAX_ETS_TABLES`](http://learnyousomeerlang.com/ets) | `erlang.max_ets_tables`
 `-name` | `nodename`
 
-<div class="note">
-<div class="title">Note on upgrading to 2.0</div>
-In versions of Riak prior to 2.0, Erlang VM-related parameters were
-specified in a `vm.args` configuration file; in versions 2.0 and later,
-all Erlang-VM-specific parameters are set in the `riak.conf` file. If
-you're upgrading to 2.0 from an earlier version, you can still use your
-old `vm.args` if you wish.  Please note, however, that if you set one or
-more parameters in both `vm.args` and in `riak.conf`, the settings in
-`vm.args` will override those in `riak.conf`.
-</div>
+{{% note title="Note on upgrading to 2.0" %}}
+In versions of Riak prior to 2.0, Erlang VM-related parameters were specified
+in a `vm.args` configuration file; in versions 2.0 and later, all
+Erlang-VM-specific parameters are set in the `riak.conf` file. If you're
+upgrading to 2.0 from an earlier version, you can still use your old `vm.args`
+if you wish.  Please note, however, that if you set one or more parameters in
+both `vm.args` and in `riak.conf`, the settings in `vm.args` will override
+those in `riak.conf`.
+{{% /note %}}
 
 ## SMP
 

--- a/content/riak/kv/2.1.4/using/reference/bucket-types.md
+++ b/content/riak/kv/2.1.4/using/reference/bucket-types.md
@@ -16,14 +16,12 @@ Bucket types allow groups of buckets to share configuration details and
 for Riak users to manage bucket properties more efficiently than in the
 older configuration system based on [bucket properties](/riak/kv/2.1.4/developing/usage/bucket-types/#bucket-properties-and-operations).
 
-<div class="note">
-<div class="title">Important note on cluster downgrades</div>
-If you upgrade a Riak to version 2.0 or later, you can still downgrade
-the cluster to a pre-2.0 version <em>as long as you have not created and
-activated a bucket type in the cluster</em>. Once any bucket type has
-been created and activated, you can no longer downgrade the cluster to a
-pre-2.0 version.
-</div>
+{{% note title="Important note on cluster downgrades" %}}
+If you upgrade a Riak to version 2.0 or later, you can still downgrade the
+cluster to a pre-2.0 version _as long as you have not created and activated a
+bucket type in the cluster_. Once any bucket type has been created and
+activated, you can no longer downgrade the cluster to a pre-2.0 version.
+{{% /note %}}
 
 ## How Bucket Types Work
 
@@ -133,11 +131,11 @@ If creation is successful, you should see the following output:
 type_using_defaults created
 ```
 
-<div class="note">
+{{% note %}}
 The `create` command can be run multiple times prior to a bucket type being
 activated. Riak will persist only those properties contained in the final call
 of the command.
-</div>
+{{% /note %}}
 
 Creating bucket types that assign properties _always_ involves passing
 stringified JSON to the `create` command. One way to do that is to pass
@@ -247,7 +245,7 @@ of the type:
 riak-admin bucket-type update type_to_update '{"props":{ ... }}'
 ```
 
-<div class="note"><div class="title">Immutable Configurations</div>
+{{% note title="Immutable Configurations" %}}
 Any bucket properties associated with a type can be modified after a bucket is
 created, with three important exceptions:
 
@@ -255,14 +253,14 @@ created, with three important exceptions:
 * `datatype`
 * `write_once`
 
-If a bucket type entails strong consistency (requiring that `consistent` be set
-to `true`), is set up as a `map`, `set`, or `counter`, or is defined as a write-once 
-bucket (requiring `write_once` be set to `true`), then this will be true of
-the bucket types.
+If a bucket type entails strong consistency (requiring that `consistent` be
+set to `true`), is set up as a `map`, `set`, or `counter`, or is defined as a
+write-once  bucket (requiring `write_once` be set to `true`), then this will
+be true of the bucket types.
 
-If you need to change one of these properties, we recommend that
-you simply create and activate a new bucket type.
-</div>
+If you need to change one of these properties, we recommend that you simply
+create and activate a new bucket type.
+{{% /note %}}
 
 ## Buckets as Namespaces
 
@@ -390,12 +388,11 @@ curl http://localhost:8098/types/type1/buckets/my_bucket/keys/my_key
 curl http://localhost:8098/types/type2/buckets/my_bucket/keys/my_key
 ```
 
-<div class="note">
-<div class="title">Note on object location</div>
-In Riak 2.x, <em>all requests</em> must be made to a location specified
-by a bucket type, bucket, and key rather than to a bucket/key pair, as
-in previous versions.
-</div>
+{{% note title="Note on object location" %}}
+In Riak 2.x, _all requests_ must be made to a location specified by a bucket
+type, bucket, and key rather than to a bucket/key pair, as in previous
+versions.
+{{% /note %}}
 
 If requests are made to a bucket/key pair without a specified bucket
 type, `default` will be used in place of a bucket type. The following

--- a/content/riak/kv/2.1.4/using/reference/custom-code.md
+++ b/content/riak/kv/2.1.4/using/reference/custom-code.md
@@ -31,13 +31,13 @@ name must have the same name the module. So if you are given a file named
 If you have been given Erlang code and are expected to compile it for
 your developers, keep the following notes in mind.
 
-<div class="info"><div class="title">Note on the Erlang Compiler</div> You
-must use the Erlang compiler (<tt>erlc</tt>) associated with the Riak
+{{% note title="Note on the Erlang Compiler" %}}
+You must use the Erlang compiler (`erlc`) associated with the Riak
 installation or the version of Erlang used when compiling Riak from source.
-For packaged Riak installations, you can consult Table 1 below for the
-default location of Riak's <tt>erlc</tt> for each supported platform.
-If you compiled from source, use the <tt>erlc</tt> from the Erlang version
-you used to compile Riak.</div>
+For packaged Riak installations, you can consult Table 1 below for the default
+location of Riak's `erlc` for each supported platform. If you compiled from
+source, use the `erlc` from the Erlang version you used to compile Riak.
+{{% /note %}}
 
 <table style="width: 100%; border-spacing: 0px;">
 <tbody>
@@ -88,8 +88,9 @@ and loaded. For our example, we'll use a temporary directory `/tmp/beams`,
 but you should choose a directory for production functions based on your
 own requirements such that they will be available where and when needed.
 
-<div class="info">Ensure that the directory chosen above can be read by
-the <tt>riak</tt> user.</div>
+{{% note %}}
+Ensure that the directory chosen above can be read by the `riak` user.
+{{% /note %}}
 
 Successful compilation will result in a new `.beam` file,
 `validate_json.beam`.
@@ -124,5 +125,7 @@ value store has fully initialized and become available for use.
 This is done with the `riak-admin wait-for-service` command as detailed
 in the [Commands documentation](/riak/kv/2.1.4/using/admin/riak-admin/#wait-for-service).
 
-<div class="note">It is important that you ensure riak_kv is
-active before restarting the next node.</div>
+{{% note %}}
+It is important that you ensure riak_kv is active before restarting the next
+node.
+{{% /note %}}

--- a/content/riak/kv/2.1.4/using/reference/multi-datacenter/comparison.md
+++ b/content/riak/kv/2.1.4/using/reference/multi-datacenter/comparison.md
@@ -18,13 +18,12 @@ aliases:
 This document is a systematic comparison of [Version 2](/riak/kv/2.1.4/using/reference/v2-multi-datacenter) and [Version 3](/riak/kv/2.1.4/using/reference/v3-multi-datacenter) of Riak Enterprise's Multi-Datacenter
 Replication capabilities.
 
-<div class="note">
-<div class="title">Important note on mixing versions</div>
+{{% note title="Important note on mixing versions" %}}
 If you are installing Riak Enterprise anew, you should use version 3
-replication. Under no circumstances should you mix version 2 and version
-3 replication. This comparison is meant only to list improvements
-introduced in version 3.
-</div>
+replication. Under no circumstances should you mix version 2 and version 3
+replication. This comparison is meant only to list improvements introduced in
+version 3.
+{{% /note %}}
 
 ## Version 2
 

--- a/content/riak/kv/2.1.4/using/reference/multi-datacenter/monitoring.md
+++ b/content/riak/kv/2.1.4/using/reference/multi-datacenter/monitoring.md
@@ -34,14 +34,12 @@ replication:
 * Use canary (test) objects to test replication and establish trip times
   from source to sink clusters
 
-<div class="note">
-<div class="title">Note on querying and time windows</div>
-Riak's statistics are calculated over a sliding 60-second window. Each
-time you query the stats interface, each sliding statistic shown is a
-sum or histogram value calculated from the previous 60 seconds of data.
-Because of this, the stats interface should not be queried more than
-once per minute.
-</div>
+{{% note title="Note on querying and time windows" %}}
+Riak's statistics are calculated over a sliding 60-second window. Each time
+you query the stats interface, each sliding statistic shown is a sum or
+histogram value calculated from the previous 60 seconds of data. Because of
+this, the stats interface should not be queried more than once per minute.
+{{% /note %}}
 
 ## Statistics
 

--- a/content/riak/kv/2.1.4/using/reference/statistics-monitoring.md
+++ b/content/riak/kv/2.1.4/using/reference/statistics-monitoring.md
@@ -92,15 +92,13 @@ As with the throughput metrics, keeping an eye on average (and max)
 latency times will help detect usage patterns, and provide advanced
 warnings for potential problems.
 
-<div class="note">
-<div class="title">Note on FSM Time Stats</div>
-FSM Time Stats represent the amount of time in microseconds required
-to traverse the GET or PUT Finite State Machine code, offering a
-picture of general node health. From your application's perspective,
-FSM Time effectively represents experienced latency. Mean, Median, and
-95th-, 99th-, and 100th-percentile (Max) counters are displayed. These
-are one-minute stats.
-</div>
+{{% note title="Note on FSM Time Stats" %}}
+FSM Time Stats represent the amount of time in microseconds required to
+traverse the GET or PUT Finite State Machine code, offering a picture of
+general node health. From your application's perspective, FSM Time effectively
+represents experienced latency. Mean, Median, and 95th-, 99th-, and
+100th-percentile (Max) counters are displayed. These are one-minute stats.
+{{% /note %}}
 
 Metric | Also | Relevance | Latency (in microseconds)
 :------|:-----|:----------|:-------------------------
@@ -191,19 +189,21 @@ reported success with when used for monitoring the operational status of
 their Riak clusters. Community and open source projects are presented
 along with commercial and hosted services.
 
-<div class="note">
-<div class="title">Note on Riak 2.x Statistics Support</div>
-Many of the below tools were either created by third-parties or Basho engineers
-for general usage, and have been passed to the community for further updates. As
-such, many of the below only aggregate the statistics and messages that were
-output by Riak 1.4.x.</br>
+{{% note title="Note on Riak 2.x Statistics Support" %}}
+Many of the below tools were either created by third-parties or Basho
+engineers for general usage, and have been passed to the community for further
+updates. As such, many of the below only aggregate the statistics and messages
+that were output by Riak 1.4.x.
+
 Like all code under [Basho Labs](https://github.com/basho-labs/), the below
-tools are "best effort" and have no dedicated Basho support. We both appreciate
-and need your contribution to keep these tools stable and up to date. Please
-open up a GitHub issue on the repository if you'd like to be a maintainer.</br>
-Look for banners calling out the tools we've verified that support the latest Riak 2.x
-statistics!
-</div>
+tools are "best effort" and have no dedicated Basho support. We both
+appreciate and need your contribution to keep these tools stable and up to
+date. Please open up a GitHub issue on the repository if you'd like to be a
+maintainer.
+
+Look for banners calling out the tools we've verified that support the latest
+Riak 2.x statistics!
+{{% /note %}}
 
 ### Self-Hosted Monitoring Tools
 
@@ -250,9 +250,9 @@ the Riak HTTP [`/stats`](/riak/kv/2.1.4/developing/api/http/status) endpoint is 
 
 #### Nagios
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x.**
+{{% /note %}}
 
 [Nagios](http://www.nagios.org) is a monitoring and alerting solution
 that can provide information on the status of Riak cluster nodes, in
@@ -286,9 +286,9 @@ module specifically designed to read Riak statistics.
 
 #### Zabbix
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [Zabbix](http://www.zabbix.com) is an open-source performance monitoring,
 alerting, and graphing solution that can provide information on the state of
@@ -312,9 +312,9 @@ capacity planning in a Riak cluster environment.
 
 #### New Relic
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [New Relic](http://newrelic.com) is a data analytics and visualization platform
 that can provide information on the current and past states of Riak nodes and

--- a/content/riak/kv/2.1.4/using/reference/strong-consistency.md
+++ b/content/riak/kv/2.1.4/using/reference/strong-consistency.md
@@ -15,10 +15,14 @@ toc: true
 [usage bucket types]: /riak/kv/2.1.4/developing/usage/bucket-types
 [concept eventual consistency]: /riak/kv/2.1.4/learn/concepts/eventual-consistency
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 Riak was originally designed as an [eventually consistent](/riak/kv/2.1.4/learn/concepts/eventual-consistency) system, fundamentally geared toward providing partition
 (i.e. fault) tolerance and high read and write availability.

--- a/content/riak/kv/2.1.4/using/reference/v3-multi-datacenter/cascading-writes.md
+++ b/content/riak/kv/2.1.4/using/reference/v3-multi-datacenter/cascading-writes.md
@@ -28,13 +28,11 @@ Riak Enterprise. It will need to be manually enabled on new clusters.
 Cascading realtime requires the `{riak_repl, rtq_meta}` capability to
 function.
 
-<div class="note">
-<div class="title">Note on cascading tracking</div>
-Cascading tracking is a simple list of where an object has been written.
-This works well for most common configurations. Larger installations,
-however, may have writes cascade to clusters to which other clusters
-have already written.
-</div>
+{{% note title="Note on cascading tracking" %}}
+Cascading tracking is a simple list of where an object has been written. This
+works well for most common configurations. Larger installations, however, may
+have writes cascade to clusters to which other clusters have already written.
+{{% /note %}}
 
 
 ```

--- a/content/riak/kv/2.1.4/using/repair-recovery/errors.md
+++ b/content/riak/kv/2.1.4/using/repair-recovery/errors.md
@@ -135,11 +135,10 @@ Riak to explain the correct course of action. For example, the
 `map/reduce` `parse_input` phase will respond like this when it
 encounters an invalid input:
 
-<div class="note">
-<div class="title">Note on inputs</div>
-Inputs must be a binary bucket, a tuple of bucket and key-filters, a
-list of target tuples, a search index, or modfun tuple: `INPUT`.
-</div>
+{{% note title="Note on inputs" %}}
+Inputs must be a binary bucket, a tuple of bucket and key-filters, a list of
+target tuples, a search index, or modfun tuple: `INPUT`.
+{{% /note %}}
 
 For the remaining common error codes, they are often marked by Erlang
 atoms (and quite often wrapped within an `{error,{badmatch,{...` tuple,

--- a/content/riak/kv/2.1.4/using/repair-recovery/failure-recovery.md
+++ b/content/riak/kv/2.1.4/using/repair-recovery/failure-recovery.md
@@ -117,6 +117,8 @@ spreading load and increasing available CPU and IOPS.
 
 See [Changing Cluster Information](/riak/kv/2.1.4/using/cluster-operations/changing-cluster-info/#clusters-from-backups) for instructions on cluster recovery.
 
-<div class="info">
-<div class="title">Tip</div> If you are a licensed Riak Enterprise or CS customer and require assistance or further advice with a cluster recovery, please file a ticket with the <a href="https://help.basho.com">Basho Helpdesk</a>.
-</div>
+{{% note title="Tip" %}}
+If you are a licensed Riak Enterprise or CS customer and require assistance or
+further advice with a cluster recovery, please file a ticket with the
+<a href="https://help.basho.com">Basho Helpdesk</a>.
+{{% /note %}}

--- a/content/riak/kv/2.1.4/using/repair-recovery/repairs.md
+++ b/content/riak/kv/2.1.4/using/repair-recovery/repairs.md
@@ -169,10 +169,11 @@ If there are compaction errors in any of your vnodes, those will be listed in th
 ./442446784738847563128068650529343492278651453440/LOG 
 ```
 
-<div class="note">
-<div class="title">Note</div>
-While corruption on one vnode is not uncommon, corruption in several vnodes very likely means that there is a deeper problem that needs to be address, perhaps on the OS or hardware level.
-</div>
+{{% note title="Note" %}}
+While corruption on one vnode is not uncommon, corruption in several vnodes
+very likely means that there is a deeper problem that needs to be address,
+perhaps on the OS or hardware level.
+{{% /note %}}
 
 ## Healing Corrupted LevelDBs
 

--- a/content/riak/kv/2.1.4/using/running-a-cluster.md
+++ b/content/riak/kv/2.1.4/using/running-a-cluster.md
@@ -91,21 +91,20 @@ listener.protobuf.internal = 192.168.1.10:8087
 {"192.168.1.10", 8087 },
 ```
 
-<div class="note">
-<div class="title">Note on upgrading to 2.0</div>
-If you are upgrading to Riak version 2.0 or later from an pre-2.0
-release, you can use either your old `app.config`/ `vm.args`
-configuration files or the newer `riak.conf` if you wish. If you have
-installed Riak 2.0 directly, you should use only `riak.conf`.
+{{% note title="Note on upgrading to 2.0" %}}
+If you are upgrading to Riak version 2.0 or later from an pre-2.0 release, you
+can use either your old `app.config`/ `vm.args` configuration files or the
+newer `riak.conf` if you wish. If you have installed Riak 2.0 directly, you
+should use only `riak.conf`.
 
 Below, examples will be provided for both the old and new configuration
-systems. Bear in mind that you need to use either the older or the newer
-but never both simultaneously.
+systems. Bear in mind that you need to use either the older or the newer but
+never both simultaneously.
 
 More on configuring Riak can be found in the <a
 href="http://docs.basho.com/riak/kv/2.1.4/configuring/">Configuration
 Files</a> documentation.
-</div>
+{{% /note %}}
 
 If you're using the HTTP interface, you will need to alter your
 configuration in an analogous way:
@@ -180,14 +179,13 @@ the node's ring file.
 riak-admin cluster replace riak@127.0.0.1 riak@192.168.1.10
 ```
 
-<div class="note">
-<div class="title">Note on single nodes</div>
-If a node is started singly using default settings, as you might do when
-you are building your first test environment, you will need to remove
-the ring files from the data directory after you edit your configuration
-files. `riak-admin cluster replace` will not work since the node has not
-been joined to a cluster.
-</div>
+{{% note title="Note on single nodes" %}}
+If a node is started singly using default settings, as you might do when you
+are building your first test environment, you will need to remove the ring
+files from the data directory after you edit your configuration files.
+`riak-admin cluster replace` will not work since the node has not been joined
+to a cluster.
+{{% /note %}}
 
 As with all cluster changes, you need to view the planned changes by
 running `riak-admin cluster plan` and then running `riak-admin cluster

--- a/content/riak/kv/2.1.4/using/security/basics.md
+++ b/content/riak/kv/2.1.4/using/security/basics.md
@@ -444,13 +444,11 @@ Permission | Operation |
 `riak_kv.list_keys` | List all of the keys in a bucket
 `riak_kv.list_buckets` | List all buckets
 
-<div class="note">
-<div class="title">Note on Listing Keys and Buckets</div>
-<code>riak_kv.list_keys</code> and <code>riak_kv.list_buckets</code> are
-both very expensive operations that should be performed very rarely and
-never in production. Access to this functionality should be granted very
-carefully.
-</div>
+{{% note title="Note on Listing Keys and Buckets" %}}
+`riak_kv.list_keys` and `riak_kv.list_buckets` are both very expensive
+operations that should be performed very rarely and never in production.
+Access to this functionality should be granted very carefully.
+{{% /note %}}
 
 If you'd like to create, for example, a `client` account that is
 allowed only to run `GET` and `PUT` requests on all buckets:
@@ -631,23 +629,20 @@ The following command would remove the source for `riakuser` on
 riak-admin security del-source riakuser 127.0.0.1/32
 ```
 
-<div class="note">
-<div class="title">Note on Removing Sources</div>
-If you apply a security source both to <code>all</code> and to specific
-users and then wish to remove that source, you will need to do so in
-separate steps. The <code>riak-admin security del-source all ...</code>
-command by itself is not sufficient.
+{{% note title="Note on Removing Sources" %}}
+If you apply a security source both to `all` and to specific users and then
+wish to remove that source, you will need to do so in separate steps. The
+`riak-admin security del-source all ...` command by itself is not sufficient.
 
-For example, if you have assigned the source <code>password</code> to
-both <code>all</code> and to the user <code>riakuser</code> on the
-network <code>127.0.0.1/32</code>, the following two-step process would
-be required to fully remove the source:
+For example, if you have assigned the source `password` to both `all` and to
+the user `riakuser` on the network `127.0.0.1/32`, the following two-step
+process would be required to fully remove the source:
 
 ```bash
 riak-admin security del-source all 127.0.0.1/32 password
 riak-admin security del-source riakuser 127.0.0.1/32 password
 ```
-</div>
+{{% /note %}}
 
 ### More Usage Examples
 

--- a/content/riak/kv/2.1.4/using/security/managing-sources.md
+++ b/content/riak/kv/2.1.4/using/security/managing-sources.md
@@ -29,11 +29,10 @@ The examples below will assume that the network in question is
 [created](/riak/kv/2.1.4/using/security/basics/#user-management) and that
 security has been [enabled](/riak/kv/2.1.4/using/security/basics/#the-basics).
 
-<div class="note">
-<div class="title">Note on SSL connections</div>
-If you use <em>any</em> of the aforementioned security sources, even
-<code>trust</code>, you will need to do so via a secure SSL connection.
-</div>
+{{% note title="Note on SSL connections" %}}
+If you use _any_ of the aforementioned security sources, even `trust`, you
+will need to do so via a secure SSL connection.
+{{% /note %}}
 
 ## Trust-based Authentication
 

--- a/content/riak/kv/2.2.0/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.2.0/configuring/load-balancing-proxy.md
@@ -184,15 +184,13 @@ act as a front-end proxy to a 5-node Riak cluster.
 This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
-<div class="note">
-<div class="title">Nginx version notes</div>
-This example configuration was verified on <strong>Nginx version
-1.2.3</strong>. Please be aware that earlier versions of Nginx did not
-support any HTTP 1.1 semantics for upstream communication to backends.
-You should carefully examine this configuration and make changes
-appropriate to your specific environment before attempting to use
-it
-</div>
+{{% note title="Nginx version notes" %}}
+This example configuration was verified on **Nginx version 1.2.3**. Please be
+aware that earlier versions of Nginx did not support any HTTP 1.1 semantics
+for upstream communication to backends. You should carefully examine this
+configuration and make changes appropriate to your specific environment before
+attempting to use it
+{{% /note %}}
 
 Here is an example `nginx.conf` file:
 
@@ -250,13 +248,12 @@ server {
 }
 ```
 
-<div class="note">
-<div class="title">Note on access controls</div>
-Even when filtering and limiting requests to GETs only as done in the
-example, you should strongly consider additional access controls beyond
-what Nginx can provide directly, such as specific firewall rules to
-limit inbound connections to trusted sources.
-</div>
+{{% note title="Note on access controls" %}}
+Even when filtering and limiting requests to GETs only as done in the example,
+you should strongly consider additional access controls beyond what Nginx can
+provide directly, such as specific firewall rules to limit inbound connections
+to trusted sources.
+{{% /note %}}
 
 ### Querying Secondary Indexes Over HTTP
 

--- a/content/riak/kv/2.2.0/configuring/load-balancing-proxy.md
+++ b/content/riak/kv/2.2.0/configuring/load-balancing-proxy.md
@@ -185,7 +185,7 @@ This example forwards all GET requests to Riak nodes while rejecting all
 other HTTP operations.
 
 <div class="note">
-<div class="title">Nginx version notes</div
+<div class="title">Nginx version notes</div>
 This example configuration was verified on <strong>Nginx version
 1.2.3</strong>. Please be aware that earlier versions of Nginx did not
 support any HTTP 1.1 semantics for upstream communication to backends.

--- a/content/riak/kv/2.2.0/configuring/v2-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.2.0/configuring/v2-multi-datacenter/ssl.md
@@ -68,8 +68,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -77,7 +76,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.2.0/configuring/v3-multi-datacenter/quick-start.md
+++ b/content/riak/kv/2.2.0/configuring/v3-multi-datacenter/quick-start.md
@@ -137,13 +137,11 @@ Sink             Cluster Name         <Ctrl-Pid>      [Members]
 Cluster1          Cluster1            <0.4456.0>      ["10.60.67.149:9080"] (via 10.60.67.149:9080)
 ```
 
-<div class="note">
-<div class="title">Note on connections</div>
-At this point, if you do not have connections, replication will not
-work. Check your IP bindings by running <code>netstat -a</code> on all
-nodes. You should see <code>*:9080 LISTENING</code>. If not, you have
-configuration problems.
-</div>
+{{% note title="Note on connections" %}}
+At this point, if you do not have connections, replication will not work.
+Check your IP bindings by running `netstat -a` on all nodes. You should see
+`*:9080 LISTENING`. If not, you have configuration problems.
+{{% /note %}}
 
 ### Enable Realtime Replication
 

--- a/content/riak/kv/2.2.0/configuring/v3-multi-datacenter/ssl.md
+++ b/content/riak/kv/2.2.0/configuring/v3-multi-datacenter/ssl.md
@@ -54,12 +54,11 @@ the `riak-core` section of [`advanced.confg`][config reference#advanced.config]:
 The `cacertsdir` is a directory containing all the CA certificates
 needed to verify the CA chain back to the root.
 
-<div class="note">
-<div class="title">Note on configuration</div>
+{{% note title="Note on configuration" %}}
 In Version 3 replication, the SSL settings need to be placed in the
-<code>riak-core</code> section of <code>advanced.config</code> as opposed to
-the <code>riak-repl</code> section used by Version 2 replication.
-</div>
+`riak-core` section of `advanced.config` as opposed to the `riak-repl` section
+used by Version 2 replication.
+{{% /note %}}
 
 ## Verifying Peer Certificates
 
@@ -80,8 +79,7 @@ would be allowed to connect, but `corp.com` still would not.
 If no ACL (or only the special value `"*"`) is specified, no CN filtering
 is performed, except as described below.
 
-<div class="info">
-<div class="title">Identical Local and Peer Common Names</div>
+{{% note title="Identical Local and Peer Common Names" %}}
 As a special case supporting the view that a host's CN is a fully-qualified
 domain name that uniquely identifies a single network device, if the CNs of
 the local and peer certificates are the same, the nodes will *NOT* be allowed
@@ -89,7 +87,7 @@ to connect.
 
 This evaluation supercedes ACL checks, so it cannot be overridden with any
 setting of the `peer_common_name_acl` property.
-</div>
+{{% /note %}}
 
 ### Examples
 

--- a/content/riak/kv/2.2.0/developing/api/http/fetch-object.md
+++ b/content/riak/kv/2.2.0/developing/api/http/fetch-object.md
@@ -79,22 +79,23 @@ datetime format
 The body of the response will be the contents of the object except when siblings
 are present.
 
-<div class="note"><div class="title">Siblings</div>
-<p>When `allow_mult` is set to true in the bucket properties, concurrent updates
-are allowed to create "sibling" objects, meaning that the object has any number
-of different values that are related to one another by the vector clock.  This
-allows your application to use its own conflict resolution technique.</p>
+{{% note title="Siblings" %}}
+When `allow_mult` is set to true in the bucket properties, concurrent updates
+are allowed to create "sibling" objects, meaning that the object has any
+number of different values that are related to one another by the vector
+clock.  This allows your application to use its own conflict resolution
+technique.
 
-<p>An object with multiple sibling values will result in a `300 Multiple
-Choices` response.  If the `Accept` header prefers `multipart/mixed`, all
-siblings will be returned in a single request as sections of the
-`multipart/mixed` response body.  Otherwise, a list of "vtags" will be given in
-a simple text format. You can request individual siblings by adding the `vtag`
-query parameter. Scroll down to the 'manually requesting siblings' example below for more information.</p>
+An object with multiple sibling values will result in a `300 Multiple Choices`
+response.  If the `Accept` header prefers `multipart/mixed`, all siblings will
+be returned in a single request as sections of the `multipart/mixed` response
+body.  Otherwise, a list of "vtags" will be given in a simple text format. You
+can request individual siblings by adding the `vtag` query parameter. Scroll
+down to the 'manually requesting siblings' example below for more information.
 
-<p>To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
-given in the response.</p>
-</div>
+To resolve the conflict, store the resolved version with the `X-Riak-Vclock`
+given in the response.
+{{% /note %}}
 
 ## Simple Example
 

--- a/content/riak/kv/2.2.0/developing/api/http/link-walking.md
+++ b/content/riak/kv/2.2.0/developing/api/http/link-walking.md
@@ -30,22 +30,19 @@ is a special case of [MapReduce](/riak/kv/2.2.0/developing/usage/mapreduce), and
 GET /buckets/bucket/keys/key/[bucket],[tag],[keep]
 ```
 
-<div class="info"><div class="title">Link filters</div>
-<p>A link filter within the request URL is made of three parts, separated by
-commas:</p>
+{{% note title="Link filters" %}}
+A link filter within the request URL is made of three parts, separated by
+commas:
 
-<ul>
-<li>Bucket - a bucket name to limit the links to</li>
-<li>Tag - a "riaktag" to limit the links to</li>
-<li>Keep - 0 or 1, whether to return results from this phase</li>
-</ul>
+* Bucket - a bucket name to limit the links to
+* Tag - a "riaktag" to limit the links to
+* Keep - 0 or 1, whether to return results from this phase
 
-<p>Any of the three parts may be replaced with <code>_</code> (underscore),
-signifying that any value is valid. Multiple phases of links can be followed by
-adding additional path segments to the URL, separating the link filters by
-slashes. The final phase in the link-walking query implicitly returns its
-results.</p>
-</div>
+Any of the three parts may be replaced with `_` (underscore), signifying that
+any value is valid. Multiple phases of links can be followed by adding
+additional path segments to the URL, separating the link filters by slashes.
+The final phase in the link-walking query implicitly returns its results.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.2.0/developing/api/http/list-buckets.md
+++ b/content/riak/kv/2.2.0/developing/api/http/list-buckets.md
@@ -17,10 +17,10 @@ aliases:
 
 Lists all known buckets (ones that have keys stored in them).
 
-<div class="note"><div class="title">Not for production use</div>
+{{% note title="Not for production use" %}}
 Similar to the list keys operation, this requires traversing all keys stored
 in the cluster and should not be used in production.
-</div>
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.2.0/developing/api/http/list-keys.md
+++ b/content/riak/kv/2.2.0/developing/api/http/list-keys.md
@@ -17,12 +17,10 @@ aliases:
 
 Lists keys in a bucket.
 
-<div class="note">
-<div class="title">Not for production use</div>
-
-This operation requires traversing all keys stored in the cluster and should not be used in production.
-
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.2.0/developing/api/http/set-bucket-props.md
+++ b/content/riak/kv/2.2.0/developing/api/http/set-bucket-props.md
@@ -50,14 +50,12 @@ the bucket
 
 Other properties do exist but are not commonly modified.
 
-<div class="note">
-<div class="title">Property types</div>
-<p>Make sure you use the proper types for attributes like <strong>n_val</strong>
-and <strong>allow_mult</strong>. If you use strings instead of integers and
-booleans respectively, you may see some odd errors in your logs, saying
-something like
-<code>"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"</code>.</p>
-</div>
+{{% note title="Property types" %}}
+Make sure you use the proper types for attributes like **n_val** and
+**allow_mult**. If you use strings instead of integers and booleans
+respectively, you may see some odd errors in your logs, saying something like
+`"{badarith,[{riak_kv_util,normalize_rw_value,2},]}"`.
+{{% /note %}}
 
 ## Response
 

--- a/content/riak/kv/2.2.0/developing/api/protocol-buffers.md
+++ b/content/riak/kv/2.2.0/developing/api/protocol-buffers.md
@@ -106,12 +106,11 @@ Code | Message |
 254 | `RpbAuthResp` |
 255 | `RpbStartTls` |
 
-<div class="info">
-<div class="title">Message Definitions</div>
-All Protocol Buffers messages are defined in the <code>riak.proto</code>
-and other <code>.proto</code> files in the <code>/src</code> directory
-of the <a href="https://github.com/basho/riak_pb">RiakPB</a> project.
-</div>
+{{% note title="Message Definitions" %}}
+All Protocol Buffers messages are defined in the `riak.proto` and other
+`.proto` files in the `/src` directory of the
+<a href="https://github.com/basho/riak_pb">RiakPB</a> project.
+{{% /note %}}
 
 ### Error Response
 

--- a/content/riak/kv/2.2.0/developing/api/protocol-buffers/fetch-object.md
+++ b/content/riak/kv/2.2.0/developing/api/protocol-buffers/fetch-object.md
@@ -137,14 +137,12 @@ of the following optional parameters:
 * `deleted` --- Whether the object has been deleted (i.e. whether a
   tombstone for the object has been found under the specified key)
 
-<div class="note">
-<div class="title">Note on missing keys</div>
-Remember: if a key is not stored in Riak, an <code>RpbGetResp</code>
-response without the <code>content</code> and <code>vclock</code> fields
-will be returned. This should be mapped to whatever convention the
-client language uses to return not found. The Erlang client, for
-example, returns the atom <code>{error, notfound}</code>.
-</div>
+{{% note title="Note on missing keys" %}}
+Remember: if a key is not stored in Riak, an `RpbGetResp` response without the
+`content` and `vclock` fields will be returned. This should be mapped to
+whatever convention the client language uses to return not found. The Erlang
+client, for example, returns the atom `{error, notfound}`.
+{{% /note %}}
 
 ## Example
 

--- a/content/riak/kv/2.2.0/developing/api/protocol-buffers/get-client-id.md
+++ b/content/riak/kv/2.2.0/developing/api/protocol-buffers/get-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.2.0/dev/references/protocol-buffers/get-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Get the client id used for this connection. Client ids are used for
 conflict resolution and each unique actor in the system should be

--- a/content/riak/kv/2.2.0/developing/api/protocol-buffers/list-buckets.md
+++ b/content/riak/kv/2.2.0/developing/api/protocol-buffers/list-buckets.md
@@ -17,12 +17,10 @@ aliases:
 
 List all of the bucket names available.
 
-<div class="note">
-<div class="title">Caution</div>
-
-This call can be expensive for the server. Do not use in
-performance-sensitive code.
-</div>
+{{% note title="Caution" %}}
+This call can be expensive for the server. Do not use in performance-sensitive
+code.
+{{% /note %}}
 
 
 ## Request

--- a/content/riak/kv/2.2.0/developing/api/protocol-buffers/list-keys.md
+++ b/content/riak/kv/2.2.0/developing/api/protocol-buffers/list-keys.md
@@ -18,11 +18,10 @@ aliases:
 List all of the keys in a bucket. This is a streaming call, with
 multiple response messages sent for each request.
 
-<div class="note">
-<div class="title">Not for production use</div>
-This operation requires traversing all keys stored in the cluster and
-should not be used in production.
-</div>
+{{% note title="Not for production use" %}}
+This operation requires traversing all keys stored in the cluster and should
+not be used in production.
+{{% /note %}}
 
 ## Request
 

--- a/content/riak/kv/2.2.0/developing/api/protocol-buffers/set-client-id.md
+++ b/content/riak/kv/2.2.0/developing/api/protocol-buffers/set-client-id.md
@@ -15,12 +15,11 @@ aliases:
   - /riak/kv/2.2.0/dev/references/protocol-buffers/set-client-id
 ---
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-The use of client IDs in conflict resolution is now deprecated in Riak.
-If you are building or maintaining a Riak client that is intended to be
-compatible with Riak 1.4 or later, you can safely ignore client IDs.
-</div>
+{{% note title="Deprecation notice" %}}
+The use of client IDs in conflict resolution is now deprecated in Riak. If you
+are building or maintaining a Riak client that is intended to be compatible
+with Riak 1.4 or later, you can safely ignore client IDs.
+{{% /note %}}
 
 Set the client ID for this connection. A library may want to set the
 client ID if it has a good way to uniquely identify actors across

--- a/content/riak/kv/2.2.0/developing/app-guide/replication-properties.md
+++ b/content/riak/kv/2.2.0/developing/app-guide/replication-properties.md
@@ -154,15 +154,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -330,15 +328,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -355,14 +352,12 @@ documentation on [Bitcask](/riak/kv/2.2.0/setup/planning/backend/bitcask), [Leve
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.2.0/developing/client-libraries.md
+++ b/content/riak/kv/2.2.0/developing/client-libraries.md
@@ -49,12 +49,11 @@ developing something that you wish to see added to this list, please
 fork the [Riak Docs repo on GitHub](https://github.com/basho/basho_docs)
 and send us a pull request.
 
-<div class="note">
-<div class="title">Note on community-produced libraries</div>
-All of these projects and libraries are at various stages of
-completeness and may not suit your application's needs based on their
-level of maturity and activity.
-</div>
+{{% note title="Note on community-produced libraries" %}}
+All of these projects and libraries are at various stages of completeness and
+may not suit your application's needs based on their level of maturity and
+activity.
+{{% /note %}}
 
 ### Client Libraries and Frameworks
 

--- a/content/riak/kv/2.2.0/developing/getting-started/csharp.md
+++ b/content/riak/kv/2.2.0/developing/getting-started/csharp.md
@@ -25,10 +25,12 @@ To try this flavor of Riak, a working installation of the .NET Framework or Mono
 
 Install [the Riak .NET Client](https://github.com/basho/riak-dotnet-client/wiki/Installation) through [NuGet](http://nuget.org/packages/RiakClient) or the Visual Studio NuGet package manager.
 
-<div class="note">
-<div class="title">Configuring for a remote cluster</div>
-By default, the Riak .NET Client will add a section to your `app.config` file for a four node local cluster. If you are using a remote cluster, open up `app.config` and change the `hostAddress` values to point to nodes in your remote cluster.
-</div>
+{{% note title="Configuring for a remote cluster" %}}
+By default, the Riak .NET Client will add a section to your `app.config` file
+for a four node local cluster. If you are using a remote cluster, open up
+`app.config` and change the `hostAddress` values to point to nodes in your
+remote cluster.
+{{% /note %}}
 
 ### Connecting to Riak
 

--- a/content/riak/kv/2.2.0/developing/getting-started/csharp/object-modeling.md
+++ b/content/riak/kv/2.2.0/developing/getting-started/csharp/object-modeling.md
@@ -64,12 +64,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially when many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially when many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.2.0/developing/getting-started/erlang/object-modeling.md
+++ b/content/riak/kv/2.2.0/developing/getting-started/erlang/object-modeling.md
@@ -18,14 +18,13 @@ aliases:
 
 To get started, let's create the records that we'll be using.
 
-<div class="note">
-<div class="title">Code Download</div>
+{{% note title="Code Download" %}}
 You can also download the code for this chapter at
 [Github](https://github.com/basho/taste-of-riak/tree/am-dem-erlang-modules/erlang/Ch03-Msgy-Schema).
 
-The Github version includes Erlang type specifications which have been
-omitted here for brevity.
-</div>
+The Github version includes Erlang type specifications which have been omitted
+here for brevity.
+{{% /note %}}
 
 
 ```erlang
@@ -91,13 +90,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.2.0/developing/getting-started/golang/object-modeling.md
+++ b/content/riak/kv/2.2.0/developing/getting-started/golang/object-modeling.md
@@ -182,13 +182,11 @@ users and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2 MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2 MB. Objects larger than that can
+hurt performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.2.0/developing/getting-started/java.md
+++ b/content/riak/kv/2.2.0/developing/getting-started/java.md
@@ -40,13 +40,11 @@ Next, download
 [`TasteOfRiak.java`](https://github.com/basho/basho_docs/raw/master/extras/code-examples/TasteOfRiak.java)
 source code for this tutorial, and save it to your working directory.
 
-<div class="note">
-<div class="title">Configuring for a local cluster</div>
-The `TasteOfRiak.java` file that you downloaded is set up to communicate
-with a 1-node Riak cluster listening on `localhost` port 10017. We
-recommend modifying the connection info directly within the
-`setUpCluster()` method.
-</div>
+{{% note title="Configuring for a local cluster" %}}
+The `TasteOfRiak.java` file that you downloaded is set up to communicate with
+a 1-node Riak cluster listening on `localhost` port 10017. We recommend
+modifying the connection info directly within the `setUpCluster()` method.
+{{% /note %}}
 
 If you execute the `TasteOfRiak.java` file within your IDE, you should
 see the following:

--- a/content/riak/kv/2.2.0/developing/getting-started/java/object-modeling.md
+++ b/content/riak/kv/2.2.0/developing/getting-started/java/object-modeling.md
@@ -157,12 +157,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.2.0/developing/getting-started/nodejs/object-modeling.md
+++ b/content/riak/kv/2.2.0/developing/getting-started/nodejs/object-modeling.md
@@ -73,12 +73,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_SENT_2014-03-06` or `marketing_group_INBOX_2014-03-05`,
 respectively.
 
-<div class="note"><div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.2.0/developing/getting-started/python/object-modeling.md
+++ b/content/riak/kv/2.2.0/developing/getting-started/python/object-modeling.md
@@ -83,13 +83,11 @@ users, and `<groupname>_<type>_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06` or `marketing_group_Inbox_2014-03-06`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially if many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially if many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.2.0/developing/getting-started/ruby/object-modeling.md
+++ b/content/riak/kv/2.2.0/developing/getting-started/ruby/object-modeling.md
@@ -94,13 +94,11 @@ users, and `<groupname>_Inbox_<date>` for groups, which will look like
 `joeuser_Sent_2014-03-06Z` or `marketing_group_Inbox_2014-03-05Z`,
 respectively.
 
-<div class="note">
-<div class="title">Note</div>
-Riak performs best with objects under 1-2MB. Objects larger than that
-can hurt performance, especially many siblings are being created. We
-will cover siblings, sibling resolution, and sibling explosions in the
-next chapter.
-</div>
+{{% note title="Note" %}}
+Riak performs best with objects under 1-2MB. Objects larger than that can hurt
+performance, especially many siblings are being created. We will cover
+siblings, sibling resolution, and sibling explosions in the next chapter.
+{{% /note %}}
 
 #### Keeping our story straight with repositories
 

--- a/content/riak/kv/2.2.0/developing/usage/conflict-resolution.md
+++ b/content/riak/kv/2.2.0/developing/usage/conflict-resolution.md
@@ -25,16 +25,15 @@ If you are using Riak in an [eventually consistent](/riak/kv/2.2.0/learn/concept
 unavoidable. Often, Riak can resolve these conflicts on its own
 internally if you use causal context, i.e. [vector clocks](/riak/kv/2.2.0/learn/concepts/causal-context#vector-clocks) or [dotted version vectors](/riak/kv/2.2.0/learn/concepts/causal-context#dotted-version-vectors), when updating objects. Instructions on this can be found in the section [below](#siblings).
 
-<div class="note">
-<div class="title">Important note on terminology</div>
-In versions of Riak prior to 2.0, vector clocks were the only causal
-context mechanism available in Riak, which changed with the introduction
-of dotted version vectors in 2.0. Please note that you may frequent find
-terminology in client library APIs, internal Basho documentation, and
-more that uses the term "vector clock" interchangeably with causal
-context in general. Riak's HTTP API still uses a `X-Riak-Vclock` header,
-for example, even if you are using dotted version vectors.
-</div>
+{{% note title="Important note on terminology" %}}
+In versions of Riak prior to 2.0, vector clocks were the only causal context
+mechanism available in Riak, which changed with the introduction of dotted
+version vectors in 2.0. Please note that you may frequent find terminology in
+client library APIs, internal Basho documentation, and more that uses the term
+"vector clock" interchangeably with causal context in general. Riak's HTTP API
+still uses a `X-Riak-Vclock` header, for example, even if you are using dotted
+version vectors.
+{{% /note %}}
 
 But even when you use causal context, Riak cannot always decide which
 value is most causally recent, especially in cases involving concurrent
@@ -118,12 +117,10 @@ will be no concurrent updates. If you are storing immutable data in
 which each object is guaranteed to have its own key or engaging in
 operations related to bulk loading, you should consider LWW.
 
-<div class="note">
-<div class="title">Undefined behavior warning</div>
-Setting both <code>allow_mult</code> and <code>last_write_wins</code> to
-<code>true</code> necessarily leads to unpredictable behavior and should
-always be avoided.
-</div>
+{{% note title="Undefined behavior warning" %}}
+Setting both `allow_mult` and `last_write_wins` to `true` necessarily leads to
+unpredictable behavior and should always be avoided.
+{{% /note %}}
 
 ### Resolve Conflicts on the Application Side
 
@@ -601,13 +598,12 @@ X-Riak-Vclock: a85hYGBgzGDKBVIcR4M2cgczH7HPYEpkzGNlsP/VfYYvCwA=
 # accompany the write for Riak to be able to use the vector clock
 ```
 
-<div class="note">
-<div class="title">Concurrent conflict resolution</div>
+{{% note title="Concurrent conflict resolution" %}}
 It should be noted that it is possible to have two clients that are
 simultaneously engaging in conflict resolution. To avoid a pathological
-divergence, you should be sure to limit the number of reconciliations
-and fail once that limit has been exceeded.
-</div>
+divergence, you should be sure to limit the number of reconciliations and fail
+once that limit has been exceeded.
+{{% /note %}}
 
 ### Sibling Explosion
 
@@ -649,13 +645,10 @@ better performance. Some use cases where you might want to use
 `last_write_wins` include caching, session storage, and insert-only
 (no updates).
 
-<div class="note">
-<div class="title">Note on combining <code>allow_mult</code> and
-<code>last_write_wins</code></div>
-The combination of setting both the <code>allow_mult</code> and
-<code>last_write_wins</code> properties to <code>true</code> leads to
-undefined behavior and should not be used.
-</div>
+{{% note title="Note on combining `allow_mult` and `last_write_wins`" %}}
+The combination of setting both the `allow_mult` and `last_write_wins`
+properties to `true` leads to undefined behavior and should not be used.
+{{% /note %}}
 
 ## Vector Clock Pruning
 

--- a/content/riak/kv/2.2.0/developing/usage/reading-objects.md
+++ b/content/riak/kv/2.2.0/developing/usage/reading-objects.md
@@ -197,12 +197,10 @@ The most common error code:
 
 * `404 Not Found`
 
-<div class="note">
-<div class="title">Note</div>
-If you're using a Riak client instead of HTTP, these responses will vary
-a great deal, so make sure to check the documentation for your specific
-client.
-</div>
+{{% note title="Note" %}}
+If you're using a Riak client instead of HTTP, these responses will vary a
+great deal, so make sure to check the documentation for your specific client.
+{{% /note %}}
 
 ## Not Found
 

--- a/content/riak/kv/2.2.0/developing/usage/replication.md
+++ b/content/riak/kv/2.2.0/developing/usage/replication.md
@@ -45,18 +45,17 @@ is one of the features that differentiates Riak from other databases.
 At the bottom of the page, you'll find a [screencast](/riak/kv/2.2.0/developing/app-guide/replication-properties#screencast) that briefly explains how to adjust your
 replication levels to match your application and business needs.
 
-<div class="note">
-<div class="title">Note on strong consistency</div>
+{{% note title="Note on strong consistency" %}}
 An option introduced in Riak version 2.0 is to use Riak as a
-<a href="http://docs.basho.com/riak/kv/2.2.0/using/reference/strong-consistency/">strongly consistent</a>
-system for data in specified buckets. Using Riak in this way is
-fundamentally different from adjusting replication properties and
-fine-tuning the availability/consistency trade-off, as it sacrifices
-<em>all</em> availability guarantees when necessary. Therefore, you
-should consult the <a href="http://docs.basho.com/riak/kv/2.2.0/developing/app-guide/strong-consistency/">Using
-Strong Consistency</a> documentation, as this option will not be covered
-in this tutorial.
-</div>
+<a href="http://docs.basho.com/riak/kv/2.2.0/using/reference/strong-consistency/">strongly
+consistent</a> system for data in specified buckets. Using Riak in this way is
+fundamentally different from adjusting replication properties and fine-tuning
+the availability/consistency trade-off, as it sacrifices _all_ availability
+guarantees when necessary. Therefore, you should consult the
+<a href="http://docs.basho.com/riak/kv/2.2.0/developing/app-guide/strong-consistency/">Using
+Strong Consistency</a> documentation, as this option will not be covered in
+this tutorial.
+{{% /note %}}
 
 ## How Replication Properties Work
 
@@ -163,15 +162,13 @@ curl -XPUT http://localhost:8098/types/n_val_equals_2/buckets/test_bucket/keys/t
 Now, whenever we write to a bucket of this type, Riak will write a
 replica of the object to two different nodes.
 
-<div class="note">
-<div class="title">A Word on Setting the N Value</div>
-<code>n_val</code> must be greater than 0 and less than or equal to the
-number of actual nodes in your cluster to get all the benefits of
-replication. We advise against modifying the <code>n_val</code> of a
-bucket after its initial creation as this may result in failed reads
-because the new value may not be replicated to all the appropriate
-partitions.
-</div>
+{{% note title="A Word on Setting the N Value" %}}
+`n_val` must be greater than 0 and less than or equal to the number of actual
+nodes in your cluster to get all the benefits of replication. We advise
+against modifying the `n_val` of a bucket after its initial creation as this
+may result in failed reads because the new value may not be replicated to all
+the appropriate partitions.
+{{% /note %}}
 
 ## R Value and Read Failure Tolerance
 
@@ -339,15 +336,14 @@ more likely to receive the most up-to-date values, but at the cost of a
 higher probability that reads or writes will fail because primary vnodes
 are unavailable.
 
-<div class="note">
-<div class="title">Note on PW</div>
-If PW is set to a non-zero value, there is a higher risk (usually very
-small) that failure will be reported to the client upon write. But this
-does not necessarily mean that the write has failed completely. If there
-are reachable primary vnodes, those vnodes will still write the new data
-to Riak. When the failed vnode returns to service, it will receive the
-new copy of the data via either read repair or active anti-entropy.
-</div>
+{{% note title="Note on PW" %}}
+If PW is set to a non-zero value, there is a higher risk (usually very small)
+that failure will be reported to the client upon write. But this does not
+necessarily mean that the write has failed completely. If there are reachable
+primary vnodes, those vnodes will still write the new data to Riak. When the
+failed vnode returns to service, it will receive the new copy of the data via
+either read repair or active anti-entropy.
+{{% /note %}}
 
 ## Durable Writes with DW
 
@@ -364,14 +360,12 @@ documentation on [Bitcask][plan backend bitcask], [LevelDB][plan backend leveldb
 
 ## Delete Quorum with RW
 
-<div class="note">
-<div class="title">Deprecation notice</div>
-It is no longer necessary to specify an RW value when making delete
-requests. We explain its meaning here, however, because RW still shows
-up as a property of Riak buckets (as <code>rw</code>) for the sake of
-backwards compatibility. Feel free to skip this explanation unless you
-are curious about the meaning of RW.
-</div>
+{{% note title="Deprecation notice" %}}
+It is no longer necessary to specify an RW value when making delete requests.
+We explain its meaning here, however, because RW still shows up as a property
+of Riak buckets (as `rw`) for the sake of backwards compatibility. Feel free
+to skip this explanation unless you are curious about the meaning of RW.
+{{% /note %}}
 
 Deleting an object requires successfully reading an object and then
 writing a tombstone to the object's key that specifies that an object

--- a/content/riak/kv/2.2.0/developing/usage/security/erlang.md
+++ b/content/riak/kv/2.2.0/developing/usage/security/erlang.md
@@ -24,13 +24,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.2.0/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Erlang Client Basics
 

--- a/content/riak/kv/2.2.0/developing/usage/security/java.md
+++ b/content/riak/kv/2.2.0/developing/usage/security/java.md
@@ -23,13 +23,11 @@ If you are using [trust-](/riak/kv/2.2.0/using/security/managing-sources/#trust-
 security setup described [below](#java-client-basics). [Certificate](/riak/kv/2.2.0/using/security/managing-sources/#certificate-based-authentication)-based authentication is not
 yet supported in the Java client.
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Java Client Basics
 

--- a/content/riak/kv/2.2.0/developing/usage/security/python.md
+++ b/content/riak/kv/2.2.0/developing/usage/security/python.md
@@ -25,13 +25,11 @@ in a [later section](#password-based-authentication). If you are using
 [certificate](/riak/kv/2.2.0/using/security/managing-sources/#certificate-based-authentication)-based authentication, follow
 the instructions in the [section below](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## OpenSSL Versions
 

--- a/content/riak/kv/2.2.0/developing/usage/security/ruby.md
+++ b/content/riak/kv/2.2.0/developing/usage/security/ruby.md
@@ -25,13 +25,11 @@ can use the security setup described in the [Ruby Client Basics](#ruby-client-ba
 in a [later section](#password-based-authentication), while [certificate](/riak/kv/2.2.0/using/security/managing-sources/#certificate-based-authentication)-based authentication
 is covered [further down](#certificate-based-authentication).
 
-<div class="note">
-<div class="title">Note on certificate generation</div>
+{{% note title="Note on certificate generation" %}}
 This tutorial does not cover certificate generation. It assumes that all
-necessary certificates have already been created and are stored in a
-directory called `/ssl_dir`. This directory name is used only for
-example purposes.
-</div>
+necessary certificates have already been created and are stored in a directory
+called `/ssl_dir`. This directory name is used only for example purposes.
+{{% /note %}}
 
 ## Ruby Client Basics
 

--- a/content/riak/kv/2.2.0/learn/concepts/strong-consistency.md
+++ b/content/riak/kv/2.2.0/learn/concepts/strong-consistency.md
@@ -18,10 +18,14 @@ aliases:
 [usage bucket types]: /riak/kv/2.2.0/developing/usage/bucket-types
 [concept eventual consistency]: /riak/kv/2.2.0/learn/concepts/eventual-consistency
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 Riak was originally designed as an [eventually consistent](/riak/kv/2.2.0/learn/concepts/eventual-consistency) system, fundamentally geared toward providing partition
 (i.e. fault) tolerance and high read and write availability.

--- a/content/riak/kv/2.2.0/setup/installing/amazon-web-services.md
+++ b/content/riak/kv/2.2.0/setup/installing/amazon-web-services.md
@@ -62,10 +62,10 @@ You will need need to launch at least 3 instances to form a Riak cluster.  When 
 
 You can find more information on connecting to an instance on the official [Amazon EC2 instance guide](http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/AccessingInstances.html).
 
-<div class="note">
-<div class="title">Note</div>
-The following clustering setup will <em>not</em> be resilient to instance restarts unless deployed in Amazon VPC.
-</div>
+{{% note title="Note" %}}
+The following clustering setup will _not_ be resilient to instance restarts
+unless deployed in Amazon VPC.
+{{% /note %}}
 
 1. On the first node, obtain the internal IP address:
 

--- a/content/riak/kv/2.2.0/setup/installing/mac-osx.md
+++ b/content/riak/kv/2.2.0/setup/installing/mac-osx.md
@@ -52,13 +52,12 @@ directory and execute `bin/riak start` to start the Riak node.
 
 ## Homebrew
 
-<div class="note">
-<div class="title">Warning: Homebrew not always up to date</div>
-Homebrew's Riak recipe is community supported, and thus is not always up
-to date with the latest Riak package. Please ensure that the current
-recipe is using the latest supported code (and don't be afraid to update
-it if it's not).
-</div>
+{{% note title="Warning: Homebrew not always up to date" %}}
+Homebrew's Riak recipe is community supported, and thus is not always up to
+date with the latest Riak package. Please ensure that the current recipe is
+using the latest supported code (and don't be afraid to update it if it's
+not).
+{{% /note %}}
 
 Installing Riak 2.0 with [Homebrew](http://brew.sh/) is easy:
 
@@ -92,11 +91,10 @@ the Riak installation directory via environment variables.
 You must have Xcode tools installed from [Apple's Developer
 website](http://developer.apple.com/).
 
-<div class="note">
-<div class="title">Note on Clang</div>
-Riak will not compile with Clang. Please make sure that your default
-C/C++ compiler is [GCC](https://gcc.gnu.org/).
-</div>
+{{% note title="Note on Clang" %}}
+Riak will not compile with Clang. Please make sure that your default C/C++
+compiler is [GCC](https://gcc.gnu.org/).
+{{% /note %}}
 
 Riak requires [Erlang](http://www.erlang.org/) R16B02+.
 

--- a/content/riak/kv/2.2.0/using/admin/riak-admin.md
+++ b/content/riak/kv/2.2.0/using/admin/riak-admin.md
@@ -184,11 +184,10 @@ rename the nodes of a cluster. For more information, visit the
 riak-admin reip <old nodename> <new nodename>
 ```
 
-<div class="note">
-<div class="title">Note about reip prior to Riak 2.0</title></div>
-Several bugs have been fixed related to reip in Riak 2.0. We recommend
-against using reip prior to 2.0, if possible.
-</div>
+{{% note title="Note about reip prior to Riak 2.0" %}}
+Several bugs have been fixed related to reip in Riak 2.0. We recommend against
+using reip prior to 2.0, if possible.
+{{% /note %}}
 
 
 ## js-reload
@@ -384,12 +383,10 @@ entropy tree building, and key repairs which were triggered by AAE.
  * The *Max* column shows the maximum number of keys repaired during all
    key exchanges since the last node restart.
 
-<div class="note">
-<div class="title">Note in AAE status information</div>
-All AAE status information is in-memory and is reset across a node
-restart. Only tree build times are persistent (since trees themselves
-are persistent)
-</div>
+{{% note title="Note in AAE status information" %}}
+All AAE status information is in-memory and is reset across a node restart.
+Only tree build times are persistent (since trees themselves are persistent)
+{{% /note %}}
 
 More details on the `aae-status` command are available in the [Riak
 version 1.3 release notes](https://github.com/basho/riak/blob/1.3/RELEASE-NOTES.md#active-anti-entropy).
@@ -623,11 +620,10 @@ repaired for a given exchange round since the node has started.
 
 ### switch-to-new-search
 
-<div class="info">
-<div class="title">Only For Legacy Migration</div>
-This is only needed when migrating from legacy riak search to the new
-Search (Yokozuna).
-</div>
+{{% note title="Only For Legacy Migration" %}}
+This is only needed when migrating from legacy riak search to the new Search
+(Yokozuna).
+{{% /note %}}
 
 ```bash
 riak-admin search switch-to-new-search

--- a/content/riak/kv/2.2.0/using/admin/riak-control.md
+++ b/content/riak/kv/2.2.0/using/admin/riak-control.md
@@ -57,12 +57,11 @@ listener.https.<name> = 127.0.0.1:8096
 %%     the `riak_api` tuple's value list.
 ```
 
-<div class="note">
-<div class="title">Note on SSL</div>
-We strongly recommend that you enable SSL for Riak Control. It is
-disabled by default, and if you wish to enable it you must do so
-explicitly. More information can be found in the document below.
-</div>
+{{% note title="Note on SSL" %}}
+We strongly recommend that you enable SSL for Riak Control. It is disabled by
+default, and if you wish to enable it you must do so explicitly. More
+information can be found in the document below.
+{{% /note %}}
 
 ## Enabling and Disabling Riak Control
 
@@ -168,16 +167,15 @@ be because you are using self-signed certificates. If you have
 authentication enabled in your configuration, you will next be asked to
 authenticate. Enter an appropriate username and password now.
 
-<div class="note">
-<div class="title">Note on browser TLS</div>
-Your browser needs to be support TLS v1.2 to use Riak Control over
-HTTPS. A list of browsers that support TLS v1.2 can be found
+{{% note title="Note on browser TLS" %}}
+Your browser needs to be support TLS v1.2 to use Riak Control over HTTPS. A
+list of browsers that support TLS v1.2 can be found
 [here](https://en.wikipedia.org/wiki/Transport_Layer_Security#Web_browsers).
-TLS v1.2 may be disabled by default on your browser, for example if you
-are using Firefox versions earlier than 27, Safari versions earlier than
-7, Chrome versions earlier than 30, or Internet Explorer versions
-earlier than 11.  To enable it, follow browser-specific instructions.
-</div>
+TLS v1.2 may be disabled by default on your browser, for example if you are
+using Firefox versions earlier than 27, Safari versions earlier than 7, Chrome
+versions earlier than 30, or Internet Explorer versions earlier than 11.  To
+enable it, follow browser-specific instructions.
+{{% /note %}}
 
 ### Snapshot View
 

--- a/content/riak/kv/2.2.0/using/cluster-operations/adding-removing-nodes.md
+++ b/content/riak/kv/2.2.0/using/cluster-operations/adding-removing-nodes.md
@@ -136,15 +136,14 @@ Transfers resulting from cluster changes: 51
 If the plan is to your liking, submit the changes by running `riak-admin
 cluster commit`.
 
-<div class="note">
-<div class="title">Note on ring changes</div>
-The algorithm that distributes partitions across the cluster
-during membership changes is non-deterministic. As a result, there is no
-optimal ring. In the event that a plan results in a slightly uneven
-distribution of partitions, the plan can be cleared. Clearing a cluster
-plan with `riak-admin cluster clear` and running `riak-admin cluster
-plan` again will produce a slightly different ring.
-</div>
+{{% note title="Note on ring changes" %}}
+The algorithm that distributes partitions across the cluster during membership
+changes is non-deterministic. As a result, there is no optimal ring. In the
+event that a plan results in a slightly uneven distribution of partitions, the
+plan can be cleared. Clearing a cluster plan with `riak-admin cluster clear`
+and running `riak-admin cluster plan` again will produce a slightly different
+ring.
+{{% /note %}}
 
 ## Removing a Node From a Cluster
 

--- a/content/riak/kv/2.2.0/using/cluster-operations/bucket-types.md
+++ b/content/riak/kv/2.2.0/using/cluster-operations/bucket-types.md
@@ -16,14 +16,13 @@ Buckets are essentially a flat namespace in Riak. They allow the same
 key name to exist in multiple buckets and enable you to apply
 configurations across keys.
 
-<div class="info">
-<div class="title">How Many Buckets Can I Have?</div>
-Buckets come with virtually no cost <em>except for when you modify the
-default bucket properties</em>. Modified bucket properties are gossiped
-around the cluster and therefore add to the amount of data sent around
-the network. In other words, buckets using the <tt>default</tt> bucket
-type are free. More on that in the next section.
-</div>
+{{% note title="How Many Buckets Can I Have?" %}}
+Buckets come with virtually no cost _except for when you modify the default
+bucket properties_. Modified bucket properties are gossiped around the cluster
+and therefore add to the amount of data sent around the network. In other
+words, buckets using the `default` bucket type are free. More on that in the
+next section.
+{{% /note %}}
 
 In Riak versions 2.0 and later, Basho suggests that you [use bucket types](/riak/kv/2.2.0/developing/usage/bucket-types) to namespace and configure all buckets you use. Bucket types have a lower overhead within the cluster than the
 default bucket namespace but require an additional setup step on the

--- a/content/riak/kv/2.2.0/using/cluster-operations/changing-cluster-info.md
+++ b/content/riak/kv/2.2.0/using/cluster-operations/changing-cluster-info.md
@@ -302,9 +302,12 @@ Reconfigure `node1.localdomain` to listen on the new private IP address *192.168
 
 11. Clean up by deleting the renamed `ring` directory once all previous steps have been successfully completed.
 
-<div class="note"><div class="title">Note</div>
-When using the `riak-admin force-replace` command, you will always get a warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be lost`. Since we didn't delete any data files and we are replacing the node with itself under a new name, we will not lose any replicas.
-</div>
+{{% note title="Note" %}}
+When using the `riak-admin force-replace` command, you will always get a
+warning message like: `WARNING: All of 'riak@10.1.42.11' replicas will be
+lost`. Since we didn't delete any data files and we are replacing the node
+with itself under a new name, we will not lose any replicas.
+{{% /note %}}
 
 <a id="repeat"></a>
 #### Repeat previous steps on each node

--- a/content/riak/kv/2.2.0/using/cluster-operations/replacing-node.md
+++ b/content/riak/kv/2.2.0/using/cluster-operations/replacing-node.md
@@ -86,12 +86,10 @@ with the [`riak-admin ringready`](/riak/kv/2.2.0/using/admin/riak-admin/#ringrea
 and [`riak-admin member-status`](/riak/kv/2.2.0/using/admin/riak-admin/#member-status)
 commands.
 
-<div class="info">
-<div class="title">Ring Settling</div>
-You'll need to make sure that no other ring changes occur between the
-time when you start the new node and the ring settles with the new IP
-info.
+{{% note title="Ring Settling" %}}
+You'll need to make sure that no other ring changes occur between the time
+when you start the new node and the ring settles with the new IP info.
 
-The ring is considered settled when the new node reports `true` when you
-run the `riak-admin ringready` command.
-</div>
+The ring is considered settled when the new node reports `true` when you run
+the `riak-admin ringready` command.
+{{% /note %}}

--- a/content/riak/kv/2.2.0/using/cluster-operations/strong-consistency.md
+++ b/content/riak/kv/2.2.0/using/cluster-operations/strong-consistency.md
@@ -12,10 +12,14 @@ menu:
 toc: true
 ---
 
-<div class="note">
-<div class="title">Please Note:</div>
-Riak KV's strong consistency is an experimental feature and may be removed from the product in the future. Strong consistency is not commercially supported or production-ready. Strong consistency is incompatible with Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its usage in any production environment.
-</div>
+{{% note title="Please Note:" %}}
+Riak KV's strong consistency is an experimental feature and may be removed
+from the product in the future. Strong consistency is not commercially
+supported or production-ready. Strong consistency is incompatible with
+Multi-Datacenter Replication, Riak Search, Bitcask Expiration, LevelDB
+Secondary Indexes, Riak Data Types and Commit Hooks. We do not recommend its
+usage in any production environment.
+{{% /note %}}
 
 ## Monitoring Strong Consistency
 

--- a/content/riak/kv/2.2.0/using/performance.md
+++ b/content/riak/kv/2.2.0/using/performance.md
@@ -26,13 +26,12 @@ changes.
 For performance and tuning recommendations specific to running Riak
 clusters on the Amazon Web Services EC2 environment, see [AWS Performance Tuning](/riak/kv/2.2.0/using/performance/amazon-web-services).
 
-<div class="note">
-<div class="title">Note on other operating systems</div>
+{{% note title="Note on other operating systems" %}}
 Unless otherwise specified, the tunings recommended below are for Linux
-distributions. Users implementing Riak on BSD and Solaris distributions
-can use these tuning recommendations to make analogous changes in those
-operating systems.
-</div>
+distributions. Users implementing Riak on BSD and Solaris distributions can
+use these tuning recommendations to make analogous changes in those operating
+systems.
+{{% /note %}}
 
 ## Storage and File System Tuning
 
@@ -187,12 +186,11 @@ net.ipv4.tcp_tw_reuse = 1
 net.ipv4.tcp_moderate_rcvbuf = 1
 ```
 
-<div class="note">
-<div class="title">Note on system default</div>
+{{% note title="Note on system default" %}}
 In general, these recommended values should be compared with the system
-defaults and only changed if benchmarks or other performance metrics
-indicate that networking is the bottleneck.
-</div>
+defaults and only changed if benchmarks or other performance metrics indicate
+that networking is the bottleneck.
+{{% /note %}}
 
 The following settings are optional, but may improve performance on a
 10Gb network:
@@ -227,11 +225,10 @@ ethtool -K eth0 tso off
 `ethtool` settings can be persisted across reboots by adding the above
 command to the `/etc/rc.local` script.
 
-<div class="info">
-<div class="title">Pro tip</div>
-Tuning these values will be required if they are changed, as they affect
-all network operations.
-</div>
+{{% note title="Pro tip" %}}
+Tuning these values will be required if they are changed, as they affect all
+network operations.
+{{% /note %}}
 
 ## Optional I/O Settings
 

--- a/content/riak/kv/2.2.0/using/performance/amazon-web-services.md
+++ b/content/riak/kv/2.2.0/using/performance/amazon-web-services.md
@@ -54,14 +54,13 @@ indexes are not needed for the application.
 In any case, proper benchmarking and tuning are needed to achieve the
 desired performance.
 
-<div class="info">
-<div class="title">Tip</div>
-Most successful AWS cluster deployments use more EC2 instances than they
-would the same number of physical nodes to compensate for the
-performance variability caused by shared, virtualized resources. Plan to
-have more EC2 instance based nodes than physical server nodes when
-estimating cluster size with respect to node count.
-</div>
+{{% note title="Tip" %}}
+Most successful AWS cluster deployments use more EC2 instances than they would
+the same number of physical nodes to compensate for the performance
+variability caused by shared, virtualized resources. Plan to have more EC2
+instance based nodes than physical server nodes when estimating cluster size
+with respect to node count.
+{{% /note %}}
 
 ## Operating System
 

--- a/content/riak/kv/2.2.0/using/performance/erlang.md
+++ b/content/riak/kv/2.2.0/using/performance/erlang.md
@@ -44,16 +44,15 @@ Erlang parameter | Riak parameter
 [`-env ERL_MAX_ETS_TABLES`](http://learnyousomeerlang.com/ets) | `erlang.max_ets_tables`
 `-name` | `nodename`
 
-<div class="note">
-<div class="title">Note on upgrading to 2.0</div>
-In versions of Riak prior to 2.0, Erlang VM-related parameters were
-specified in a `vm.args` configuration file; in versions 2.0 and later,
-all Erlang-VM-specific parameters are set in the `riak.conf` file. If
-you're upgrading to 2.0 from an earlier version, you can still use your
-old `vm.args` if you wish.  Please note, however, that if you set one or
-more parameters in both `vm.args` and in `riak.conf`, the settings in
-`vm.args` will override those in `riak.conf`.
-</div>
+{{% note title="Note on upgrading to 2.0" %}}
+In versions of Riak prior to 2.0, Erlang VM-related parameters were specified
+in a `vm.args` configuration file; in versions 2.0 and later, all
+Erlang-VM-specific parameters are set in the `riak.conf` file. If you're
+upgrading to 2.0 from an earlier version, you can still use your old `vm.args`
+if you wish.  Please note, however, that if you set one or more parameters in
+both `vm.args` and in `riak.conf`, the settings in `vm.args` will override
+those in `riak.conf`.
+{{% /note %}}
 
 ## SMP
 

--- a/content/riak/kv/2.2.0/using/reference/bucket-types.md
+++ b/content/riak/kv/2.2.0/using/reference/bucket-types.md
@@ -16,14 +16,12 @@ Bucket types allow groups of buckets to share configuration details and
 for Riak users to manage bucket properties more efficiently than in the
 older configuration system based on [bucket properties](/riak/kv/2.2.0/developing/usage/bucket-types/#bucket-properties-and-operations).
 
-<div class="note">
-<div class="title">Important note on cluster downgrades</div>
-If you upgrade a Riak to version 2.0 or later, you can still downgrade
-the cluster to a pre-2.0 version <em>as long as you have not created and
-activated a bucket type in the cluster</em>. Once any bucket type has
-been created and activated, you can no longer downgrade the cluster to a
-pre-2.0 version.
-</div>
+{{% note title="Important note on cluster downgrades" %}}
+If you upgrade a Riak to version 2.0 or later, you can still downgrade the
+cluster to a pre-2.0 version _as long as you have not created and activated a
+bucket type in the cluster_. Once any bucket type has been created and
+activated, you can no longer downgrade the cluster to a pre-2.0 version.
+{{% /note %}}
 
 ## How Bucket Types Work
 
@@ -129,11 +127,11 @@ If creation is successful, you should see the following output:
 type_using_defaults created
 ```
 
-<div class="note">
+{{% note %}}
 The `create` command can be run multiple times prior to a bucket type being
 activated. Riak will persist only those properties contained in the final call
 of the command.
-</div>
+{{% /note %}}
 
 Creating bucket types that assign properties _always_ involves passing
 stringified JSON to the `create` command. One way to do that is to pass
@@ -243,11 +241,22 @@ of the type:
 riak-admin bucket-type update type_to_update '{"props":{ ... }}'
 ```
 
-> **Note**
->
-> Any bucket properties associated with a type can be modified after a bucket is created, with two important exceptions: `consistent` and `datatype`. If a bucket type entails strong consistency (requiring that `consistent` be set to `true`) or is set up as a `map`, `set`, or `counter`, then this will be true of the bucket type once and for all.
->
-> If you need to change one of these properties, it is recommended that you simply create and activate a new bucket type.
+{{% note title="Immutable Configurations" %}}
+Any bucket properties associated with a type can be modified after a bucket is
+created, with three important exceptions:
+
+* `consistent`
+* `datatype`
+* `write_once`
+
+If a bucket type entails strong consistency (requiring that `consistent` be
+set to `true`), is set up as a `map`, `set`, or `counter`, or is defined as a
+write-once  bucket (requiring `write_once` be set to `true`), then this will
+be true of the bucket types.
+
+If you need to change one of these properties, we recommend that you simply
+create and activate a new bucket type.
+{{% /note %}}
 
 ## Buckets as Namespaces
 
@@ -375,12 +384,11 @@ curl http://localhost:8098/types/type1/buckets/my_bucket/keys/my_key
 curl http://localhost:8098/types/type2/buckets/my_bucket/keys/my_key
 ```
 
-<div class="note">
-<div class="title">Note on object location</div>
-In Riak 2.x, <em>all requests</em> must be made to a location specified
-by a bucket type, bucket, and key rather than to a bucket/key pair, as
-in previous versions.
-</div>
+{{% note title="Note on object location" %}}
+In Riak 2.x, _all requests_ must be made to a location specified by a bucket
+type, bucket, and key rather than to a bucket/key pair, as in previous
+versions.
+{{% /note %}}
 
 If requests are made to a bucket/key pair without a specified bucket
 type, `default` will be used in place of a bucket type. The following

--- a/content/riak/kv/2.2.0/using/reference/custom-code.md
+++ b/content/riak/kv/2.2.0/using/reference/custom-code.md
@@ -31,13 +31,13 @@ name must have the same name the module. So if you are given a file named
 If you have been given Erlang code and are expected to compile it for
 your developers, keep the following notes in mind.
 
-<div class="info"><div class="title">Note on the Erlang Compiler</div> You
-must use the Erlang compiler (<tt>erlc</tt>) associated with the Riak
+{{% note title="Note on the Erlang Compiler" %}}
+You must use the Erlang compiler (`erlc`) associated with the Riak
 installation or the version of Erlang used when compiling Riak from source.
-For packaged Riak installations, you can consult Table 1 below for the
-default location of Riak's <tt>erlc</tt> for each supported platform.
-If you compiled from source, use the <tt>erlc</tt> from the Erlang version
-you used to compile Riak.</div>
+For packaged Riak installations, you can consult Table 1 below for the default
+location of Riak's `erlc` for each supported platform. If you compiled from
+source, use the `erlc` from the Erlang version you used to compile Riak.
+{{% /note %}}
 
 <table style="width: 100%; border-spacing: 0px;">
 <tbody>
@@ -88,8 +88,9 @@ and loaded. For our example, we'll use a temporary directory `/tmp/beams`,
 but you should choose a directory for production functions based on your
 own requirements such that they will be available where and when needed.
 
-<div class="info">Ensure that the directory chosen above can be read by
-the <tt>riak</tt> user.</div>
+{{% note %}}
+Ensure that the directory chosen above can be read by the `riak` user.
+{{% /note %}}
 
 Successful compilation will result in a new `.beam` file,
 `validate_json.beam`.
@@ -124,5 +125,7 @@ value store has fully initialized and become available for use.
 This is done with the `riak-admin wait-for-service` command as detailed
 in the [Commands documentation](/riak/kv/2.2.0/using/admin/riak-admin/#wait-for-service).
 
-<div class="note">It is important that you ensure riak_kv is
-active before restarting the next node.</div>
+{{% note %}}
+It is important that you ensure riak_kv is active before restarting the next
+node.
+{{% /note %}}

--- a/content/riak/kv/2.2.0/using/reference/multi-datacenter/comparison.md
+++ b/content/riak/kv/2.2.0/using/reference/multi-datacenter/comparison.md
@@ -18,13 +18,12 @@ aliases:
 This document is a systematic comparison of [Version 2](/riak/kv/2.2.0/using/reference/v2-multi-datacenter) and [Version 3](/riak/kv/2.2.0/using/reference/v3-multi-datacenter) of Riak Enterprise's Multi-Datacenter
 Replication capabilities.
 
-<div class="note">
-<div class="title">Important note on mixing versions</div>
+{{% note title="Important note on mixing versions" %}}
 If you are installing Riak Enterprise anew, you should use version 3
-replication. Under no circumstances should you mix version 2 and version
-3 replication. This comparison is meant only to list improvements
-introduced in version 3.
-</div>
+replication. Under no circumstances should you mix version 2 and version 3
+replication. This comparison is meant only to list improvements introduced in
+version 3.
+{{% /note %}}
 
 ## Version 2
 

--- a/content/riak/kv/2.2.0/using/reference/multi-datacenter/monitoring.md
+++ b/content/riak/kv/2.2.0/using/reference/multi-datacenter/monitoring.md
@@ -34,14 +34,12 @@ replication:
 * Use canary (test) objects to test replication and establish trip times
   from source to sink clusters
 
-<div class="note">
-<div class="title">Note on querying and time windows</div>
-Riak's statistics are calculated over a sliding 60-second window. Each
-time you query the stats interface, each sliding statistic shown is a
-sum or histogram value calculated from the previous 60 seconds of data.
-Because of this, the stats interface should not be queried more than
-once per minute.
-</div>
+{{% note title="Note on querying and time windows" %}}
+Riak's statistics are calculated over a sliding 60-second window. Each time
+you query the stats interface, each sliding statistic shown is a sum or
+histogram value calculated from the previous 60 seconds of data. Because of
+this, the stats interface should not be queried more than once per minute.
+{{% /note %}}
 
 ## Statistics
 

--- a/content/riak/kv/2.2.0/using/reference/statistics-monitoring.md
+++ b/content/riak/kv/2.2.0/using/reference/statistics-monitoring.md
@@ -92,15 +92,13 @@ As with the throughput metrics, keeping an eye on average (and max)
 latency times will help detect usage patterns, and provide advanced
 warnings for potential problems.
 
-<div class="note">
-<div class="title">Note on FSM Time Stats</div>
-FSM Time Stats represent the amount of time in microseconds required
-to traverse the GET or PUT Finite State Machine code, offering a
-picture of general node health. From your application's perspective,
-FSM Time effectively represents experienced latency. Mean, Median, and
-95th-, 99th-, and 100th-percentile (Max) counters are displayed. These
-are one-minute stats.
-</div>
+{{% note title="Note on FSM Time Stats" %}}
+FSM Time Stats represent the amount of time in microseconds required to
+traverse the GET or PUT Finite State Machine code, offering a picture of
+general node health. From your application's perspective, FSM Time effectively
+represents experienced latency. Mean, Median, and 95th-, 99th-, and
+100th-percentile (Max) counters are displayed. These are one-minute stats.
+{{% /note %}}
 
 Metric | Also | Relevance | Latency (in microseconds)
 :------|:-----|:----------|:-------------------------
@@ -204,19 +202,21 @@ reported success with when used for monitoring the operational status of
 their Riak clusters. Community and open source projects are presented
 along with commercial and hosted services.
 
-<div class="note">
-<div class="title">Note on Riak 2.x Statistics Support</div>
-Many of the below tools were either created by third-parties or Basho engineers
-for general usage, and have been passed to the community for further updates. As
-such, many of the below only aggregate the statistics and messages that were
-output by Riak 1.4.x.</br>
+{{% note title="Note on Riak 2.x Statistics Support" %}}
+Many of the below tools were either created by third-parties or Basho
+engineers for general usage, and have been passed to the community for further
+updates. As such, many of the below only aggregate the statistics and messages
+that were output by Riak 1.4.x.
+
 Like all code under [Basho Labs](https://github.com/basho-labs/), the below
-tools are "best effort" and have no dedicated Basho support. We both appreciate
-and need your contribution to keep these tools stable and up to date. Please
-open up a GitHub issue on the repository if you'd like to be a maintainer.</br>
-Look for banners calling out the tools we've verified that support the latest Riak 2.x
-statistics!
-</div>
+tools are "best effort" and have no dedicated Basho support. We both
+appreciate and need your contribution to keep these tools stable and up to
+date. Please open up a GitHub issue on the repository if you'd like to be a
+maintainer.
+
+Look for banners calling out the tools we've verified that support the latest
+Riak 2.x statistics!
+{{% /note %}}
 
 ### Self-Hosted Monitoring Tools
 
@@ -263,9 +263,9 @@ the Riak HTTP [`/stats`](/riak/kv/2.2.0/developing/api/http/status) endpoint is 
 
 #### Nagios
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x.**
+{{% /note %}}
 
 [Nagios](http://www.nagios.org) is a monitoring and alerting solution
 that can provide information on the status of Riak cluster nodes, in
@@ -299,9 +299,9 @@ module specifically designed to read Riak statistics.
 
 #### Zabbix
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [Zabbix](http://www.zabbix.com) is an open-source performance monitoring,
 alerting, and graphing solution that can provide information on the state of
@@ -325,9 +325,9 @@ capacity planning in a Riak cluster environment.
 
 #### New Relic
 
-<div class="note">
-<strong>Tested and Verified Support for Riak 2.x Stats.</strong>
-</div>
+{{% note %}}
+**Tested and Verified Support for Riak 2.x Stats.**
+{{% /note %}}
 
 [New Relic](http://newrelic.com) is a data analytics and visualization platform
 that can provide information on the current and past states of Riak nodes and

--- a/content/riak/kv/2.2.0/using/reference/v3-multi-datacenter/cascading-writes.md
+++ b/content/riak/kv/2.2.0/using/reference/v3-multi-datacenter/cascading-writes.md
@@ -28,13 +28,11 @@ Riak Enterprise. It will need to be manually enabled on new clusters.
 Cascading realtime requires the `{riak_repl, rtq_meta}` capability to
 function.
 
-<div class="note">
-<div class="title">Note on cascading tracking</div>
-Cascading tracking is a simple list of where an object has been written.
-This works well for most common configurations. Larger installations,
-however, may have writes cascade to clusters to which other clusters
-have already written.
-</div>
+{{% note title="Note on cascading tracking" %}}
+Cascading tracking is a simple list of where an object has been written. This
+works well for most common configurations. Larger installations, however, may
+have writes cascade to clusters to which other clusters have already written.
+{{% /note %}}
 
 
 ```

--- a/content/riak/kv/2.2.0/using/repair-recovery/errors.md
+++ b/content/riak/kv/2.2.0/using/repair-recovery/errors.md
@@ -135,11 +135,10 @@ Riak to explain the correct course of action. For example, the
 `map/reduce` `parse_input` phase will respond like this when it
 encounters an invalid input:
 
-<div class="note">
-<div class="title">Note on inputs</div>
-Inputs must be a binary bucket, a tuple of bucket and key-filters, a
-list of target tuples, a search index, or modfun tuple: `INPUT`.
-</div>
+{{% note title="Note on inputs" %}}
+Inputs must be a binary bucket, a tuple of bucket and key-filters, a list of
+target tuples, a search index, or modfun tuple: `INPUT`.
+{{% /note %}}
 
 For the remaining common error codes, they are often marked by Erlang
 atoms (and quite often wrapped within an `{error,{badmatch,{...` tuple,

--- a/content/riak/kv/2.2.0/using/repair-recovery/failure-recovery.md
+++ b/content/riak/kv/2.2.0/using/repair-recovery/failure-recovery.md
@@ -118,6 +118,8 @@ spreading load and increasing available CPU and IOPS.
 
 See [Changing Cluster Information](/riak/kv/2.1.4/using/cluster-operations/changing-cluster-info/#clusters-from-backups) for instructions on cluster recovery.
 
-<div class="info">
-<div class="title">Tip</div> If you are a licensed Riak Enterprise or CS customer and require assistance or further advice with a cluster recovery, please file a ticket with the <a href="https://help.basho.com">Basho Helpdesk</a>.
-</div>
+{{% note title="Tip" %}}
+If you are a licensed Riak Enterprise or CS customer and require assistance or
+further advice with a cluster recovery, please file a ticket with the
+<a href="https://help.basho.com">Basho Helpdesk</a>.
+{{% /note %}}

--- a/content/riak/kv/2.2.0/using/repair-recovery/repairs.md
+++ b/content/riak/kv/2.2.0/using/repair-recovery/repairs.md
@@ -91,10 +91,11 @@ If there are compaction errors in any of your vnodes, those will be listed in th
 ./442446784738847563128068650529343492278651453440/LOG 
 ```
 
-<div class="note">
-<div class="title">Note</div>
-While corruption on one vnode is not uncommon, corruption in several vnodes very likely means that there is a deeper problem that needs to be address, perhaps on the OS or hardware level.
-</div>
+{{% note title="Note" %}}
+While corruption on one vnode is not uncommon, corruption in several vnodes
+very likely means that there is a deeper problem that needs to be address,
+perhaps on the OS or hardware level.
+{{% /note %}}
 
 ## Healing Corrupted LevelDBs
 

--- a/content/riak/kv/2.2.0/using/running-a-cluster.md
+++ b/content/riak/kv/2.2.0/using/running-a-cluster.md
@@ -171,14 +171,13 @@ the node's ring file.
 riak-admin cluster replace riak@127.0.0.1 riak@192.168.1.10
 ```
 
-<div class="note">
-<div class="title">Note on single nodes</div>
-If a node is started singly using default settings, as you might do when
-you are building your first test environment, you will need to remove
-the ring files from the data directory after you edit your configuration
-files. `riak-admin cluster replace` will not work since the node has not
-been joined to a cluster.
-</div>
+{{% note title="Note on single nodes" %}}
+If a node is started singly using default settings, as you might do when you
+are building your first test environment, you will need to remove the ring
+files from the data directory after you edit your configuration files.
+`riak-admin cluster replace` will not work since the node has not been joined
+to a cluster.
+{{% /note %}}
 
 As with all cluster changes, you need to view the planned changes by
 running `riak-admin cluster plan` and then running `riak-admin cluster

--- a/content/riak/kv/2.2.0/using/security/basics.md
+++ b/content/riak/kv/2.2.0/using/security/basics.md
@@ -444,13 +444,11 @@ Permission | Operation |
 `riak_kv.list_keys` | List all of the keys in a bucket
 `riak_kv.list_buckets` | List all buckets
 
-<div class="note">
-<div class="title">Note on Listing Keys and Buckets</div>
-<code>riak_kv.list_keys</code> and <code>riak_kv.list_buckets</code> are
-both very expensive operations that should be performed very rarely and
-never in production. Access to this functionality should be granted very
-carefully.
-</div>
+{{% note title="Note on Listing Keys and Buckets" %}}
+`riak_kv.list_keys` and `riak_kv.list_buckets` are both very expensive
+operations that should be performed very rarely and never in production.
+Access to this functionality should be granted very carefully.
+{{% /note %}}
 
 If you'd like to create, for example, a `client` account that is
 allowed only to run `GET` and `PUT` requests on all buckets:
@@ -631,23 +629,20 @@ The following command would remove the source for `riakuser` on
 riak-admin security del-source riakuser 127.0.0.1/32
 ```
 
-<div class="note">
-<div class="title">Note on Removing Sources</div>
-If you apply a security source both to <code>all</code> and to specific
-users and then wish to remove that source, you will need to do so in
-separate steps. The <code>riak-admin security del-source all ...</code>
-command by itself is not sufficient.
+{{% note title="Note on Removing Sources" %}}
+If you apply a security source both to `all` and to specific users and then
+wish to remove that source, you will need to do so in separate steps. The
+`riak-admin security del-source all ...` command by itself is not sufficient.
 
-For example, if you have assigned the source <code>password</code> to
-both <code>all</code> and to the user <code>riakuser</code> on the
-network <code>127.0.0.1/32</code>, the following two-step process would
-be required to fully remove the source:
+For example, if you have assigned the source `password` to both `all` and to
+the user `riakuser` on the network `127.0.0.1/32`, the following two-step
+process would be required to fully remove the source:
 
 ```bash
 riak-admin security del-source all 127.0.0.1/32 password
 riak-admin security del-source riakuser 127.0.0.1/32 password
 ```
-</div>
+{{% /note %}}
 
 ### More Usage Examples
 

--- a/content/riak/kv/2.2.0/using/security/managing-sources.md
+++ b/content/riak/kv/2.2.0/using/security/managing-sources.md
@@ -29,11 +29,10 @@ The examples below will assume that the network in question is
 [created](/riak/kv/2.2.0/using/security/basics/#user-management) and that
 security has been [enabled](/riak/kv/2.2.0/using/security/basics/#the-basics).
 
-<div class="note">
-<div class="title">Note on SSL connections</div>
-If you use <em>any</em> of the aforementioned security sources, even
-<code>trust</code>, you will need to do so via a secure SSL connection.
-</div>
+{{% note title="Note on SSL connections" %}}
+If you use _any_ of the aforementioned security sources, even `trust`, you
+will need to do so via a secure SSL connection.
+{{% /note %}}
 
 ## Trust-based Authentication
 


### PR DESCRIPTION
Like it says on the tin.

This change was motivated by removing incorrectly formatted `<div class="info">` elements, and the script I built for it worked to convert `<div class="note">` elements as well.

Any `<div class="info">` whose contents are indented were left, because markdown would have incorrectly interpreted the contents as a codeblock.

<details>
  <summary>For the curious, here's the script I used to make the edits (minus some manual fixups for lists).</summary>

```python
#!/usr/bin/env python

# find riak/kv -type f | xargs perl -pi -e 's/Nginx version notes<\/div/Nginx version notes<\/div>/'
# find riak/cs -type f | xargs perl -pi -e 's/clas="title"/class="title"/'

import sys
import re
import textwrap

file_name = sys.argv[1]

r = re.compile(
    r"""(?<=\n)
        <div\sclass="(info|note)">
        (?:\n)?
        (?:<div\sclass="title">(.*?)<\/div>)?
        (?:\n)?
        (.+?)
        (?:\n)?
        <\/div>""",
    re.X | re.S)

wrapper = textwrap.TextWrapper()
wrapper.width = 78
wrapper.break_on_hyphens = False
wrapper.break_long_words = False

with open(file_name) as f:
  old = f.read()

m = r.search(old)
while (m != None):
  new_str = "{{% note "

  if m.group(2):
    title_text = ' '.join(m.group(2).strip().split())

    title_text = re.sub(r"<\/title>", "", title_text)

    title_text = re.sub(r"<\/?strong>", "**", title_text)
    title_text = re.sub(r"<\/?code>", "`", title_text)
    title_text = re.sub(r"<\/?em>", "_", title_text)

    new_str += "title=\"" + title_text + "\" "

  new_str += "%}}\n"

  body_text = m.group(3).strip()

  body_text = re.sub(r"<\/?strong>", "**", body_text)
  body_text = re.sub(r"<\/?code>", "`", body_text)
  body_text = re.sub(r"<\/?tt>", "`", body_text)
  body_text = re.sub(r"<\/?em>", "_", body_text)

  body_text = re.sub(r"<\/?br\/?>", "\n", body_text)
  body_text = re.sub(r"<\/?p\/?>", "", body_text)

  body_text = re.sub(r"<\/?ul\/?>\n", "", body_text)
  body_text = re.sub(r"<li>", "* ", body_text)
  body_text = re.sub(r"<\/li>", "\n", body_text)

  body_text = re.sub(r"<a href", "<a-href", body_text)

  body_set = textwrap.dedent(body_text).split('\n\n')
  for i, paragraph in enumerate(body_set):
    if re.match(r"```", paragraph ): continue
    li_match = re.match(r"(\s*)\d+(\\)?\.\s*", paragraph)
    ul_match = re.match(r"(\s*)\\?[\*\-]\s*", paragraph)

    initial_initial_indent = wrapper.initial_indent
    initial_subsequent_indent = wrapper.subsequent_indent

    if li_match:
      wrapper.initial_indent += ' '*len(li_match.group(1))
      wrapper.subsequent_indent += ' '*li_match.end()
    if ul_match:
      wrapper.initial_indent += ' '*len(ul_match.group(1))
      wrapper.subsequent_indent += ' '*ul_match.end()

    body_set[i] = wrapper.fill(paragraph.strip())

    wrapper.initial_indent = initial_initial_indent
    wrapper.subsequent_indent = initial_subsequent_indent

  wrapped_body = '\n\n'.join(body_set)

  wrapped_body = re.sub(r"<a-href", "<a href", wrapped_body)

  new_str += wrapped_body + "\n"
  new_str += "{{% /note %}}"

  old = old[:m.start()] + new_str + old[m.end():]

  m = r.search(old)

with open(file_name, "w") as f:
  old = f.write(old)

# import pdb; pdb.set_trace()
```

</details>