### PR TITLE
Fixes download urls

### DIFF
--- a/content/riak/kv/2.2.0/setup/installing/debian-ubuntu.md
+++ b/content/riak/kv/2.2.0/setup/installing/debian-ubuntu.md
@@ -182,21 +182,21 @@ for the target platform:
 #### Ubuntu Lucid Lynx (10.04)
 
 ```bash
-wget http://s3.amazonaws.com/downloads.basho.com/riak/2.0/2.2.0/ubuntu/lucid/riak_2.2.0-1_amd64.deb
+wget http://s3.amazonaws.com/downloads.basho.com/riak/2.2/2.2.0/ubuntu/lucid/riak_2.2.0-1_amd64.deb
 sudo dpkg -i riak_2.2.0-1_amd64.deb
 ```
 
 #### Ubuntu Natty Narwhal (11.04)
 
 ```bash
-wget http://s3.amazonaws.com/downloads.basho.com/riak/2.0/2.2.0/ubuntu/natty/riak_2.2.0-1_amd64.deb
+wget http://s3.amazonaws.com/downloads.basho.com/riak/2.2/2.2.0/ubuntu/natty/riak_2.2.0-1_amd64.deb
 sudo dpkg -i riak_2.2.0-1_amd64.deb
 ```
 
 #### Ubuntu Precise Pangolin (12.04)
 
 ```bash
-wget http://s3.amazonaws.com/downloads.basho.com/riak/2.0/2.2.0/ubuntu/precise/riak_2.2.0-1_amd64.deb
+wget http://s3.amazonaws.com/downloads.basho.com/riak/2.2/2.2.0/ubuntu/precise/riak_2.2.0-1_amd64.deb
 sudo dpkg -i riak_2.2.0-1_amd64.deb
 ```
 
@@ -212,7 +212,7 @@ Riak requires an [Erlang](http://www.erlang.org/) installation.
 Instructions can be found in [Installing Erlang][install source erlang].
 
 ```bash
-wget http://s3.amazonaws.com/downloads.basho.com/riak/2.0/2.2.0/riak-2.2.0.tar.gz
+wget http://s3.amazonaws.com/downloads.basho.com/riak/2.2/2.2.0/riak-2.2.0.tar.gz
 tar zxvf riak-2.2.0.tar.gz
 cd riak-2.2.0
 make rel

--- a/content/riak/kv/2.2.0/setup/installing/freebsd.md
+++ b/content/riak/kv/2.2.0/setup/installing/freebsd.md
@@ -44,7 +44,7 @@ You can install the Riak binary package on FreeBSD remotely using the
 `pkg_add` remote option. For this example, we're installing `riak-2.2.0-FreeBSD-amd64.tbz`.
 
 ```bash
-sudo pkg_add -r http://s3.amazonaws.com/downloads.basho.com/riak/2.0/2.2.0/freebsd/9/riak-2.2.0-FreeBSD-amd64.tbz
+sudo pkg_add -r http://s3.amazonaws.com/downloads.basho.com/riak/2.2/2.2.0/freebsd/9/riak-2.2.0-FreeBSD-amd64.tbz
 ```
 
 When Riak is installed, a message is displayed with information about the installation and available documentation.

--- a/content/riak/kv/2.2.0/setup/installing/rhel-centos.md
+++ b/content/riak/kv/2.2.0/setup/installing/rhel-centos.md
@@ -118,7 +118,7 @@ sudo yum install riak
 Or you can install the `.rpm` package manually:
 
 ```bash
-wget http://s3.amazonaws.com/downloads.basho.com/riak/2.0/2.2.0/rhel/5/riak-2.2.0-1.el5.x86_64.rpm
+wget http://s3.amazonaws.com/downloads.basho.com/riak/2.2/2.2.0/rhel/5/riak-2.2.0-1.el5.x86_64.rpm
 sudo rpm -Uvh riak-2.2.0-1.el5.x86_64.rpm
 ```
 
@@ -134,7 +134,7 @@ sudo yum install riak
 Or you can install the `.rpm` package manually:
 
 ```bash
-wget http://s3.amazonaws.com/downloads.basho.com/riak/2.0/2.2.0/rhel/6/riak-2.2.0-1.el6.x86_64.rpm
+wget http://s3.amazonaws.com/downloads.basho.com/riak/2.2/2.2.0/rhel/6/riak-2.2.0-1.el6.x86_64.rpm
 sudo rpm -Uvh riak-2.2.0-1.el6.x86_64.rpm
 ```
 

--- a/content/riak/kv/2.2.0/setup/installing/smartos.md
+++ b/content/riak/kv/2.2.0/setup/installing/smartos.md
@@ -74,7 +74,7 @@ cat /opt/local/etc/pkgin/repositories.conf
 Download your version of the Riak binary package for SmartOS:
 
 ```bash
-curl -o /tmp/riak-2.2.0-SmartOS-x86_64.tgz http://s3.amazonaws.com/downloads.basho.com/riak/2.0/2.2.0/smartos/1.8/riak-2.2.0-SmartOS-x86_64.tgz
+curl -o /tmp/riak-2.2.0-SmartOS-x86_64.tgz http://s3.amazonaws.com/downloads.basho.com/riak/2.2/2.2.0/smartos/1.8/riak-2.2.0-SmartOS-x86_64.tgz
 ```
 
 Next, install the package:

--- a/content/riak/kv/2.2.0/setup/installing/solaris.md
+++ b/content/riak/kv/2.2.0/setup/installing/solaris.md
@@ -54,7 +54,7 @@ Note that you must restart to have the above settings take effect.
 Download your version of the Riak binary package for Solaris 10:
 
 ```bash
-curl -o /tmp/BASHOriak-2.2.0-Solaris10-i386.pkg.gz http://s3.amazonaws.com/downloads.basho.com/riak/2.0/2.2.0/solaris/10/BASHOriak-2.2.0-Solaris10-x86_64.pkg.gz
+curl -o /tmp/BASHOriak-2.2.0-Solaris10-i386.pkg.gz http://s3.amazonaws.com/downloads.basho.com/riak/2.2/2.2.0/solaris/10/BASHOriak-2.2.0-Solaris10-x86_64.pkg.gz
 ```
 
 Next, install the package:


### PR DESCRIPTION
As part of the version docs migration, we didn't catch the x.y part of the download URLs