### PR TITLE
Fix typo found on `Running a Cluster` page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: true
 language: ruby
 rvm:
-- 2.2
+- 2.2.5
 before_install:
 - gem update --system
 - gem --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: true
 language: ruby
 rvm:
-- 2.2.5
+- rbx-2.2.5
 before_install:
 - gem update --system
 - gem --version

--- a/content/riak/kv/2.2.3/using/running-a-cluster.md
+++ b/content/riak/kv/2.2.3/using/running-a-cluster.md
@@ -46,7 +46,7 @@ options:
 `ring` directory. This will require rejoining all nodes into a
 cluster again.
 >
-> *Rename the node using the [`riak-admin cluster replace`](/riak/kv/2.2.3/using/admin/riak-admin/#cluster-replace) command. This will not work if you have previously only started Riak with a single node.
+> * Rename the node using the [`riak-admin cluster replace`](/riak/kv/2.2.3/using/admin/riak-admin/#cluster-replace) command. This will not work if you have previously only started Riak with a single node.
 
 ## Configure the First Node
 


### PR DESCRIPTION
A bulletpoint didn't have a space so wasn't being shown properly.