### PR TITLE
Remove incorrect warning about case-sensitivity

### DIFF
--- a/content/riak/ts/1.5.2/using/planning.md
+++ b/content/riak/ts/1.5.2/using/planning.md
@@ -65,8 +65,6 @@ A TS table is made up of:
 
 The column definitions will determine the columns of your TS table, while the primary key determines where data is stored in your TS cluster.
 
-Keywords are case sensitive, so be sure to capitalize appropriately.
-
 {{% note title="Table Limitations" %}}
 You cannot create a table with more than 511 total columns. If you try to create a table with more than 511 columns, you will receive an error.
 {{% /note %}}


### PR DESCRIPTION
SQL keywords are not case sensitive in TS. The statement in ts/1.5.2/using/planning.md about case-sensitivity is directly contradicted by https://github.com/basho/basho_docs/blame/master/content/riak/ts/1.5.2/learn-about/sqlriakts.md#L24