### PR TITLE
WIP: Revise and extend expiry docs

### DIFF
--- a/content/riak/ts/1.6.0/table-management/global-object-expiration.md
+++ b/content/riak/ts/1.6.0/table-management/global-object-expiration.md
@@ -24,6 +24,7 @@ canonical_link: "https://docs.basho.com/riak/ts/latest/table-management/global-o
 
 [ttl]: https://en.wikipedia.org/wiki/Time_to_live
 [table expiry]: /riak/ts/1.6.0/table-management/per-table-object-expiration
+[read repair]: /riak/kv/2.2.1/learn/concepts/replication/#read-repair
 
 By default, LevelDB keeps all of your data. But Riak TS allows you to configure object expiration (`expiry`) or [time to live (TTL)][ttl] for your data on a global or [per table basis][table expiry].
 
@@ -37,7 +38,7 @@ To enable global object expiry, add the `leveldb.expiration` setting to your ria
 leveldb.expiration = on
 ```
 
-Enabling expiry will instruct LevelDB to start tracking write times for data. New or updated data, along with recently-written data that has not yet been compacted, will be eligible for expiry. Older data will not expire until it is rewritten, due to data updates or internal read repair[XXX http://docs.basho.com/riak/kv/2.2.0/learn/concepts/replication/].
+Enabling expiry will instruct LevelDB to start tracking write times for data. New or updated data, along with recently-written data that has not yet been compacted, will be eligible for expiry. Older data will not expire until it is rewritten, due to data updates or internal [read repair].
 
 If expiration is enabled without configuring a retention time, LevelDB will track the age of data but will not expire it.
 

--- a/content/riak/ts/1.6.0/table-management/global-object-expiration.md
+++ b/content/riak/ts/1.6.0/table-management/global-object-expiration.md
@@ -37,9 +37,10 @@ To enable global object expiry, add the `leveldb.expiration` setting to your ria
 leveldb.expiration = on
 ```
 
-{{% note %}}
-Turning on global object expiration will not retroactively expire previous data. Only data created while expiration is on will be scheduled for expiration.
-{{% /note %}}
+Enabling expiry will instruct LevelDB to start tracking write times for data. New or updated data, along with recently-written data that has not yet been compacted, will be eligible for expiry. Older data will not expire until it is rewritten, due to data updates or internal read repair[XXX http://docs.basho.com/riak/kv/2.2.0/learn/concepts/replication/].
+
+If expiration is enabled without configuring a retention time, LevelDB will track the age of data but will not expire it.
+
 
 ## Setting Retention Time
 
@@ -67,6 +68,8 @@ You can also combine durations. For example, let's say you wanted objects to exp
 leveldb.expiration = on
 leveldb.expiration.retention_time = 8d9h
 ```
+
+The minimum *effective* expiry period is 1 minute, and in fact data can remain for almost 2 minutes if written shortly after the "top" of the minute.
 
 ## Expiry Modes
 

--- a/content/riak/ts/1.6.0/table-management/per-table-object-expiration.md
+++ b/content/riak/ts/1.6.0/table-management/per-table-object-expiration.md
@@ -27,7 +27,7 @@ canonical_link: "https://docs.basho.com/riak/ts/latest/table-management/per-tabl
 [create table]: /riak/ts/1.6.0/table-management/creating-activating/
 [create table with]: /riak/ts/1.6.0/table-management/creating-activating/#using-with
 
-By default, LevelDB keeps all of your data. But Riak TS allows you to configure object expiration (`expiry`) or [time to live (TTL)][ttl] for your data on a [global][global expiry] or a per table basis.
+By default, LevelDB keeps all of your data. But Riak TS allows you to configure object expiration (`expiry`) or [time to live (TTL)][ttl] for your data on a [global][global expiry] or, when using Basho's Enterprise Edition, a per table basis.
 
 Expiration is disabled by default, but enabling it lets you expire older objects to reclaim the space used or purge data with a limited time value.
 
@@ -49,16 +49,14 @@ leveldb.expiration.mode = whole_file
 
 These settings will apply globally. So if you enable expiry on a table and the `default_time_to_live` or `expiration_mode` table properties are not set, the table will inherit the values set in riak.conf.
 
-{{% note %}}
-Turning on object expiration will not retroactively expire previous data. Only data created while expiration is on will be scheduled for expiration.
-{{% /note %}}
+See [global expiry][global expiry] for a discussion of what happens to existing data when expiry is enabled.
 
 ## Expiry Table Properties
 
 |Property Name|Default|Values|
 |---|---|---|
 |expiration|`disabled|``enabled` / `disabled`|
-|defaut_time_to_live|`unlimited`|`unlimited` or a duration string|
+|default_time_to_live|`unlimited`|`unlimited` or a duration string|
 |expiration_mode|`whole_file`|`use_global_config` / `per_item` / `whole_file`|
 
 Each table can have one or more of the properties listed above. If any properties are omitted on the table, the property values in riak.conf will be used. If the properties are not set within riak.conf, the default values will be used.
@@ -82,7 +80,17 @@ CREATE TABLE GeoCheckin
     )
 ) WITH (
     expiration = enabled
-    default_time_to_live = 123.4m
+    default_time_to_live = 123m
+    expiration_mode = whole_file
+)
+```
+
+For existing tables, bucket properties can be modified with the `ALTER TABLE` command.
+
+```
+ALTER TABLE GeoCheckin WITH (
+    expiration = enabled
+    default_time_to_live = 123m
     expiration_mode = whole_file
 )
 ```


### PR DESCRIPTION
This is a work in progress, and I have left some of the link syntax broken for the moment.

* Add information on `alter table`
* Capture some of the nuance around older data and expiry
* Make explicit the outcome of enabling expiry without corresponding ttl
* Clarify that 1 minute is the finest level of granularity