### PR TITLE
Smarg/misc errata

### DIFF
--- a/content/riak/kv/2.2.1/using/admin.md
+++ b/content/riak/kv/2.2.1/using/admin.md
@@ -32,13 +32,13 @@ Explains usage of the `riak-admin cluster` interface, which enables you to perfo
 
 Details the `riak-admin` interface.
 
-[Learn More >>][use admin riak cli]
+[Learn More >>][use admin riak-admin]
 
 #### [riak Command Line Interface][use admin riak-admin]
 
 Covers the `riak` interface, which enables control of the processes associated with a Riak node.
 
-[Learn More >>][use admin riak-admin]
+[Learn More >>][use admin riak cli]
 
 #### [Riak Control][use admin riak control]
 

--- a/content/riak/ts/1.5.2/learn-about/bestpractices.md
+++ b/content/riak/ts/1.5.2/learn-about/bestpractices.md
@@ -39,7 +39,7 @@ To help speed the performance of Riak TS and avoid destroying and recreating tab
 
 For instance, let's say we have a time series database storing information about air quality for a given location. The data coming in from sensors in given locations includes: geohash for location, timestamp, levels of CO2, smog particles in the air, temperature, and humidity.
 
-The most common queries we'll have will be to determine, for a given location and timeframe, the spikes in O2 for a given temperature. Since our use case requires fast reads, we'll choose to correlate data with Spark. In that case, we'll choose to use geohash location and timestamp for the first and second fields in the partition key, since queries are faster on partition key. And we'll put CO2, smog, temperature, and humidity data as [column definitions][planning column def].
+The most common queries we'll have will be to determine, for a given location and timeframe, the spikes in CO2 for a given temperature. Since our use case requires fast reads, we'll choose to correlate data with Spark. In that case, we'll choose to use geohash location and timestamp for the first and second fields in the partition key, since queries are faster on partition key. And we'll put CO2, smog, temperature, and humidity data as [column definitions][planning column def].
 
 
 ## Quantum

--- a/content/riak/ts/1.5.2/learn-about/sqlriakts.md
+++ b/content/riak/ts/1.5.2/learn-about/sqlriakts.md
@@ -39,7 +39,7 @@ It also supports double-quoted column references (a.k.a. field names).
 
 ## Schema Design
 
-Let's say you want to store and graph usage metrics on a heterogeneous collection of network servers: disk usage, memory usage, CPU temperatures, load averages, and other metrics. Our graphing is going to be a single metric for a single host at a time, so our primary key should cover time, hostname, and the metric name. Since some metrics won't be on every server (i.e. our Riak servers have more disks than our Rails servers) and we want to be able to add metrics in the future, we're going to have a narrow table with only one metric per row.
+Let's say you want to store and graph usage metrics on a heterogeneous collection of network servers: disk usage, memory usage, CPU temperatures, load averages, and other metrics. Our graphing is going to be a single metric for a single host at a time, so our primary key should cover time, hostname, and the metric name. Since some metrics won't be on every server (for example, our Riak servers have more disks than our Rails servers) and we want to be able to add metrics in the future, we're going to have a narrow table with only one metric per row.
 
 Since we've decided to have our compound primary key cover time, hostname, and metric name, the only thing left to decide is the quantization.
 


### PR DESCRIPTION
Contains 3 cherry-pickable *minor* errata:

1. An "i.e." that should be "e.g.". Since Latin abbreviations are confusing (case in point), I chose "for example".
2. TS docs using "CO2" as an example, slipped in an "O2".
3. A pair of swapped links to command line documentation for `riak-admin` and `riak`.
