### PR TITLE
Remove Homebrew install instuctions

### DIFF
--- a/content/riak/kv/2.2.3/setup/installing/mac-osx.md
+++ b/content/riak/kv/2.2.3/setup/installing/mac-osx.md
@@ -50,42 +50,6 @@ tar xzvf riak-2.2.3-osx-x86_64.tar.gz
 After the release is untarred, you will be able to `cd` into the `riak`
 directory and execute `bin/riak start` to start the Riak node.
 
-## Homebrew
-
-{{% note title="Warning: Homebrew not always up to date" %}}
-Homebrew's Riak recipe is community supported, and thus is not always up to
-date with the latest Riak package. Please ensure that the current recipe is
-using the latest supported code (and don't be afraid to update it if it's
-not).
-{{% /note %}}
-
-Installing Riak 2.0 with [Homebrew](http://brew.sh/) is easy:
-
-```bash
-brew install --devrel riak
-```
-
-By default, this will place a `2.2.3` folder in
-`/usr/local/Cellar/riak`.
-
-Be aware that you will most likely see the following message after
-running `brew install`:
-
-```
-Error: The `brew link` step did not complete successfully
-The formula built, but is not symlinked into /usr/local
-
-You can try again using:
-  brew link riak
-```
-
-We do not recommend using `brew link` with Riak. Instead, we recommend
-either copying that directory to a desired location on your machine,
-aliasing the executables in the `/bin` directory, or interacting with
-the Riak installation directory via environment variables.
-
-**Note**: Homebrew will install Erlang if you don't have it already.
-
 ## Installing From Source
 
 You must have Xcode tools installed from [Apple's Developer


### PR DESCRIPTION
It has been removed [1][] due to Erlang 17 dependency, which only supports EOL OpenSSL. The formulae also had numerous issues building, which most likely needs upstream changes (aka here) before being submitted again. An alternative would be an official tap [2][].

This PR only removes the now inaccurate docs, as the other changes are probably much bigger and definitely requires some thinking.

[1]: https://github.com/Homebrew/homebrew-core/pull/46552
[2]: https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap