### PR TITLE
Fix erroneous note & spelling error

### DIFF
--- a/content/riak/kv/2.0.0/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.0.0/using/cluster-operations/inspecting-node.md
@@ -37,7 +37,7 @@ minimum of 5 transactions is required for statistics to be generated.
 
 We recommended checking stats every 90-120 seconds for best performance.
 
-Repeated runs of the `riak-admin status` command does not have a
+Repeated runs of the `riak-admin status` command should not have a
 negative performance impact as the statistics are cached internally in
 Riak.
 

--- a/content/riak/kv/2.0.0/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.0.0/using/cluster-operations/inspecting-node.md
@@ -35,12 +35,10 @@ minimum of 5 transactions is required for statistics to be generated.
 
 #### Performance
 
-> **Please Note:**
->
-> Due to a recent bug, executing `riak-admin status` more than once a minute can have an impact on performance. We recommended checking stats every 90-120 seconds due to this bug.
+We recommended checking stats every 90-120 seconds for best performance.
 
 Repeated runs of the `riak-admin status` command does not have a
-negative performance impact as the statstics are cached internally in
+negative performance impact as the statistics are cached internally in
 Riak.
 
 ### Active Stats

--- a/content/riak/kv/2.0.1/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.0.1/using/cluster-operations/inspecting-node.md
@@ -37,7 +37,7 @@ minimum of 5 transactions is required for statistics to be generated.
 
 We recommended checking stats every 90-120 seconds for best performance.
 
-Repeated runs of the `riak-admin status` command does not have a
+Repeated runs of the `riak-admin status` command should not have a
 negative performance impact as the statistics are cached internally in
 Riak.
 

--- a/content/riak/kv/2.0.1/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.0.1/using/cluster-operations/inspecting-node.md
@@ -35,12 +35,10 @@ minimum of 5 transactions is required for statistics to be generated.
 
 #### Performance
 
-> **Please Note:**
->
-> Due to a recent bug, executing `riak-admin status` more than once a minute can have an impact on performance. We recommended checking stats every 90-120 seconds due to this bug.
+We recommended checking stats every 90-120 seconds for best performance.
 
 Repeated runs of the `riak-admin status` command does not have a
-negative performance impact as the statstics are cached internally in
+negative performance impact as the statistics are cached internally in
 Riak.
 
 ### Active Stats

--- a/content/riak/kv/2.0.2/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.0.2/using/cluster-operations/inspecting-node.md
@@ -37,7 +37,7 @@ minimum of 5 transactions is required for statistics to be generated.
 
 We recommended checking stats every 90-120 seconds for best performance.
 
-Repeated runs of the `riak-admin status` command does not have a
+Repeated runs of the `riak-admin status` command should not have a
 negative performance impact as the statistics are cached internally in
 Riak.
 

--- a/content/riak/kv/2.0.2/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.0.2/using/cluster-operations/inspecting-node.md
@@ -35,12 +35,10 @@ minimum of 5 transactions is required for statistics to be generated.
 
 #### Performance
 
-> **Please Note:**
->
-> Due to a recent bug, executing `riak-admin status` more than once a minute can have an impact on performance. We recommended checking stats every 90-120 seconds due to this bug.
+We recommended checking stats every 90-120 seconds for best performance.
 
 Repeated runs of the `riak-admin status` command does not have a
-negative performance impact as the statstics are cached internally in
+negative performance impact as the statistics are cached internally in
 Riak.
 
 ### Active Stats

--- a/content/riak/kv/2.0.4/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.0.4/using/cluster-operations/inspecting-node.md
@@ -37,7 +37,7 @@ minimum of 5 transactions is required for statistics to be generated.
 
 We recommended checking stats every 90-120 seconds for best performance.
 
-Repeated runs of the `riak-admin status` command does not have a
+Repeated runs of the `riak-admin status` command should not have a
 negative performance impact as the statistics are cached internally in
 Riak.
 

--- a/content/riak/kv/2.0.4/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.0.4/using/cluster-operations/inspecting-node.md
@@ -35,12 +35,10 @@ minimum of 5 transactions is required for statistics to be generated.
 
 #### Performance
 
-> **Please Note:**
->
-> Due to a recent bug, executing `riak-admin status` more than once a minute can have an impact on performance. We recommended checking stats every 90-120 seconds due to this bug.
+We recommended checking stats every 90-120 seconds for best performance.
 
 Repeated runs of the `riak-admin status` command does not have a
-negative performance impact as the statstics are cached internally in
+negative performance impact as the statistics are cached internally in
 Riak.
 
 ### Active Stats

--- a/content/riak/kv/2.0.5/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.0.5/using/cluster-operations/inspecting-node.md
@@ -37,7 +37,7 @@ minimum of 5 transactions is required for statistics to be generated.
 
 We recommended checking stats every 90-120 seconds for best performance.
 
-Repeated runs of the `riak-admin status` command does not have a
+Repeated runs of the `riak-admin status` command should not have a
 negative performance impact as the statistics are cached internally in
 Riak.
 

--- a/content/riak/kv/2.0.5/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.0.5/using/cluster-operations/inspecting-node.md
@@ -35,12 +35,10 @@ minimum of 5 transactions is required for statistics to be generated.
 
 #### Performance
 
-> **Please Note:**
->
-> Due to a recent bug, executing `riak-admin status` more than once a minute can have an impact on performance. We recommended checking stats every 90-120 seconds due to this bug.
+We recommended checking stats every 90-120 seconds for best performance.
 
 Repeated runs of the `riak-admin status` command does not have a
-negative performance impact as the statstics are cached internally in
+negative performance impact as the statistics are cached internally in
 Riak.
 
 ### Active Stats

--- a/content/riak/kv/2.0.6/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.0.6/using/cluster-operations/inspecting-node.md
@@ -37,7 +37,7 @@ minimum of 5 transactions is required for statistics to be generated.
 
 We recommended checking stats every 90-120 seconds for best performance.
 
-Repeated runs of the `riak-admin status` command does not have a
+Repeated runs of the `riak-admin status` command should not have a
 negative performance impact as the statistics are cached internally in
 Riak.
 

--- a/content/riak/kv/2.0.6/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.0.6/using/cluster-operations/inspecting-node.md
@@ -35,12 +35,10 @@ minimum of 5 transactions is required for statistics to be generated.
 
 #### Performance
 
-> **Please Note:**
->
-> Due to a recent bug, executing `riak-admin status` more than once a minute can have an impact on performance. We recommended checking stats every 90-120 seconds due to this bug.
+We recommended checking stats every 90-120 seconds for best performance.
 
 Repeated runs of the `riak-admin status` command does not have a
-negative performance impact as the statstics are cached internally in
+negative performance impact as the statistics are cached internally in
 Riak.
 
 ### Active Stats

--- a/content/riak/kv/2.0.7/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.0.7/using/cluster-operations/inspecting-node.md
@@ -37,7 +37,7 @@ minimum of 5 transactions is required for statistics to be generated.
 
 We recommended checking stats every 90-120 seconds for best performance.
 
-Repeated runs of the `riak-admin status` command does not have a
+Repeated runs of the `riak-admin status` command should not have a
 negative performance impact as the statistics are cached internally in
 Riak.
 

--- a/content/riak/kv/2.0.7/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.0.7/using/cluster-operations/inspecting-node.md
@@ -35,12 +35,10 @@ minimum of 5 transactions is required for statistics to be generated.
 
 #### Performance
 
-> **Please Note:**
->
-> Due to a recent bug, executing `riak-admin status` more than once a minute can have an impact on performance. We recommended checking stats every 90-120 seconds due to this bug.
+We recommended checking stats every 90-120 seconds for best performance.
 
 Repeated runs of the `riak-admin status` command does not have a
-negative performance impact as the statstics are cached internally in
+negative performance impact as the statistics are cached internally in
 Riak.
 
 ### Active Stats

--- a/content/riak/kv/2.0.8/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.0.8/using/cluster-operations/inspecting-node.md
@@ -37,7 +37,7 @@ minimum of 5 transactions is required for statistics to be generated.
 
 We recommended checking stats every 90-120 seconds for best performance.
 
-Repeated runs of the `riak-admin status` command does not have a
+Repeated runs of the `riak-admin status` command should not have a
 negative performance impact as the statistics are cached internally in
 Riak.
 

--- a/content/riak/kv/2.0.8/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.0.8/using/cluster-operations/inspecting-node.md
@@ -35,12 +35,10 @@ minimum of 5 transactions is required for statistics to be generated.
 
 #### Performance
 
-> **Please Note:**
->
-> Due to a recent bug, executing `riak-admin status` more than once a minute can have an impact on performance. We recommended checking stats every 90-120 seconds due to this bug.
+We recommended checking stats every 90-120 seconds for best performance.
 
 Repeated runs of the `riak-admin status` command does not have a
-negative performance impact as the statstics are cached internally in
+negative performance impact as the statistics are cached internally in
 Riak.
 
 ### Active Stats

--- a/content/riak/kv/2.0.9/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.0.9/using/cluster-operations/inspecting-node.md
@@ -37,7 +37,7 @@ minimum of 5 transactions is required for statistics to be generated.
 
 We recommended checking stats every 90-120 seconds for best performance.
 
-Repeated runs of the `riak-admin status` command does not have a
+Repeated runs of the `riak-admin status` command should not have a
 negative performance impact as the statistics are cached internally in
 Riak.
 

--- a/content/riak/kv/2.0.9/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.0.9/using/cluster-operations/inspecting-node.md
@@ -35,12 +35,10 @@ minimum of 5 transactions is required for statistics to be generated.
 
 #### Performance
 
-> **Please Note:**
->
-> Due to a recent bug, executing `riak-admin status` more than once a minute can have an impact on performance. We recommended checking stats every 90-120 seconds due to this bug.
+We recommended checking stats every 90-120 seconds for best performance.
 
 Repeated runs of the `riak-admin status` command does not have a
-negative performance impact as the statstics are cached internally in
+negative performance impact as the statistics are cached internally in
 Riak.
 
 ### Active Stats

--- a/content/riak/kv/2.1.1/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.1.1/using/cluster-operations/inspecting-node.md
@@ -37,7 +37,7 @@ minimum of 5 transactions is required for statistics to be generated.
 
 We recommended checking stats every 90-120 seconds for best performance.
 
-Repeated runs of the `riak-admin status` command does not have a
+Repeated runs of the `riak-admin status` command should not have a
 negative performance impact as the statistics are cached internally in
 Riak.
 

--- a/content/riak/kv/2.1.1/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.1.1/using/cluster-operations/inspecting-node.md
@@ -35,12 +35,10 @@ minimum of 5 transactions is required for statistics to be generated.
 
 #### Performance
 
-> **Please Note:**
->
-> Due to a recent bug, executing `riak-admin status` more than once a minute can have an impact on performance. We recommended checking stats every 90-120 seconds due to this bug.
+We recommended checking stats every 90-120 seconds for best performance.
 
 Repeated runs of the `riak-admin status` command does not have a
-negative performance impact as the statstics are cached internally in
+negative performance impact as the statistics are cached internally in
 Riak.
 
 ### Active Stats

--- a/content/riak/kv/2.1.3/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.1.3/using/cluster-operations/inspecting-node.md
@@ -37,7 +37,7 @@ minimum of 5 transactions is required for statistics to be generated.
 
 We recommended checking stats every 90-120 seconds for best performance.
 
-Repeated runs of the `riak-admin status` command does not have a
+Repeated runs of the `riak-admin status` command should not have a
 negative performance impact as the statistics are cached internally in
 Riak.
 

--- a/content/riak/kv/2.1.3/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.1.3/using/cluster-operations/inspecting-node.md
@@ -35,12 +35,10 @@ minimum of 5 transactions is required for statistics to be generated.
 
 #### Performance
 
-> **Please Note:**
->
-> Due to a recent bug, executing `riak-admin status` more than once a minute can have an impact on performance. We recommended checking stats every 90-120 seconds due to this bug.
+We recommended checking stats every 90-120 seconds for best performance.
 
 Repeated runs of the `riak-admin status` command does not have a
-negative performance impact as the statstics are cached internally in
+negative performance impact as the statistics are cached internally in
 Riak.
 
 ### Active Stats

--- a/content/riak/kv/2.1.4/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.1.4/using/cluster-operations/inspecting-node.md
@@ -37,7 +37,7 @@ minimum of 5 transactions is required for statistics to be generated.
 
 We recommended checking stats every 90-120 seconds for best performance.
 
-Repeated runs of the `riak-admin status` command does not have a
+Repeated runs of the `riak-admin status` command should not have a
 negative performance impact as the statistics are cached internally in
 Riak.
 

--- a/content/riak/kv/2.1.4/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.1.4/using/cluster-operations/inspecting-node.md
@@ -35,12 +35,10 @@ minimum of 5 transactions is required for statistics to be generated.
 
 #### Performance
 
-> **Please Note:**
->
-> Due to a recent bug, executing `riak-admin status` more than once a minute can have an impact on performance. We recommended checking stats every 90-120 seconds due to this bug.
+We recommended checking stats every 90-120 seconds for best performance.
 
 Repeated runs of the `riak-admin status` command does not have a
-negative performance impact as the statstics are cached internally in
+negative performance impact as the statistics are cached internally in
 Riak.
 
 ### Active Stats

--- a/content/riak/kv/2.2.0/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.2.0/using/cluster-operations/inspecting-node.md
@@ -37,7 +37,7 @@ minimum of 5 transactions is required for statistics to be generated.
 
 We recommended checking stats every 90-120 seconds for best performance.
 
-Repeated runs of the `riak-admin status` command does not have a
+Repeated runs of the `riak-admin status` command should not have a
 negative performance impact as the statistics are cached internally in
 Riak.
 

--- a/content/riak/kv/2.2.0/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.2.0/using/cluster-operations/inspecting-node.md
@@ -35,12 +35,10 @@ minimum of 5 transactions is required for statistics to be generated.
 
 #### Performance
 
-> **Please Note:**
->
-> Due to a recent bug, executing `riak-admin status` more than once a minute can have an impact on performance. We recommended checking stats every 90-120 seconds due to this bug.
+We recommended checking stats every 90-120 seconds for best performance.
 
 Repeated runs of the `riak-admin status` command does not have a
-negative performance impact as the statstics are cached internally in
+negative performance impact as the statistics are cached internally in
 Riak.
 
 ### Active Stats

--- a/content/riak/kv/2.2.1/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.2.1/using/cluster-operations/inspecting-node.md
@@ -37,7 +37,7 @@ minimum of 5 transactions is required for statistics to be generated.
 
 We recommended checking stats every 90-120 seconds for best performance.
 
-Repeated runs of the `riak-admin status` command does not have a
+Repeated runs of the `riak-admin status` command should not have a
 negative performance impact as the statistics are cached internally in
 Riak.
 

--- a/content/riak/kv/2.2.1/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.2.1/using/cluster-operations/inspecting-node.md
@@ -35,12 +35,10 @@ minimum of 5 transactions is required for statistics to be generated.
 
 #### Performance
 
-> **Please Note:**
->
-> Due to a recent bug, executing `riak-admin status` more than once a minute can have an impact on performance. We recommended checking stats every 90-120 seconds due to this bug.
+We recommended checking stats every 90-120 seconds for best performance.
 
 Repeated runs of the `riak-admin status` command does not have a
-negative performance impact as the statstics are cached internally in
+negative performance impact as the statistics are cached internally in
 Riak.
 
 ### Active Stats

--- a/content/riak/kv/2.2.2/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.2.2/using/cluster-operations/inspecting-node.md
@@ -37,7 +37,7 @@ minimum of 5 transactions is required for statistics to be generated.
 
 We recommended checking stats every 90-120 seconds for best performance.
 
-Repeated runs of the `riak-admin status` command does not have a
+Repeated runs of the `riak-admin status` command should not have a
 negative performance impact as the statistics are cached internally in
 Riak.
 

--- a/content/riak/kv/2.2.2/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.2.2/using/cluster-operations/inspecting-node.md
@@ -35,12 +35,10 @@ minimum of 5 transactions is required for statistics to be generated.
 
 #### Performance
 
-> **Please Note:**
->
-> Due to a recent bug, executing `riak-admin status` more than once a minute can have an impact on performance. We recommended checking stats every 90-120 seconds due to this bug.
+We recommended checking stats every 90-120 seconds for best performance.
 
 Repeated runs of the `riak-admin status` command does not have a
-negative performance impact as the statstics are cached internally in
+negative performance impact as the statistics are cached internally in
 Riak.
 
 ### Active Stats

--- a/content/riak/kv/2.2.3/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.2.3/using/cluster-operations/inspecting-node.md
@@ -37,7 +37,7 @@ minimum of 5 transactions is required for statistics to be generated.
 
 We recommended checking stats every 90-120 seconds for best performance.
 
-Repeated runs of the `riak-admin status` command does not have a
+Repeated runs of the `riak-admin status` command should not have a
 negative performance impact as the statistics are cached internally in
 Riak.
 

--- a/content/riak/kv/2.2.3/using/cluster-operations/inspecting-node.md
+++ b/content/riak/kv/2.2.3/using/cluster-operations/inspecting-node.md
@@ -35,12 +35,10 @@ minimum of 5 transactions is required for statistics to be generated.
 
 #### Performance
 
-> **Please Note:**
->
-> Due to a recent bug, executing `riak-admin status` more than once a minute can have an impact on performance. We recommended checking stats every 90-120 seconds due to this bug.
+We recommended checking stats every 90-120 seconds for best performance.
 
 Repeated runs of the `riak-admin status` command does not have a
-negative performance impact as the statstics are cached internally in
+negative performance impact as the statistics are cached internally in
 Riak.
 
 ### Active Stats


### PR DESCRIPTION
When fixing Issue #2090, we misread the error and so left the incorrect information present in the docs. This commit removes the note about a bug (long gone since KV 1.3) and fixes a spelling error.