### PR TITLE
Review bucket types in HTTP API object pages

### DIFF
--- a/content/riak/kv/2.2.1/developing/api/http/delete-object.md
+++ b/content/riak/kv/2.2.1/developing/api/http/delete-object.md
@@ -20,6 +20,7 @@ Deletes an object from the specified bucket / key.
 ## Request
 
 ```
+DELETE /types/type/buckets/bucket/keys/key
 DELETE /buckets/bucket/keys/key
 ```
 

--- a/content/riak/kv/2.2.1/developing/api/http/fetch-object.md
+++ b/content/riak/kv/2.2.1/developing/api/http/fetch-object.md
@@ -20,6 +20,7 @@ Reads an object from the specified bucket/key.
 ## Request
 
 ```bash
+GET /types/type/buckets/bucket/keys/key
 GET /buckets/bucket/keys/key
 ```
 

--- a/content/riak/kv/2.2.1/developing/api/http/store-object.md
+++ b/content/riak/kv/2.2.1/developing/api/http/store-object.md
@@ -22,8 +22,10 @@ Riak assign a key to a new object.
 ## Request
 
 ```bash
-POST /buckets/bucket/keys       # Riak-defined key
-PUT /buckets/bucket/keys/key    # User-defined key
+POST /types/type/buckets/bucket/keys       # Riak-defined key
+PUT /types/type/buckets/bucket/keys/key    # User-defined key
+POST /buckets/bucket/keys                  # Riak-defined key
+PUT /buckets/bucket/keys/key               # User-defined key
 ```
 
 For the sake of compatibility with older clients, `POST` is also acceptable in


### PR DESCRIPTION
I was using DELETE and I found I had to prepend `/types/<type>` in order to make it work (I had written the key as datatype). The HTTP API overview page lists only the URLs with the `/types/<type>` prefix - **not sure if the specific pages shall list both** (I think yes).
I **did not proofread the modified pages for inconsistencies with bucket types**.