### PR TITLE
Fix issue with malformed Markdown code fence breaking formatting

### DIFF
--- a/content/riak/kv/2.2.3/developing/getting-started/golang/object-modeling.md
+++ b/content/riak/kv/2.2.3/developing/getting-started/golang/object-modeling.md
@@ -133,7 +133,7 @@ func (t *Timeline) AddMsg(msgKey string) {
 func (t *Timeline) GetId() string {
   return t.id
 }
-````
+```
 
 We'll be using the bucket `Users` to store our data. We won't be [using bucket types](/riak/kv/2.2.3/developing/usage/bucket-types) here, so we don't need to specify one.
 


### PR DESCRIPTION
Hello! I was having trouble reading the 2.2.3 Riak KV docs for Go:

https://docs.riak.com/riak/kv/latest/developing/getting-started/golang/object-modeling/index.html

Search on this page for:

```
We'll be using the bucket `Users` to store our data.
```

This 4-tick code fence breaks rendering for a significant part of the page and makes it harder to read, even though it renders fine in GitHub.

This fix should allow this document to render properly on docs.riak.com.

Thank you for the detailed docs and I hope this makes them better for the next readers.